### PR TITLE
Expose additional AppleScript Notes surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,12 @@ On first use, macOS will ask for permission to automate Notes.app. Click "OK" to
 | **Delete Notes** | Remove notes (moves to Recently Deleted) |
 | **Move Notes** | Organize notes into folders (supports nested paths) |
 | **Folder Management** | Create, list, and delete folders with full hierarchical path support |
-| **Multi-Account** | Work with iCloud, Gmail, Exchange, or any configured account |
+| **Multi-Account** | Work with iCloud, Gmail, Exchange, or any configured account, including account IDs and default folders |
 | **Batch Operations** | Delete or move multiple notes at once |
 | **Checklist State** | Read checklist done/undone state directly from the Notes database (requires Full Disk Access) |
 | **Export** | Export all notes as JSON or get individual notes as Markdown |
 | **Attachments** | List attachments, save them to disk, or fetch their bytes as base64 |
+| **Notes.app UI State** | Reveal a note in Notes.app or read the current Notes.app selection |
 | **Sync Awareness** | Detect iCloud sync in progress, warn about incomplete results |
 | **Collaboration** | Detect shared notes, warn before modifying |
 | **Diagnostics** | `health-check` plus a richer `doctor` (reachability, automation permission, accounts, Full Disk Access), sync status, and statistics |
@@ -302,6 +303,19 @@ Retrieves a note using its unique CoreData identifier.
 
 ---
 
+#### `show-note`
+
+Reveals a note in Notes.app using its unique CoreData identifier.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | string | Yes | The CoreData URL identifier (e.g., `x-coredata://...`) |
+| `separately` | boolean | No | Open in a separate note window when supported by Notes.app |
+
+**Returns:** Confirmation that Notes.app accepted the show command.
+
+---
+
 #### `update-note`
 
 Updates an existing note's content and/or title.
@@ -459,6 +473,16 @@ Lists all notes, optionally filtered by folder, date, and limit.
 
 ---
 
+#### `get-selected-notes`
+
+Reads the currently selected note(s) from the Notes.app UI.
+
+**Parameters:** None
+
+**Returns:** Selected note metadata, including IDs for follow-up operations. Returns an empty list when Notes.app has no selected note.
+
+---
+
 ### Folder Operations
 
 #### `list-folders`
@@ -474,7 +498,7 @@ Lists all folders in an account with full hierarchical paths.
 {}
 ```
 
-**Returns:** List of folder paths. Nested folders are shown as full paths (e.g., `Work/Clients/Omnia`). Duplicate folder names are disambiguated by their full path. Literal slashes in folder names are escaped as `\/` (e.g., `Spain\/Portugal 2023`).
+**Returns:** List of folders with IDs, paths, account names, and shared state. Nested folders are shown as full paths (e.g., `Work/Clients/Omnia`). Duplicate folder names are disambiguated by their full path. Literal slashes in folder names are escaped as `\/` (e.g., `Spain\/Portugal 2023`).
 
 ---
 
@@ -533,7 +557,17 @@ Lists all configured Notes accounts.
 {}
 ```
 
-**Returns:** List of account names (e.g., "iCloud", "Gmail", "Exchange").
+**Returns:** List of accounts with names, IDs, upgraded state, and default folder metadata.
+
+---
+
+#### `get-default-location`
+
+Returns the default account and folder Notes.app uses for newly created notes.
+
+**Parameters:** None
+
+**Returns:** Default account and folder metadata, including IDs and shared state.
 
 ---
 
@@ -631,7 +665,7 @@ Lists attachments in a note.
 | `title` | string | No | Note title |
 | `account` | string | No | Account containing the note |
 
-**Returns:** List of attachments with names and content types.
+**Returns:** List of attachments with IDs, names, content identifiers, URLs when available, created/modified dates, and shared state.
 
 ---
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -359,6 +359,27 @@ server.tool(
   }, "Error retrieving note details")
 );
 
