### PR TITLE
docs: document checklist creation limitation + add runtime warning (closes #11)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,28 @@ delete-note id="x-coredata://ABC/ICNote/p123"
 - **HTML format:** When using `format: "html"`, do NOT include a `<h1>` tag in `content` — the title is prepended automatically as `<h1>`.
 - `create-note` returns the new note's ID for subsequent operations
 
+### Checklist Creation Is Not Supported
+
+**You cannot create an Apple Notes checklist (the interactive ☐ / ☑ items) via this MCP server.** This is an Apple Notes limitation, not a server bug.
+
+When you send checklist HTML or markdown to `create-note` or `update-note`:
+
+| You send | What Notes.app renders |
+|----------|------------------------|
+| `<input type="checkbox"> Buy milk` | `Buy milk` (the `<input>` is stripped) |
+| `<ul class="checklist"><li>Buy milk</li></ul>` | A plain bulleted list (the class is dropped) |
+| `- [ ] Buy milk` in `plaintext` mode | Literal text `- [ ] Buy milk` |
+
+Apple Notes stores checklists as a paragraph style inside a gzipped protobuf blob. AppleScript's `body` interface does not expose paragraph styles, so there is no HTML or markdown input that produces a real checklist.
+
+**What to do when a user asks for a checklist note:**
+
+1. Create the note with `<ul><li>…</li></ul>` items (HTML) or `- ` bullet lines (plaintext) — the list structure is preserved.
+2. Tell the user to open the note in Notes.app, select the list items, and press **⇧⌘L** (or **Format → Checklist**) to convert them.
+3. Once converted, `get-checklist-state` and `get-note-markdown` can read the done/undone state correctly.
+
+Do not try alternative HTML class names, data attributes, or Unicode characters like `☐` — none of them produce a real checklist. The interface to set paragraph styles simply isn't exposed.
+
 ### Whitespace Accumulation on Iterative Updates
 
 **Important:** When repeatedly updating a note (especially with HTML content), Apple Notes can accumulate whitespace artifacts - specifically `<div><br></div>` tags that persist between sections even after removing them from your content.

--- a/README.md
+++ b/README.md
@@ -757,6 +757,29 @@ All other tools work normally without Full Disk Access. Only checklist state fea
 | Limited rich formatting | Use `format: "html"` on create/update for headings, lists, bold, code blocks; some complex formatting may not render |
 | Title matching | Most operations require exact title matches |
 | Checklist state | Requires Full Disk Access to read done/undone state from the database |
+| Checklist **creation** | Not supported. AppleScript's `body of note` setter strips `<input type="checkbox">` and ignores any checklist-styling CSS class. Apple Notes stores checklist items as a protobuf paragraph style (`style_type=103`) that AppleScript doesn't expose, and the SQLite database is read-only. See [Creating Checklists](#creating-checklists) below for the workaround. |
+
+### Creating Checklists
+
+**There is no programmatic way to create a true Apple Notes checklist via AppleScript** — and therefore no way via this MCP server. This is an Apple limitation, not a bug.
+
+When a note is created or updated via AppleScript:
+
+| You send | What Notes.app actually renders |
+|----------|--------------------------------|
+| `<input type="checkbox"> Item` | `Item` (the `<input>` tag is stripped) |
+| `<ul class="checklist"><li>Item</li></ul>` | A plain bulleted list — the `checklist` class is dropped |
+| Markdown `- [ ] Item` (in `plaintext` mode) | The literal text `- [ ] Item` |
+
+Apple Notes stores checklists as a paragraph style (`style_type=103`) inside a gzipped protobuf blob in the `NoteStore.sqlite` database. AppleScript's note `body` interface does not expose paragraph styles, and writing directly to the live database is unsafe.
+
+**Workarounds:**
+
+1. **Create the note with bulleted list items, then convert manually in Notes.app.** Select the items and press <kbd>⇧⌘L</kbd> (or **Format → Checklist**). This converts the list in place and the resulting checklist will be readable by `get-checklist-state` and annotated by `get-note-markdown`.
+2. **Use the Apple Shortcuts app** to script the checklist creation, since Shortcuts can manipulate Notes content at a higher level than AppleScript.
+3. **Read-only checklist support is fully implemented** — once a checklist exists (created manually or by another app), `get-checklist-state` and `get-note-markdown` will read its done/undone state correctly (with Full Disk Access).
+
+If you need to *track* todos programmatically and don't strictly need them rendered as Apple Notes checklist UI, plain markdown-style `- [ ] item` / `- [x] item` lines in a `plaintext` note are a reasonable alternative — they are searchable, human-readable, and can be parsed by downstream tooling.
 
 ### Backslash Escaping (Important for AI Agents)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import { z } from "zod";
 import { AppleNotesManager } from "@/services/appleNotesManager.js";
 import { getSyncStatus, withSyncAwarenessSync } from "@/utils/syncDetection.js";
 import { getChecklistItems, hasFullDiskAccess } from "@/utils/checklistParser.js";
+import { detectChecklistAttempt } from "@/utils/contentWarnings.js";
 
 // Read version from package.json to keep it in sync
 const require = createRequire(import.meta.url);
@@ -131,7 +132,12 @@ server.tool(
   "create-note",
   {
     title: z.string().min(1, "Title is required"),
-    content: z.string().min(1, "Content is required"),
+    content: z
+      .string()
+      .min(1, "Content is required")
+      .describe(
+        'Note body. AppleScript cannot create true Apple Notes checklists — `<input type="checkbox">`, checklist CSS classes, and markdown `- [ ]` lines do not render as checkable items. To produce a checklist, create the note with a plain `<ul>` or `- ` list and convert it in Notes.app with ⇧⌘L.'
+      ),
     format: z
       .enum(["plaintext", "html"])
       .optional()
@@ -153,7 +159,8 @@ server.tool(
       );
     }
 
-    return successResponse(`Note created: "${note.title}" [id: ${note.id}]`);
+    const checklistWarning = detectChecklistAttempt(content) ?? "";
+    return successResponse(`Note created: "${note.title}" [id: ${note.id}]${checklistWarning}`);
   }, "Error creating note")
 );
 
