### PR TITLE
docs: sync package.json description with repo one-liner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 - Added `docs/NODE-RUNTIME-AND-TCC-PERMISSIONS.md`: why macOS re-prompts for Full Disk Access / Automation when the server runs under an ad-hoc-signed (e.g. Homebrew) Node, and the fix — run it under the official Developer-ID-signed Node so the grant survives Node updates. README and CLAUDE.md now point at it.
+- Synced the `package.json` `description` with the canonical GitHub repo one-liner ("…via Claude and other AI assistants").
 
 ## [2.1.0] - 2026-06-20
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apple-notes-mcp",
   "version": "2.1.0",
-  "description": "MCP server for Apple Notes - create, search, update, and manage notes via Claude and Codex",
+  "description": "MCP server for Apple Notes - create, search, update, and manage notes via Claude and other AI assistants",
   "type": "module",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
Brings the `package.json` `description` into exact agreement with the canonical GitHub repo one-liner.

- Changed the trailing "via Claude and Codex" → "via Claude and other AI assistants" so it matches the GitHub description verbatim ("other AI assistants" is a superset that still covers Codex).
- Recorded the sync under `## [Unreleased] → ### Documentation` in CHANGELOG.md.

README tagline ("read, create, search, and manage notes") verified accurate — no change needed.

Docs/metadata only — no `src/` logic touched. `format:check`, `npm test` (383 passing), and `build` all green.