+// --- show-note ---
+
+server.tool(
+  "show-note",
+  "Use when: the user wants to reveal a known note in Notes.app by id.\nReturns: confirmation that Notes.app accepted the show command.\nDo not use when: you only need note content (get-note-content) or metadata (get-note-by-id).\nNote: this opens or focuses the Notes UI.",
+  {
+    id: z.string().min(1, "Note ID is required"),
+    separately: z
+      .boolean()
+      .optional()
+      .describe("Open in a separate note window when supported by Notes.app"),
+  },
+  withErrorHandling(({ id, separately = false }) => {
+    const success = notesManager.showNoteById(id, separately);
+    if (!success) {
+      return errorResponse(`Failed to show note with ID "${id}"`);
+    }
+    return successResponse(`Shown note with ID "${id}" in Notes.app`, { id, separately });
+  }, "Error showing note")
+);
+
 // --- update-note ---
 
 server.tool(
@@ -610,6 +631,26 @@ server.tool(
   }, "Error listing notes")
 );
 
+// --- get-selected-notes ---
+
+server.tool(
+  "get-selected-notes",
+  "Use when: the user asks what note(s) are currently selected in Notes.app.\nReturns: selected note metadata with ids for follow-up operations.\nDo not use when: searching all notes (search-notes) or listing a folder (list-notes).\nNote: reads Notes.app UI selection; it may be empty if Notes is closed or no note is selected.",
+  {},
+  withErrorHandling(() => {
+    const notes = notesManager.getSelectedNotes();
+    if (notes.length === 0) {
+      return successResponse("No notes are currently selected in Notes.app", {
+        notes: [],
+        count: 0,
+      });
+    }
+
+    const noteList = notes.map((n) => `  - ${n.title} [id: ${n.id}]`).join("\n");
+    return successResponse(`Selected note(s):\n${noteList}`, { notes, count: notes.length });
+  }, "Error getting selected notes")
+);
+
 // =============================================================================
 // Folder Tools
 // =============================================================================
@@ -714,12 +755,33 @@ server.tool(
       return successResponse("No Notes accounts found", { accounts: [], count: 0 });
     }
 
-    const accountList = accounts.map((a) => `  - ${a.name}`).join("\n");
+    const accountList = accounts
+      .map((a) => {
+        const defaultFolder = a.defaultFolder ? ` (default folder: ${a.defaultFolder})` : "";
+        const upgraded = a.upgraded === undefined ? "" : `, upgraded: ${a.upgraded ? "yes" : "no"}`;
+        return `  - ${a.name}${defaultFolder}${upgraded}`;
+      })
+      .join("\n");
     return successResponse(`Found ${accounts.length} accounts:\n${accountList}`, {
       accounts,
       count: accounts.length,
     });
   }, "Error listing accounts")
+);
+
+// --- get-default-location ---
+
+server.tool(
+  "get-default-location",
+  "Use when: discovering where Notes.app will create new notes by default.\nReturns: default account and default folder metadata.\nDo not use when: you already have an explicit account/folder target.",
+  {},
+  withErrorHandling(() => {
+    const location = notesManager.getDefaultLocation();
+    const message =
+      `Default account: ${location.account.name} [id: ${location.account.id}]\n` +
+      `Default folder: ${location.folder.name} [id: ${location.folder.id}]`;
+    return successResponse(message, { ...location });
+  }, "Error getting default Notes location")
 );
 
 // =============================================================================