@@ -344,7 +351,12 @@ server.tool(
     id: z.string().optional().describe("Note ID (preferred - more reliable than title)"),
     title: z.string().optional().describe("Current note title (use id instead when available)"),
     newTitle: z.string().optional().describe("New title for the note"),
-    newContent: z.string().min(1, "New content is required"),
+    newContent: z
+      .string()
+      .min(1, "New content is required")
+      .describe(
+        "New note body. AppleScript cannot produce true Apple Notes checklists; checkbox inputs and `- [ ]` markdown do not render as checkable items. Use a plain list and convert in Notes.app with ⇧⌘L."
+      ),
     format: z
       .enum(["plaintext", "html"])
       .optional()
@@ -377,7 +389,8 @@ server.tool(
       const sharedWarning = note.shared
         ? "\n\n⚠️ This note is shared with collaborators. Your changes will be visible to them."
         : "";
-      return successResponse(`Note updated: "${displayTitle}"${sharedWarning}`);
+      const checklistWarning = detectChecklistAttempt(newContent) ?? "";
+      return successResponse(`Note updated: "${displayTitle}"${sharedWarning}${checklistWarning}`);
     }
 
     // Fall back to title-based update
@@ -408,7 +421,8 @@ server.tool(
     const sharedWarning = note.shared
       ? "\n\n⚠️ This note is shared with collaborators. Your changes will be visible to them."
       : "";
-    return successResponse(`Note updated: "${finalTitle}"${sharedWarning}`);
+    const checklistWarning = detectChecklistAttempt(newContent) ?? "";
+    return successResponse(`Note updated: "${finalTitle}"${sharedWarning}${checklistWarning}`);
   }, "Error updating note")
 );
 

