### PR TITLE
Dedupe CoreData notes returned more than once by Notes.app

### DIFF
--- a/src/services/appleNotesManager.test.ts
+++ b/src/services/appleNotesManager.test.ts
@@ -695,6 +695,22 @@ describe("AppleNotesManager", () => {
       expect(results[1].folder).toBe("Notes");
     });
 
+    it("deduplicates duplicate note IDs returned by Notes.app", () => {
+      mockExecuteAppleScript.mockReturnValue({
+        success: true,
+        output: [
+          ["Not uploaded", "x-coredata://ABC/ICNote/p1", "Notes"].join(F),
+          ["Not uploaded", "x-coredata://ABC/ICNote/p1", "Notes"].join(F),
+        ].join(R),
+      });
+
+      const results = manager.searchNotes("Not uploaded");
+
+      expect(results).toHaveLength(1);
+      expect(results[0].title).toBe("Not uploaded");
+      expect(results[0].id).toBe("x-coredata://ABC/ICNote/p1");
+    });
+
     it("scopes search to specified account", () => {
       mockExecuteAppleScript.mockReturnValue({
         success: true,
@@ -1338,7 +1354,11 @@ describe("AppleNotesManager", () => {
     it("returns array of note titles", () => {
       mockExecuteAppleScript.mockReturnValue({
         success: true,
-        output: ["Note A", "Note B", "Note C"].join(R),
+        output: [
+          ["Note A", "x-coredata://ABC/ICNote/p1"].join(F),
+          ["Note B", "x-coredata://ABC/ICNote/p2"].join(F),
+          ["Note C", "x-coredata://ABC/ICNote/p3"].join(F),
+        ].join(R),
       });
 
       const titles = manager.listNotes();
@@ -1349,12 +1369,33 @@ describe("AppleNotesManager", () => {
     it("filters out empty entries", () => {
       mockExecuteAppleScript.mockReturnValue({
         success: true,
-        output: ["Note A", "", "Note B", "", ""].join(R),
+        output: [
+          ["Note A", "x-coredata://ABC/ICNote/p1"].join(F),
+          "",
+          ["Note B", "x-coredata://ABC/ICNote/p2"].join(F),
+          "",
+          "",
+        ].join(R),
       });
 
       const titles = manager.listNotes();
 
       expect(titles).toEqual(["Note A", "Note B"]);
+    });
+
+    it("deduplicates duplicate note IDs while preserving separate notes with the same title", () => {
+      mockExecuteAppleScript.mockReturnValue({
+        success: true,
+        output: [
+          ["Same Title", "x-coredata://ABC/ICNote/p1"].join(F),
+          ["Same Title", "x-coredata://ABC/ICNote/p1"].join(F),
+          ["Same Title", "x-coredata://ABC/ICNote/p2"].join(F),
+        ].join(R),
+      });
+
+      const titles = manager.listNotes();
+
+      expect(titles).toEqual(["Same Title", "Same Title"]);
     });
 
     it("throws on failure rather than returning empty (#19)", () => {
@@ -1370,7 +1411,10 @@ describe("AppleNotesManager", () => {
     it("filters by folder when specified", () => {
       mockExecuteAppleScript.mockReturnValue({
         success: true,
-        output: ["Work Note 1", "Work Note 2"].join(R),
+        output: [
+          ["Work Note 1", "x-coredata://ABC/ICNote/p1"].join(F),
+          ["Work Note 2", "x-coredata://ABC/ICNote/p2"].join(F),
+        ].join(R),
       });
 
       manager.listNotes("iCloud", "Work");
@@ -1383,7 +1427,10 @@ describe("AppleNotesManager", () => {
     it("uses whose clause when modifiedSince is provided", () => {
       mockExecuteAppleScript.mockReturnValue({
         success: true,
-        output: ["Recent Note 1", "Recent Note 2"].join(R),
+        output: [
+          ["Recent Note 1", "x-coredata://ABC/ICNote/p1"].join(F),
+          ["Recent Note 2", "x-coredata://ABC/ICNote/p2"].join(F),
+        ].join(R),
       });
 
       const results = manager.listNotes(undefined, undefined, "2025-06-15T00:00:00");
@@ -1401,7 +1448,11 @@ describe("AppleNotesManager", () => {
     it("uses repeat loop when limit is provided", () => {
       mockExecuteAppleScript.mockReturnValue({
         success: true,
-        output: ["Note 1", "Note 2", "Note 3"].join(R),
+        output: [
+          ["Note 1", "x-coredata://ABC/ICNote/p1"].join(F),
+          ["Note 2", "x-coredata://ABC/ICNote/p2"].join(F),
+          ["Note 3", "x-coredata://ABC/ICNote/p3"].join(F),
+        ].join(R),
       });
 
       const results = manager.listNotes(undefined, undefined, undefined, 3);
@@ -1414,7 +1465,10 @@ describe("AppleNotesManager", () => {
     it("combines folder, modifiedSince, and limit", () => {
       mockExecuteAppleScript.mockReturnValue({
         success: true,
-        output: ["Work Note", "Another Work Note"].join(R),
+        output: [
+          ["Work Note", "x-coredata://ABC/ICNote/p1"].join(F),
+          ["Another Work Note", "x-coredata://ABC/ICNote/p2"].join(F),
+        ].join(R),
       });
 
       manager.listNotes("iCloud", "Work", "2025-01-01", 10);
@@ -1439,7 +1493,10 @@ describe("AppleNotesManager", () => {
     it("ignores invalid modifiedSince date and falls back to limit-only", () => {
       mockExecuteAppleScript.mockReturnValue({
         success: true,
-        output: ["Note 1", "Note 2"].join(R),
+        output: [
+          ["Note 1", "x-coredata://ABC/ICNote/p1"].join(F),
+          ["Note 2", "x-coredata://ABC/ICNote/p2"].join(F),
+        ].join(R),
       });
 
       const results = manager.listNotes(undefined, undefined, "not-a-date", 5);
@@ -1827,7 +1884,13 @@ describe("AppleNotesManager", () => {
         // Check 3: listAccounts
         .mockReturnValueOnce({ success: true, output: "iCloud" })
         // Check 4: listNotes
-        .mockReturnValueOnce({ success: true, output: ["Note 1", "Note 2"].join(R) });
+        .mockReturnValueOnce({
+          success: true,
+          output: [
+            ["Note 1", "x-coredata://ABC/ICNote/p1"].join(F),
+            ["Note 2", "x-coredata://ABC/ICNote/p2"].join(F),
+          ].join(R),
+        });
 
       const result = manager.healthCheck();
 
@@ -2286,7 +2349,10 @@ describe("AppleNotesManager", () => {
         // listFolders for iCloud
         .mockReturnValueOnce({ success: true, output: "id1\tNotes" })
         // listNotes for Notes folder
-        .mockReturnValueOnce({ success: true, output: "Test Note" })
+        .mockReturnValueOnce({
+          success: true,
+          output: ["Test Note", "x-coredata://ABC/ICNote/p1"].join(F),
+        })
         // getNoteDetails
         .mockReturnValueOnce({ success: true, output: noteDetailsOutput("Test Note", false) })
         // getNoteContent
@@ -2319,7 +2385,10 @@ describe("AppleNotesManager", () => {
         // listFolders for iCloud
         .mockReturnValueOnce({ success: true, output: "id1\tNotes" })
         // listNotes for Notes folder
-        .mockReturnValueOnce({ success: true, output: "Locked Note" })
+        .mockReturnValueOnce({
+          success: true,
+          output: ["Locked Note", "x-coredata://ABC/ICNote/p1"].join(F),
+        })
         // getNoteDetails (passwordProtected = true)
         .mockReturnValueOnce({ success: true, output: noteDetailsOutput("Locked Note", true) });
       // No getNoteContent call because note is password-protected

--- a/src/services/appleNotesManager.ts
+++ b/src/services/appleNotesManager.ts
@@ -797,24 +797,26 @@ export class AppleNotesManager {
           if (count of resultList) >= ${safeLimit} then exit repeat`
         : "";
 
-    // Get names, IDs, and folder for each matching note
-    // We use a repeat loop to get all properties, separated by a delimiter
-    // Note: Some notes may have inaccessible containers, so we wrap in try/on error
+    // Get names, IDs, and folder for each matching note.
+    // Notes.app can return the same CoreData note more than once when asking
+    // an account for all notes, so dedupe on note ID before adding results.
     const searchCommand = `
       ${dateSetup}set matchingNotes to ${notesSource} where ${whereClause}
       set resultList to {}
-      repeat with n in matchingNotes${limitCheck}
+      set seenIds to {}
+      repeat with n in matchingNotes
         try
           set noteName to name of n
           set noteId to id of n
-          set noteFolder to name of container of n
-          set end of resultList to noteName & ${AS_FIELD_SEP} & noteId & ${AS_FIELD_SEP} & noteFolder
-        on error
-          try
-            set noteName to name of n
-            set noteId to id of n
-            set end of resultList to noteName & ${AS_FIELD_SEP} & noteId & ${AS_FIELD_SEP} & "Notes"
-          end try
+          if seenIds does not contain noteId then
+            set end of seenIds to noteId
+            try
+              set noteFolder to name of container of n
+            on error
+              set noteFolder to "Notes"
+            end try
+            set end of resultList to noteName & ${AS_FIELD_SEP} & noteId & ${AS_FIELD_SEP} & noteFolder${limitCheck}
+          end if
         end try
       end repeat
       set AppleScript's text item delimiters to ${AS_RECORD_SEP}
@@ -837,11 +839,15 @@ export class AppleNotesManager {
     const items = result.output.split(RECORD_SEP);
 
     const notes: Note[] = [];
+    const seenIds = new Set<string>();
     for (const item of items) {
       const [title, id, folder] = item.split(FIELD_SEP);
       if (!title?.trim()) continue;
+      const noteId = id?.trim() || generateFallbackId();
+      if (seenIds.has(noteId)) continue;
+      seenIds.add(noteId);
       notes.push({
-        id: id?.trim() || generateFallbackId(), // Use real ID, fallback to unique temp ID
+        id: noteId,
         title: title.trim(),
         content: "", // Not fetched in search
         tags: [] as string[],
@@ -1212,7 +1218,8 @@ export class AppleNotesManager {
         }
       }
 
-      // Build the limit check
+      // Build the limit check. Check after appending so deduped results,
+      // rather than duplicate AppleScript references, determine the limit.
       const limitCheck =
         safeLimit !== undefined
           ? `
@@ -1221,8 +1228,16 @@ export class AppleNotesManager {
 
       const listCommand = `
         ${dateSetup}set resultList to {}
-        repeat with n in ${notesSource}${limitCheck}
-          set end of resultList to name of n
+        set seenIds to {}
+        repeat with n in ${notesSource}
+          try
+            set noteName to name of n
+            set noteId to id of n
+            if seenIds does not contain noteId then
+              set end of seenIds to noteId
+              set end of resultList to noteName & ${AS_FIELD_SEP} & noteId${limitCheck}
+            end if
+          end try
         end repeat
         set AppleScript's text item delimiters to ${AS_RECORD_SEP}
         return resultList as text
@@ -1239,17 +1254,35 @@ export class AppleNotesManager {
         return [];
       }
 
-      return result.output
-        .split(RECORD_SEP)
-        .map((item) => item.trim())
-        .filter((item) => item.length > 0);
+      const seenIds = new Set<string>();
+      const titles: string[] = [];
+      for (const item of result.output.split(RECORD_SEP)) {
+        const [title, id] = item.split(FIELD_SEP);
+        if (!title?.trim()) continue;
+        const noteId = id?.trim() || generateFallbackId();
+        if (seenIds.has(noteId)) continue;
+        seenIds.add(noteId);
+        titles.push(title.trim());
+      }
+      return titles;
     }
 
-    // Simple path: no date or limit filters. Coerce the name list to text with a
-    // control-char record separator so titles containing commas don't split (#18).
+    // Simple path: no date or limit filters. Use a repeat loop so duplicate
+    // CoreData note references can be deduped by ID before returning titles.
     const notesRef = folder ? `notes of ${buildFolderReference(folder)}` : `notes`;
     const listCommand = `
-      set resultList to name of ${notesRef}
+      set resultList to {}
+      set seenIds to {}
+      repeat with n in ${notesRef}
+        try
+          set noteName to name of n
+          set noteId to id of n
+          if seenIds does not contain noteId then
+            set end of seenIds to noteId
+            set end of resultList to noteName & ${AS_FIELD_SEP} & noteId
+          end if
+        end try
+      end repeat
       set AppleScript's text item delimiters to ${AS_RECORD_SEP}
       return resultList as text
     `;
@@ -1262,10 +1295,17 @@ export class AppleNotesManager {
     }
     if (!result.output.trim()) return [];
 
-    return result.output
-      .split(RECORD_SEP)
-      .map((item) => item.trim())
-      .filter((item) => item.length > 0);
+    const seenIds = new Set<string>();
+    const titles: string[] = [];
+    for (const item of result.output.split(RECORD_SEP)) {
+      const [title, id] = item.split(FIELD_SEP);
+      if (!title?.trim()) continue;
+      const noteId = id?.trim() || generateFallbackId();
+      if (seenIds.has(noteId)) continue;
+      seenIds.add(noteId);
+      titles.push(title.trim());
+    }
+    return titles;
   }
 
   /**


### PR DESCRIPTION
## The problem

When you ask Notes.app for all of an account's notes, it can hand back the same CoreData note more than once. That made `search-notes` and `list-notes` occasionally return duplicate entries for a single note.

## The fix

Dedupe on note ID at two layers, so a duplicate from either side is dropped:

- **AppleScript loop**: track seen IDs and skip a note whose ID has already been added before appending it to the result list.
- **JS parsing**: guard with a `Set<string>` so any duplicate that still slips through is filtered before results are returned.

This is applied consistently across the three code paths that enumerate notes: the search path, the date/limit list path, and the simple list path. The simple list path now uses a repeat loop (emitting name and ID) instead of `name of notes`, so it can dedupe the same way the other paths do.

## Tests

Two new tests:
- duplicate note IDs returned by Notes.app are deduped
- distinct notes that happen to share a title are preserved (dedupe is by ID, not title)

Full suite: 363 passing. `npm run typecheck` and `npm run build` are clean.