--- a/src/services/appleNotesManager.test.ts
+++ b/src/services/appleNotesManager.test.ts
@@ -1516,7 +1516,11 @@ describe("AppleNotesManager", () => {
     it("returns array of Folder objects with paths", () => {
       mockExecuteAppleScript.mockReturnValue({
         success: true,
-        output: "id1\tNotes\nid2\tArchive\nid3\tWork",
+        output: [
+          ["id1", "Notes", "", "false"].join(F),
+          ["id2", "Archive", "", "false"].join(F),
+          ["id3", "Work", "", "true"].join(F),
+        ].join(R),
       });
 
       const folders = manager.listFolders();
@@ -1526,12 +1530,18 @@ describe("AppleNotesManager", () => {
       expect(folders[1].name).toBe("Archive");
       expect(folders[2].name).toBe("Work");
       expect(folders[0].id).toBe("id1");
+      expect(folders[2].shared).toBe(true);
     });
 
     it("includes parent folder in path", () => {
       mockExecuteAppleScript.mockReturnValue({
         success: true,
-        output: "id1\tDev\nid2\tAccessibility\tid1\nid3\tWork\nid4\tClients\tid3",
+        output: [
+          ["id1", "Dev", "", "false"].join(F),
+          ["id2", "Accessibility", "id1", "false"].join(F),
+          ["id3", "Work", "", "false"].join(F),
+          ["id4", "Clients", "id3", "false"].join(F),
+        ].join(R),
       });
 
       const folders = manager.listFolders();
@@ -1546,7 +1556,13 @@ describe("AppleNotesManager", () => {
     it("disambiguates duplicate folder names using IDs", () => {
       mockExecuteAppleScript.mockReturnValue({
         success: true,
-        output: "id1\tFinance\nid2\tArchive\tid1\nid3\tTravel\nid4\tTrips\tid3\nid5\tArchive\tid4",
+        output: [
+          ["id1", "Finance", "", "false"].join(F),
+          ["id2", "Archive", "id1", "false"].join(F),
+          ["id3", "Travel", "", "false"].join(F),
+          ["id4", "Trips", "id3", "false"].join(F),
+          ["id5", "Archive", "id4", "false"].join(F),
+        ].join(R),
       });
 
       const folders = manager.listFolders();
@@ -1559,7 +1575,10 @@ describe("AppleNotesManager", () => {
     it("escapes slashes in folder names", () => {
       mockExecuteAppleScript.mockReturnValue({
         success: true,
-        output: "id1\tTravel\nid2\tSpain/Portugal 2023\tid1",
+        output: [
+          ["id1", "Travel", "", "false"].join(F),
+          ["id2", "Spain/Portugal 2023", "id1", "false"].join(F),
+        ].join(R),
       });
 
       const folders = manager.listFolders();
@@ -1572,7 +1591,7 @@ describe("AppleNotesManager", () => {
     it("includes account in Folder objects", () => {
       mockExecuteAppleScript.mockReturnValue({
         success: true,
-        output: "id1\tNotes",
+        output: ["id1", "Notes", "", "false"].join(F),
       });
 
       const folders = manager.listFolders("Gmail");
@@ -1848,7 +1867,11 @@ describe("AppleNotesManager", () => {
     it("returns array of Account objects", () => {
       mockExecuteAppleScript.mockReturnValue({
         success: true,
-        output: ["iCloud", "Gmail", "Exchange"].join(R),
+        output: [
+          ["acc1", "iCloud", "true", "folder1", "Notes"].join(F),
+          ["acc2", "Gmail", "false", "folder2", "Inbox"].join(F),
+          ["acc3", "Exchange", "false", "", ""].join(F),
+        ].join(R),
       });
 
       const accounts = manager.listAccounts();
@@ -1857,6 +1880,9 @@ describe("AppleNotesManager", () => {
       expect(accounts[0].name).toBe("iCloud");
       expect(accounts[1].name).toBe("Gmail");
       expect(accounts[2].name).toBe("Exchange");
+      expect(accounts[0].id).toBe("acc1");
+      expect(accounts[0].upgraded).toBe(true);
+      expect(accounts[0].defaultFolder).toBe("Notes");
     });
 
     it("throws on failure rather than returning empty (#19)", () => {
@@ -1867,6 +1893,108 @@ describe("AppleNotesManager", () => {
       });
 
       expect(() => manager.listAccounts()).toThrow(/Notes.app not available/);
+    });
+  });
+
+  describe("getDefaultLocation", () => {
+    it("returns default account and folder metadata", () => {
+      mockExecuteAppleScript.mockReturnValue({
+        success: true,
+        output: ["acc1", "iCloud", "true", "folder1", "Notes", "false"].join(F),
+      });
+
+      const location = manager.getDefaultLocation();
+
+      expect(location.account).toMatchObject({
+        id: "acc1",
+        name: "iCloud",
+        upgraded: true,
+        defaultFolderId: "folder1",
+        defaultFolder: "Notes",
+      });
+      expect(location.folder).toMatchObject({
+        id: "folder1",
+        name: "Notes",
+        account: "iCloud",
+        shared: false,
+      });
+    });
+
+    it("throws when default location output cannot be parsed", () => {
+      mockExecuteAppleScript.mockReturnValue({
+        success: true,
+        output: "bad-output",
+      });
+
+      expect(() => manager.getDefaultLocation()).toThrow(/parse default Notes location/);
+    });
+  });
+
+  describe("getSelectedNotes", () => {
+    it("returns selected note metadata", () => {
+      mockExecuteAppleScript.mockReturnValue({
+        success: true,
+        output: [
+          [
+            "x-coredata://ABC/ICNote/p1",
+            "Selected Note",
+            "2026-6-22-14-30-0",
+            "2026-6-22-14-35-0",
+            "false",
+            "false",
+            "Notes",
+            "iCloud",
+          ].join(F),
+        ].join(R),
+      });
+
+      const notes = manager.getSelectedNotes();
+
+      expect(notes).toHaveLength(1);
+      expect(notes[0]).toMatchObject({
+        id: "x-coredata://ABC/ICNote/p1",
+        title: "Selected Note",
+        shared: false,
+        passwordProtected: false,
+        folder: "Notes",
+        account: "iCloud",
+      });
+      expect(notes[0].created.getFullYear()).toBe(2026);
+    });
+
+    it("returns an empty array when no note is selected", () => {
+      mockExecuteAppleScript.mockReturnValue({
+        success: true,
+        output: "",
+      });
+
+      expect(manager.getSelectedNotes()).toEqual([]);
+    });
+  });
+
+  describe("showNoteById", () => {
+    it("shows a note by id", () => {
+      mockExecuteAppleScript.mockReturnValue({
+        success: true,
+        output: "",
+      });
+
+      expect(manager.showNoteById("x-coredata://ABC/ICNote/p1")).toBe(true);
+      expect(mockExecuteAppleScript).toHaveBeenCalledWith(
+        expect.stringContaining('show note id "x-coredata://ABC/ICNote/p1"')
+      );
+    });
+
+    it("can request a separate window", () => {
+      mockExecuteAppleScript.mockReturnValue({
+        success: true,
+        output: "",
+      });
+
+      manager.showNoteById("x-coredata://ABC/ICNote/p1", true);
+      expect(mockExecuteAppleScript).toHaveBeenCalledWith(
+        expect.stringContaining("separately true")
+      );
     });
   });
 
@@ -2093,16 +2221,48 @@ describe("AppleNotesManager", () => {
       const attachments = manager.listAttachmentsById("x-coredata://ABC/ICNote/p123");
 
       expect(attachments).toHaveLength(2);
-      expect(attachments[0]).toEqual({
+      expect(attachments[0]).toMatchObject({
         id: "x-coredata://ABC/ICAttachment/p1",
         name: "photo.jpg",
         contentType: "public.jpeg",
+        contentId: "public.jpeg",
       });
-      expect(attachments[1]).toEqual({
+      expect(attachments[1]).toMatchObject({
         id: "x-coredata://ABC/ICAttachment/p2",
         name: "document.pdf",
         contentType: "com.adobe.pdf",
+        contentId: "com.adobe.pdf",
       });
+    });
+
+    it("parses richer attachment metadata when present", () => {
+      mockExecuteAppleScript.mockReturnValueOnce({
+        success: true,
+        output: [
+          [
+            "x-coredata://ABC/ICAttachment/p1",
+            "site.webloc",
+            "cid:123",
+            "https://example.com",
+            "2026-6-22-10-0-0",
+            "2026-6-22-11-0-0",
+            "true",
+          ].join(F),
+        ].join(R),
+      });
+
+      const attachments = manager.listAttachmentsById("x-coredata://ABC/ICNote/p123");
+
+      expect(attachments[0]).toMatchObject({
+        id: "x-coredata://ABC/ICAttachment/p1",
+        name: "site.webloc",
+        contentType: "cid:123",
+        contentId: "cid:123",
+        url: "https://example.com",
+        shared: true,
+      });
+      expect(attachments[0].created?.getFullYear()).toBe(2026);
+      expect(attachments[0].modified?.getHours()).toBe(11);
     });
 
     it("returns empty array when note has no attachments", () => {
@@ -2146,10 +2306,11 @@ describe("AppleNotesManager", () => {
       const attachments = manager.listAttachments("My Note");
 
       expect(attachments).toHaveLength(1);
-      expect(attachments[0]).toEqual({
+      expect(attachments[0]).toMatchObject({
         id: "attach-id",
         name: "image.png",
         contentType: "public.png",
+        contentId: "public.png",
       });
     });
 

--- a/src/services/appleNotesManager.ts
+++ b/src/services/appleNotesManager.ts
@@ -19,6 +19,7 @@ import type {
   Note,
   Folder,
   Account,
+  DefaultLocation,
   HealthCheckResult,
   HealthCheckItem,
   NotesStats,
@@ -1408,25 +1409,23 @@ export class AppleNotesManager {
   listFolders(account?: string): Folder[] {
     const targetAccount = this.resolveAccount(account);
 
-    // Get each folder's ID, name, and parent ID in a single AppleScript call.
-    // Each line: "id\tname\tparentId" for subfolders, "id\tname" for top-level.
+    // Get each folder's ID, name, parent ID, and shared state in a single AppleScript call.
     // Using IDs enables correct tree building even with duplicate folder names.
     const listCommand = `
-      set folderList to ""
+      set folderList to {}
       set allFolders to every folder
       repeat with f in allFolders
         set fRef to contents of f
         set cRef to container of fRef
-        if folderList is not "" then
-          set folderList to folderList & linefeed
-        end if
+        set parentId to ""
         if class of cRef is folder then
-          set folderList to folderList & (id of fRef) & tab & (name of fRef) & tab & (id of cRef)
-        else
-          set folderList to folderList & (id of fRef) & tab & (name of fRef)
+          set parentId to id of cRef
         end if
+        set sharedFlag to shared of fRef as text
+        set end of folderList to (id of fRef) & ${AS_FIELD_SEP} & (name of fRef) & ${AS_FIELD_SEP} & parentId & ${AS_FIELD_SEP} & sharedFlag
       end repeat
-      return folderList
+      set AppleScript's text item delimiters to ${AS_RECORD_SEP}
+      return folderList as text
     `;
     const script = buildAccountScopedScript({ account: targetAccount }, listCommand);
     const result = executeAppleScript(script);
@@ -1439,13 +1438,14 @@ export class AppleNotesManager {
       return [];
     }
 
-    // Parse "id\tname[\tparentId]" lines
-    const entries = result.output.split("\n").map((line) => {
-      const parts = line.split("\t");
+    const recordSeparator = result.output.includes(RECORD_SEP) ? RECORD_SEP : "\n";
+    const entries = result.output.split(recordSeparator).map((line) => {
+      const parts = line.includes(FIELD_SEP) ? line.split(FIELD_SEP) : line.split("\t");
       return {
         id: (parts[0] || "").trim(),
         name: (parts[1] || "").trim(),
         parentId: (parts[2] || "").trim(),
+        shared: (parts[3] || "").trim().toLowerCase() === "true",
       };
     });
 
@@ -1470,6 +1470,7 @@ export class AppleNotesManager {
       id: entry.id,
       name: buildPath(entry),
       account: targetAccount,
+      shared: entry.shared,
     }));
   }
 
@@ -1711,10 +1712,22 @@ export class AppleNotesManager {
    * @returns Array of Account objects
    */
   listAccounts(): Account[] {
-    // Coerce the name list to text with a control-char record separator so an
-    // account name containing a comma can't split into phantom accounts (#18).
+    // Coerce account records to text with control-char delimiters so names
+    // containing commas or tabs can't split into phantom accounts (#18).
     const listCommand = `
-      set resultList to name of accounts
+      set resultList to {}
+      repeat with a in accounts
+        set aRef to contents of a
+        set defaultFolderId to ""
+        set defaultFolderName to ""
+        try
+          set fRef to default folder of aRef
+          set defaultFolderId to id of fRef
+          set defaultFolderName to name of fRef
+        end try
+        set upgradedFlag to upgraded of aRef as text
+        set end of resultList to (id of aRef) & ${AS_FIELD_SEP} & (name of aRef) & ${AS_FIELD_SEP} & upgradedFlag & ${AS_FIELD_SEP} & defaultFolderId & ${AS_FIELD_SEP} & defaultFolderName
+      end repeat
       set AppleScript's text item delimiters to ${AS_RECORD_SEP}
       return resultList as text
     `;
@@ -1725,12 +1738,143 @@ export class AppleNotesManager {
       throw new Error(`Failed to list accounts: ${result.error ?? "unknown error"}`);
     }
 
-    const names = result.output
+    return result.output
       .split(RECORD_SEP)
       .map((s) => s.trim())
-      .filter((s) => s.length > 0);
+      .filter((s) => s.length > 0)
+      .map((item) => {
+        const parts = item.split(FIELD_SEP);
+        if (parts.length === 1) {
+          return { name: parts[0].trim() };
+        }
+        return {
+          id: (parts[0] || "").trim(),
+          name: (parts[1] || "").trim(),
+          upgraded: (parts[2] || "").trim().toLowerCase() === "true",
+          defaultFolderId: (parts[3] || "").trim() || undefined,
+          defaultFolder: (parts[4] || "").trim() || undefined,
+        };
+      });
+  }
 
-    return names.map((name) => ({ name }));
+  /**
+   * Gets the default account and folder used by Notes.app for new notes.
+   *
+   * @returns Default account and folder metadata
+   */
+  getDefaultLocation(): DefaultLocation {
+    const command = `
+      set aRef to default account
+      set fRef to default folder of aRef
+      return (id of aRef) & ${AS_FIELD_SEP} & (name of aRef) & ${AS_FIELD_SEP} & (upgraded of aRef as text) & ${AS_FIELD_SEP} & (id of fRef) & ${AS_FIELD_SEP} & (name of fRef) & ${AS_FIELD_SEP} & (shared of fRef as text)
+    `;
+    const result = executeAppleScript(buildAppLevelScript(command));
+
+    if (!result.success) {
+      throw new Error(`Failed to get default Notes location: ${result.error ?? "unknown error"}`);
+    }
+
+    const parts = result.output.split(FIELD_SEP);
+    if (parts.length < 6) {
+      throw new Error(`Failed to parse default Notes location: ${result.output}`);
+    }
+
+    const accountName = (parts[1] || "").trim();
+    return {
+      account: {
+        id: (parts[0] || "").trim(),
+        name: accountName,
+        upgraded: (parts[2] || "").trim().toLowerCase() === "true",
+        defaultFolderId: (parts[3] || "").trim(),
+        defaultFolder: (parts[4] || "").trim(),
+      },
+      folder: {
+        id: (parts[3] || "").trim(),
+        name: (parts[4] || "").trim(),
+        account: accountName,
+        shared: (parts[5] || "").trim().toLowerCase() === "true",
+      },
+    };
+  }
+
+  /**
+   * Lists the currently selected Notes in the Notes.app UI.
+   *
+   * @returns Array of selected notes, or an empty array when nothing is selected
+   */
+  getSelectedNotes(): Note[] {
+    const command = `
+      set selectedNotes to selection
+      set noteList to {}
+      repeat with n in selectedNotes
+        set nRef to contents of n
+        set createdDate to creation date of nRef
+        set modifiedDate to modification date of nRef
+        set createdParts to ${asDatePartsExpr("createdDate")}
+        set modifiedParts to ${asDatePartsExpr("modifiedDate")}
+        set folderName to ""
+        set accountName to ""
+        try
+          set fRef to container of nRef
+          set folderName to name of fRef
+          set aRef to container of fRef
+          set accountName to name of aRef
+        end try
+        set end of noteList to (id of nRef) & ${AS_FIELD_SEP} & (name of nRef) & ${AS_FIELD_SEP} & createdParts & ${AS_FIELD_SEP} & modifiedParts & ${AS_FIELD_SEP} & (shared of nRef as text) & ${AS_FIELD_SEP} & (password protected of nRef as text) & ${AS_FIELD_SEP} & folderName & ${AS_FIELD_SEP} & accountName
+      end repeat
+      set AppleScript's text item delimiters to ${AS_RECORD_SEP}
+      return noteList as text
+    `;
+    const result = executeAppleScript(buildAppLevelScript(command));
+
+    if (!result.success) {
+      throw new Error(`Failed to get selected notes: ${result.error ?? "unknown error"}`);
+    }
+
+    if (!result.output.trim()) {
+      return [];
+    }
+
+    return result.output
+      .split(RECORD_SEP)
+      .filter((s) => s.trim())
+      .map((item) => {
+        const parts = item.split(FIELD_SEP);
+        return {
+          id: (parts[0] || "").trim(),
+          title: (parts[1] || "").trim(),
+          content: "",
+          tags: [],
+          created: parseAppleScriptDate((parts[2] || "").trim()),
+          modified: parseAppleScriptDate((parts[3] || "").trim()),
+          shared: (parts[4] || "").trim().toLowerCase() === "true",
+          passwordProtected: (parts[5] || "").trim().toLowerCase() === "true",
+          folder: (parts[6] || "").trim() || undefined,
+          account: (parts[7] || "").trim() || undefined,
+        };
+      });
+  }
+
+  /**
+   * Reveals a note in the Notes.app UI by ID.
+   *
+   * @param id - CoreData URL identifier for the note
+   * @param separately - Whether to open the note in a separate window
+   * @returns true if Notes.app accepted the show command
+   */
+  showNoteById(id: string, separately: boolean = false): boolean {
+    const safeId = sanitizeId(id);
+    const separatelyClause = separately ? " separately true" : "";
+    const result = executeAppleScript(
+      buildAppLevelScript(`show note id "${safeId}"${separatelyClause}`)
+    );
+
+    if (!result.success) {
+      console.error(`Failed to show note with ID "${id}":`, result.error);
+      return false;
+    }
+
+    return true;
   }
 
   // ===========================================================================
@@ -2024,8 +2168,17 @@ export class AppleNotesManager {
         repeat with a in attachments of theNote
           set attachId to id of a
           set attachName to name of a
-          set attachType to content identifier of a
-          set end of attachmentList to attachId & ${AS_FIELD_SEP} & attachName & ${AS_FIELD_SEP} & attachType
+          set attachContentId to content identifier of a
+          set attachUrl to ""
+          try
+            set attachUrl to URL of a as text
+          end try
+          set createdDate to creation date of a
+          set modifiedDate to modification date of a
+          set createdParts to ${asDatePartsExpr("createdDate")}
+          set modifiedParts to ${asDatePartsExpr("modifiedDate")}
+          set sharedFlag to shared of a as text
+          set end of attachmentList to attachId & ${AS_FIELD_SEP} & attachName & ${AS_FIELD_SEP} & attachContentId & ${AS_FIELD_SEP} & attachUrl & ${AS_FIELD_SEP} & createdParts & ${AS_FIELD_SEP} & modifiedParts & ${AS_FIELD_SEP} & sharedFlag
         end repeat
         set output to ""
         repeat with item in attachmentList
@@ -2054,6 +2207,11 @@ export class AppleNotesManager {
           id: parts[0].trim(),
           name: parts[1].trim(),
           contentType: parts[2].trim(),
+          contentId: parts[2].trim() || undefined,
+          url: parts[3]?.trim() || undefined,
+          created: parts[4] ? parseAppleScriptDate(parts[4].trim()) : undefined,
+          modified: parts[5] ? parseAppleScriptDate(parts[5].trim()) : undefined,
+          shared: parts[6] ? parts[6].trim().toLowerCase() === "true" : undefined,
         });
       }
     }
@@ -2076,13 +2234,22 @@ export class AppleNotesManager {
       tell application "Notes"
         tell account "${targetAccount}"
           set theNote to note "${safeTitle}"
-          set attachmentList to {}
-          repeat with a in attachments of theNote
-            set attachId to id of a
-            set attachName to name of a
-            set attachType to content identifier of a
-            set end of attachmentList to attachId & ${AS_FIELD_SEP} & attachName & ${AS_FIELD_SEP} & attachType
-          end repeat
+        set attachmentList to {}
+        repeat with a in attachments of theNote
+          set attachId to id of a
+          set attachName to name of a
+          set attachContentId to content identifier of a
+          set attachUrl to ""
+          try
+            set attachUrl to URL of a as text
+          end try
+          set createdDate to creation date of a
+          set modifiedDate to modification date of a
+          set createdParts to ${asDatePartsExpr("createdDate")}
+          set modifiedParts to ${asDatePartsExpr("modifiedDate")}
+          set sharedFlag to shared of a as text
+          set end of attachmentList to attachId & ${AS_FIELD_SEP} & attachName & ${AS_FIELD_SEP} & attachContentId & ${AS_FIELD_SEP} & attachUrl & ${AS_FIELD_SEP} & createdParts & ${AS_FIELD_SEP} & modifiedParts & ${AS_FIELD_SEP} & sharedFlag
+        end repeat
           set output to ""
           repeat with item in attachmentList
             set output to output & item & ${AS_RECORD_SEP}
@@ -2111,6 +2278,11 @@ export class AppleNotesManager {
           id: parts[0].trim(),
           name: parts[1].trim(),
           contentType: parts[2].trim(),
+          contentId: parts[2].trim() || undefined,
+          url: parts[3]?.trim() || undefined,
+          created: parts[4] ? parseAppleScriptDate(parts[4].trim()) : undefined,
+          modified: parts[5] ? parseAppleScriptDate(parts[5].trim()) : undefined,
+          shared: parts[6] ? parts[6].trim().toLowerCase() === "true" : undefined,
         });
       }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -156,6 +156,11 @@ export interface Folder {
    * Name of the account containing the folder.
    */
   account: string;
+
+  /**
+   * Whether the folder is shared with collaborators.
+   */
+  shared?: boolean;
 }
 
 /**
@@ -183,6 +188,37 @@ export interface Account {
    * This matches what appears in Notes.app's sidebar.
    */
   name: string;
+
+  /**
+   * Unique identifier for the account.
+   */
+  id?: string;
+
+  /**
+   * Whether the account has been upgraded to the modern Notes format.
+   */
+  upgraded?: boolean;
+
+  /**
+   * Name of the account's default folder.
+   */
+  defaultFolder?: string;
+
+  /**
+   * Unique identifier for the account's default folder.
+   */
+  defaultFolderId?: string;
+}
+
+/**
+ * The default Notes location for newly created notes.
+ */
+export interface DefaultLocation {
+  /** Default account used by Notes.app */
+  account: Account;
+
+  /** Default folder inside the default account */
+  folder: Folder;
 }
 
 // =============================================================================
@@ -492,6 +528,21 @@ export interface Attachment {
 
   /** UTI (Uniform Type Identifier) of the attachment, e.g., "public.jpeg" */
   contentType: string;
+
+  /** Content-id URL used in the note's HTML body. */
+  contentId?: string;
+
+  /** URL represented by URL/link attachments, when available. */
+  url?: string;
+
+  /** Timestamp when the attachment was created. */
+  created?: Date;
+
+  /** Timestamp when the attachment was last modified. */
+  modified?: Date;
+
+  /** Whether the attachment is shared with collaborators. */
+  shared?: boolean;
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- add `show-note`, `get-selected-notes`, and `get-default-location` tools
- enrich AppleScript-derived account, folder, and attachment metadata with IDs, default-folder data, shared state, URLs, and timestamps where available
- keep legacy parser compatibility for older unit fixtures and downstream mocks that still return plain account names or tab-delimited folders
- document the new tool surface in the README

## Verification

- `npm test` (390 tests)
- `npm run build`
- `npm run lint`
- `git diff --check`
- pre-push hook: `npm run typecheck` and `npm test`
