### PR TITLE
docs: record tool-description additions and destructive-tool safety notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **MCP-visible structured tool descriptions on all 26 tools (#37).** Every tool now registers a description in the `Use when: / Returns: / Do not use when:` shape so agents can pick the right tool without trial and error. The eight write/destructive tools (`create-note`, `update-note`, `delete-note`, `move-note`, `batch-delete-notes`, `batch-move-notes`, `delete-folder`, `save-attachment`) additionally carry explicit `Safety:` wording calling out the confirmation expectation. No tool behavior or parameters changed — descriptions only.
+
 ### Documentation
 - Added `docs/NODE-RUNTIME-AND-TCC-PERMISSIONS.md`: why macOS re-prompts for Full Disk Access / Automation when the server runs under an ad-hoc-signed (e.g. Homebrew) Node, and the fix — run it under the official Developer-ID-signed Node so the grant survives Node updates. README and CLAUDE.md now point at it.
 

--- a/README.md
+++ b/README.md
@@ -345,6 +345,8 @@ Updates an existing note's content and/or title.
 
 **Returns:** Confirmation message, or error if note not found.
 
+**Note:** `newContent` **replaces the entire note body** — it is not appended. To preserve existing content, read it first (e.g. with `get-note-content`) and include it in `newContent`.
+
 ---
 
 #### `delete-note`
@@ -374,6 +376,8 @@ Deletes a note (moves to Recently Deleted in Notes.app).
 ```
 
 **Returns:** Confirmation message, or error if note not found.
+
+**⚠️ Safety:** Irreversible from the agent's side — requires explicit user confirmation before calling. Prefer `search-notes` / `list-notes` first to confirm the exact id(s) being deleted.
 
 ---
 
@@ -504,6 +508,8 @@ Deletes a folder.
 
 **Returns:** Confirmation message, or error if folder not found or not empty.
 
+**⚠️ Safety:** Irreversible — requires explicit user confirmation before calling. Prefer `list-folders` first to confirm the exact folder path being deleted.
+
 ---
 
 ### Account Operations
@@ -534,6 +540,8 @@ Deletes multiple notes at once by ID.
 | `ids` | string[] | Yes | Array of note IDs to delete |
 
 **Returns:** Summary of successes and failures.
+
+**⚠️ Safety:** Irreversible — requires explicit user confirmation before calling. Prefer `search-notes` / `list-notes` first to confirm the exact ids being deleted.
 
 ---
 


### PR DESCRIPTION
## Problem
PR #37 added MCP-visible structured descriptions (`Use when: / Returns: / Do not use when: / Safety:`) to all 26 tools, with explicit confirmation/Safety wording on the eight write/destructive tools. The docs were not updated as part of that PR.

## Change
Docs-only — no `src/` changes.

- **CHANGELOG.md** — new `### Added` entry under `[Unreleased]` recording that all 26 tools now register a structured MCP-visible description, with explicit Safety/confirmation wording on the write/destructive tools. References #37.
- **README.md `## Tool Reference`**:
  - `delete-note`, `batch-delete-notes`, `delete-folder` — added a `**⚠️ Safety:**` callout (irreversible; requires explicit user confirmation; prefer search/list first to confirm affected ids/paths).
  - `update-note` — added a note that `newContent` **replaces the entire note body** (not append).

## Verification
- `npm run format:check` — green (all matched files use Prettier style).
- `npm test` — green (383 tests passed).
- `npm run build` — green (tsc + tsc-alias clean).
- `git diff` touches only CHANGELOG.md and README.md.

Self-initiated docs cleanup.