--- a/src/utils/contentWarnings.test.ts
+++ b/src/utils/contentWarnings.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Tests for the content-warning detectors.
+ */
+
+import { describe, it, expect } from "vitest";
+import { detectChecklistAttempt } from "./contentWarnings.js";
+
+describe("detectChecklistAttempt", () => {
+  it("returns null for plain text without checklist syntax", () => {
+    expect(detectChecklistAttempt("Just a regular note.")).toBeNull();
+  });
+
+  it("returns null for empty content", () => {
+    expect(detectChecklistAttempt("")).toBeNull();
+  });
+
+  it("returns null for HTML lists that are not checklists", () => {
+    expect(detectChecklistAttempt("<ul><li>Apple</li><li>Banana</li></ul>")).toBeNull();
+  });
+
+  it('warns on <input type="checkbox"> (double-quoted)', () => {
+    const w = detectChecklistAttempt('<input type="checkbox"> Buy milk');
+    expect(w).not.toBeNull();
+    expect(w).toContain("⚠️");
+    expect(w).toContain("⇧⌘L");
+  });
+
+  it("warns on <input type='checkbox'> (single-quoted)", () => {
+    expect(detectChecklistAttempt("<input type='checkbox'> Buy milk")).not.toBeNull();
+  });
+
+  it("warns on <input> with extra attributes before type", () => {
+    expect(detectChecklistAttempt('<input id="x" type="checkbox"> Item')).not.toBeNull();
+  });
+
+  it('warns on <INPUT TYPE="CHECKBOX"> (case-insensitive)', () => {
+    expect(detectChecklistAttempt('<INPUT TYPE="CHECKBOX"> Item')).not.toBeNull();
+  });
+
+  it("warns on markdown `- [ ]` syntax", () => {
+    expect(detectChecklistAttempt("- [ ] todo 1\n- [x] done 1")).not.toBeNull();
+  });
+
+  it("warns on markdown `* [ ]` syntax", () => {
+    expect(detectChecklistAttempt("* [ ] todo 1")).not.toBeNull();
+  });
+
+  it("warns on markdown checklist with leading whitespace", () => {
+    expect(detectChecklistAttempt("  - [ ] indented todo")).not.toBeNull();
+  });
+
+  it('warns on <ul class="checklist">', () => {
+    expect(detectChecklistAttempt('<ul class="checklist"><li>a</li></ul>')).not.toBeNull();
+  });
+
+  it('warns on <li class="todo">', () => {
+    expect(detectChecklistAttempt('<ul><li class="todo">a</li></ul>')).not.toBeNull();
+  });
+
+  it("does not warn on the word 'checklist' in prose", () => {
+    expect(detectChecklistAttempt("My checklist of things to do tomorrow.")).toBeNull();
+  });
+
+  it("does not warn on a literal `[ ]` not at start of a list line", () => {
+    expect(detectChecklistAttempt("The brackets [ ] are not a checklist.")).toBeNull();
+  });
+});

