### PR TITLE
fix(mcp): decouple plugin vs project-scope entrypoint resolution (v1.4.3)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,9 +1,17 @@
 {
   "name": "apple-notes",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, and organize notes and folders (macOS only)",
   "author": {
     "name": "Rob Sweet",
     "email": "rob@superiortech.io"
+  },
+  "mcpServers": {
+    "apple-notes": {
+      "command": "node",
+      "args": [
+        "${CLAUDE_PLUGIN_ROOT}/build/index.js"
+      ]
+    }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "apple-notes": {
-      "command": "npx",
-      "args": ["apple-notes-mcp"]
+      "command": "node",
+      "args": ["${CLAUDE_PROJECT_DIR:-.}/build/index.js"]
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.3] - 2026-06-01
+
+### Fixed
+- **`.mcp.json` now serves both plugin installs and clones** — the marketplace plugin install was broken (no `mcpServers` declared in `plugin.json`), and the clone/contributor workflow ran the *published* `apple-notes-mcp` package via `npx` instead of the local build. These two contexts can't share one entrypoint string because plugin installs need `${CLAUDE_PLUGIN_ROOT}` while clones need `${CLAUDE_PROJECT_DIR:-.}`, and Claude Code does not support nested defaults like `${CLAUDE_PLUGIN_ROOT:-${CLAUDE_PROJECT_DIR:-.}}`. The two paths are now decoupled: the root `.mcp.json` uses `${CLAUDE_PROJECT_DIR:-.}/build/index.js` (clone workflow), and `.claude-plugin/plugin.json` declares its own `mcpServers` using `${CLAUDE_PLUGIN_ROOT}/build/index.js` (plugin install). Because `plugin.json` declares `mcpServers`, the plugin no longer auto-loads the root `.mcp.json`, so there is no double-registration. Matches the fix shipped in apple-mail-mcp.
+
 ## [1.4.2] - 2026-05-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -712,6 +712,22 @@ If installed from source, use this configuration:
 }
 ```
 
+#### Running from a clone in Claude Code (project-scope `.mcp.json`)
+
+This repo ships a `.mcp.json` at its root so that, when you run `claude` from inside a clone, the server is registered automatically as a **project-scope** server — no manual config needed. After `npm run build`, just launch Claude Code from the repo directory and approve the server when prompted.
+
+The entrypoint is written as:
+
+```json
+"args": ["${CLAUDE_PROJECT_DIR:-.}/build/index.js"]
+```
+
+`CLAUDE_PROJECT_DIR` is the variable Claude Code injects into a project/user-scoped server's environment, and it resolves to the repo root. **You must launch `claude` from inside the repo** for this to work — the bare `.` fallback is only a last resort and is *not* reliable, because it resolves against the launching process's working directory, not the repo.
+
+> **Why not `${CLAUDE_PLUGIN_ROOT}`?** `CLAUDE_PLUGIN_ROOT` is set **only** for marketplace plugin installs, never for a project-scope clone, so it can't drive the clone workflow. Conversely, a plugin install can't use `CLAUDE_PROJECT_DIR` (in a plugin, that points at the *user's* project, not the plugin's own directory). Claude Code does **not** support nested defaults like `${CLAUDE_PLUGIN_ROOT:-${CLAUDE_PROJECT_DIR:-.}}`, so a single entrypoint string cannot serve both contexts. The two distribution paths are therefore decoupled: the **plugin** carries its own MCP config in `.claude-plugin/plugin.json` (using `${CLAUDE_PLUGIN_ROOT}`), while the root `.mcp.json` is dedicated to the **clone** workflow (using `${CLAUDE_PROJECT_DIR:-.}`). Because `plugin.json` declares its own `mcpServers`, the plugin does not also auto-load the root `.mcp.json`, so there is no double-registration.
+
+> **Heads-up on scope precedence:** project-scope (`.mcp.json`) outranks user-scope. If you *also* have an `apple-notes` entry registered at user scope (e.g. an absolute path in `~/.claude.json`), the project-scope entry wins and the user-scope one is ignored entirely. Pick one — for local development on this repo, the project-scope `.mcp.json` is the intended source. To pin a specific local build instead, register it at **local** scope (`claude mcp add apple-notes -s local -- node /abs/path/build/index.js`), which outranks project scope.
+
 ---
 
 ## Full Disk Access for Checklist Features
@@ -827,6 +843,12 @@ The `\\\\` in JSON becomes `\\` in the actual string, which represents a single 
 - Content containing `\` characters requires JSON escaping
 - Use `\\` to represent each literal backslash
 - See "Backslash Escaping" section under Known Limitations
+
+### `apple-notes` server fails to connect when run from a clone
+- Launch `claude` from **inside the repo directory** so `CLAUDE_PROJECT_DIR` resolves to the repo root (the bare `.` fallback is unreliable — it points at the launching process's working directory)
+- Run `npm run build` first — the entrypoint is `${CLAUDE_PROJECT_DIR:-.}/build/index.js`, which won't exist until you build
+- Run `claude mcp list` to check for a conflicting `apple-notes` entry at another scope (project-scope outranks user-scope, but local-scope outranks project-scope)
+- Approve the pending project-scope server when Claude Code prompts you
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "apple-notes-mcp",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "apple-notes-mcp",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "license": "MIT",
       "os": [
         "darwin"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes-mcp",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "MCP server for Apple Notes - create, search, update, and manage notes via Claude",
   "type": "module",
   "main": "build/index.js",


### PR DESCRIPTION
Mirrors the apple-mail-mcp fix (sweetrb/apple-mail-mcp#18).

**Problem:** the root `.mcp.json` used `npx apple-notes-mcp`, which runs the *published* package rather than the local build — defeating the project-scope clone / contributor workflow — and `plugin.json` declared no `mcpServers`, so the plugin auto-loaded the same root `.mcp.json`.

**Why one string can't serve both:** plugin installs need `${CLAUDE_PLUGIN_ROOT}`; project-scope clones need `${CLAUDE_PROJECT_DIR:-.}` (in a plugin, `CLAUDE_PROJECT_DIR` points at the *user's* project, not the plugin dir); and Claude Code does not support nested defaults.

**Fix — decouple:**
- `.mcp.json` → `${CLAUDE_PROJECT_DIR:-.}/build/index.js` (clone/contributor workflow, runs the local build)
- `.claude-plugin/plugin.json` declares its own `mcpServers` with `${CLAUDE_PLUGIN_ROOT}/build/index.js` (plugin install) — so it no longer auto-loads the root `.mcp.json` (no double-registration)

README gains a "Running from a clone" subsection + Troubleshooting entry. Bump 1.4.2 → 1.4.3. Gates: lint/typecheck/test (327)/build all green.