--- a/src/utils/contentWarnings.ts
+++ b/src/utils/contentWarnings.ts
@@ -1,0 +1,50 @@
+/**
+ * Content Warnings for create-note / update-note
+ *
+ * Detects content patterns that look like the user is trying to do something
+ * Apple Notes via AppleScript cannot actually render — so the response can
+ * carry a clear warning instead of silently producing a broken note.
+ *
+ * @module utils/contentWarnings
+ */
+
+/**
+ * Detects checklist-like syntax in note content.
+ *
+ * Apple Notes checklists are a paragraph style stored in a protobuf blob in
+ * the NoteStore SQLite database. AppleScript's `body of note` setter does not
+ * expose paragraph styles: `<input type="checkbox">` is stripped, a
+ * `class="checklist"` on `<ul>` is dropped, and markdown `- [ ]` lines in
+ * `plaintext` mode arrive as literal text. There is no input that produces a
+ * real checklist.
+ *
+ * @param content - The user-supplied note body (HTML or plaintext)
+ * @returns A user-facing warning string, or null when no checklist-like
+ *   patterns are present
+ */
+export function detectChecklistAttempt(content: string): string | null {
+  if (!content) return null;
+
+  // HTML checkbox input — `<input type="checkbox" ...>` in either quoting style.
+  const htmlCheckbox = /<input\b[^>]*\btype\s*=\s*["']checkbox["']/i.test(content);
+
+  // Markdown-style checklist: lines starting with optional whitespace, then
+  // `-` or `*`, a space, and `[ ]` / `[x]` / `[X]`.
+  const markdownCheckbox = /^[ \t]*[-*]\s+\[[ xX]\]/m.test(content);
+
+  // CSS class hint — some clients try `<ul class="checklist">` or
+  // `<li class="todo">`. AppleScript drops these classes too.
+  const checklistClass = /class\s*=\s*["'][^"']*\b(?:checklist|todo)\b/i.test(content);
+
+  if (!htmlCheckbox && !markdownCheckbox && !checklistClass) return null;
+
+  return (
+    "\n\n⚠️ Your content looks like a checklist, but Apple Notes checklists " +
+    'cannot be created via AppleScript — `<input type="checkbox">` is ' +
+    "stripped, checklist CSS classes are dropped, and markdown `- [ ]` lines " +
+    "arrive as literal text. The note was created with the surrounding " +
+    "structure (list items or paragraphs) intact. To convert it to a real " +
+    "Apple Notes checklist, open the note, select the items, and press " +
+    "⇧⌘L (Format → Checklist)."
+  );
+}


### PR DESCRIPTION
## Summary

Issue #11 asked how to create an Apple Note with a checklist via this MCP server. The answer is: you can't, because AppleScript's `body of note` setter does not support it — and the docs didn't say so. This PR fixes that gap and adds a runtime warning so the failure mode stops being silent.

## Diagnosis

I empirically tested three plausible HTML formats against AppleScript:

| Input | What Notes.app actually rendered |
|---|---|
| `<input type="checkbox"> Apple` | `<div>Apple</div>` — `<input>` stripped |
| `<ul class="checklist"><li>Apple</li></ul>` | Plain `<ul><li>Apple</li></ul>` — class dropped |
| `<li class="todo">Apple</li>` | Plain `<ul><li>Apple</li></ul>` — class dropped |

Apple Notes stores checklists as a protobuf paragraph style (`style_type=103`) inside the `NoteStore.sqlite` blob. The existing `checklistParser.ts` already reads this format (which is how `get-checklist-state` and `get-note-markdown` annotations work), but the database is read-only by policy and AppleScript exposes nothing for paragraph styles. There is no input that produces a real checklist via the public scripting interface.

## Workaround

Create the note with a plain `<ul><li>…</li></ul>` (HTML) or `- ` bullets (plaintext), then open the note in Notes.app, select the items, and press **⇧⌘L** (or Format → Checklist). Once converted, `get-checklist-state` and `get-note-markdown` read the done/undone state correctly.

## Changes

- **README.md** — new "Creating Checklists" section with the workaround, plus a new row in Known Limitations.
- **CLAUDE.md** — new "Checklist Creation Is Not Supported" section so AI agents stop trying alternative HTML class names, data attributes, etc.
- **src/utils/contentWarnings.ts** (new) — `detectChecklistAttempt()` utility that recognizes `<input type=checkbox>`, `class="checklist"|"todo"`, and markdown `- [ ]` / `* [ ]` lines.
- **src/utils/contentWarnings.test.ts** (new) — 14 unit tests covering positive and negative cases.
- **src/index.ts** — `create-note` and `update-note` now append a runtime warning to the success response when content looks like an attempted checklist, and their `content` / `newContent` schema descriptions mention the limitation so it shows up in MCP tool listings.

## Verification

- `npm run typecheck` ✓
- `npm run lint` ✓
- `npm test` — 327/327 pass (including 14 new tests)
- Empirical AppleScript testing against the live Notes.app confirmed all three HTML variants are stripped

Closes #11