### PR TITLE
feat: reveal folders, accounts, and attachments in Notes.app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- **Reveal folders, accounts, and attachments in Notes.app.** Three new tools extend the existing `show-note` to the rest of the objects the Notes scripting dictionary's `show` command accepts: `show-folder` (by folder id), `show-account` (by account id), and `show-attachment` (by note id + attachment id, since attachments are note-scoped). Each takes an optional `separately` flag, mirroring `show-note`. This closes the "show or reveal a note, folder, account, or attachment" surface gap from the roadmap; everything is additive AppleScript, and no existing tool changed.
 
 ## [2.3.0] - 2026-06-23
 ### Added

--- a/README.md
+++ b/README.md
@@ -551,6 +551,19 @@ Deletes a folder.
 
 ---
 
+#### `show-folder`
+
+Reveals a folder in Notes.app using its unique CoreData identifier.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | string | Yes | The folder's CoreData identifier (from `list-folders`) |
+| `separately` | boolean | No | Open in a separate window when supported by Notes.app |
+
+**Returns:** Confirmation that Notes.app accepted the show command.
+
+---
+
 ### Account Operations
 
 #### `list-accounts`
@@ -575,6 +588,19 @@ Returns the default account and folder Notes.app uses for newly created notes.
 **Parameters:** None
 
 **Returns:** Default account and folder metadata, including IDs and shared state.
+
+---
+
+#### `show-account`
+
+Reveals an account in Notes.app using its unique CoreData identifier.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | string | Yes | The account's CoreData identifier (from `list-accounts`) |
+| `separately` | boolean | No | Open in a separate window when supported by Notes.app |
+
+**Returns:** Confirmation that Notes.app accepted the show command.
 
 ---
 
@@ -700,6 +726,20 @@ Returns a note attachment's bytes as base64, without writing to disk (the read c
 | `attachmentId` | string | Yes | Attachment ID (from `list-attachments`) |
 
 **Returns:** The attachment name, content type, byte count, and base64 payload in `structuredContent.base64`.
+
+---
+
+#### `show-attachment`
+
+Reveals one note attachment in Notes.app. Attachments are elements of a note, so this takes both the note id and the attachment id (the same pair used by `save-attachment` / `fetch-attachment`).
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `noteId` | string | Yes | CoreData note ID (from `search-notes`/`list-notes`) |
+| `attachmentId` | string | Yes | Attachment ID (from `list-attachments`) |
+| `separately` | boolean | No | Open in a separate window when supported by Notes.app |
+
+**Returns:** Confirmation that Notes.app revealed the attachment.
 
 ---
 

--- a/codex/skills/apple-notes/SKILL.md
+++ b/codex/skills/apple-notes/SKILL.md
@@ -46,12 +46,14 @@ Use this skill when the user:
 | `list-folders` | List all folders in an account |
 | `create-folder` | Create a new folder |
 | `delete-folder` | Delete an empty folder |
+| `show-folder` | Reveal a folder in the Notes.app UI by ID |
 
 ### Account Operations
 
 | Tool | Purpose |
 |------|---------|
 | `list-accounts` | List configured accounts (iCloud, Gmail, etc.) |
+| `show-account` | Reveal an account in the Notes.app UI by ID |
 
 ### Attachments, Checklists, Collaboration, and Diagnostics
 
@@ -60,6 +62,7 @@ Use this skill when the user:
 | `list-attachments` | List attachments in a note |
 | `save-attachment` | Save an attachment to disk |
 | `fetch-attachment` | Fetch attachment bytes as base64 |
+| `show-attachment` | Reveal an attachment in the Notes.app UI |
 | `get-checklist-state` | Read checked/unchecked state for existing checklists |
 | `list-shared-notes` | List notes shared with collaborators |
 | `get-sync-status` | Check whether iCloud sync is active |

--- a/skills/apple-notes/SKILL.md
+++ b/skills/apple-notes/SKILL.md
@@ -46,12 +46,14 @@ Use this skill when the user:
 | `list-folders` | List all folders in an account |
 | `create-folder` | Create a new folder |
 | `delete-folder` | Delete an empty folder |
+| `show-folder` | Reveal a folder in the Notes.app UI by ID |
 
 ### Account Operations
 
 | Tool | Purpose |
 |------|---------|
 | `list-accounts` | List configured accounts (iCloud, Gmail, etc.) |
+| `show-account` | Reveal an account in the Notes.app UI by ID |
 
 ### Attachments, Checklists, Collaboration, and Diagnostics
 
@@ -60,6 +62,7 @@ Use this skill when the user:
 | `list-attachments` | List attachments in a note |
 | `save-attachment` | Save an attachment to disk |
 | `fetch-attachment` | Fetch attachment bytes as base64 |
+| `show-attachment` | Reveal an attachment in the Notes.app UI |
 | `get-checklist-state` | Read checked/unchecked state for existing checklists |
 | `list-shared-notes` | List notes shared with collaborators |
 | `get-sync-status` | Check whether iCloud sync is active |

--- a/src/index.ts
+++ b/src/index.ts
@@ -441,6 +441,62 @@ server.registerTool(
   }, "Error showing note")
 );
 
+// --- show-folder ---
+
+server.registerTool(
+  "show-folder",
+  {
+    description:
+      "Use when: the user wants to reveal a known folder in Notes.app by id.\nReturns: confirmation that Notes.app accepted the show command.\nDo not use when: you only need the folder list (list-folders).\nNote: this opens or focuses the Notes UI. Get the id from list-folders.",
+    inputSchema: {
+      id: z.string().min(1, "Folder ID is required"),
+      separately: z
+        .boolean()
+        .optional()
+        .describe("Open in a separate window when supported by Notes.app"),
+    },
+    outputSchema: {
+      id: z.string().optional(),
+      separately: z.boolean().optional(),
+    },
+  },
+  withErrorHandling(({ id, separately = false }) => {
+    const success = notesManager.showFolderById(id, separately);
+    if (!success) {
+      return errorResponse(`Failed to show folder with ID "${id}"`);
+    }
+    return successResponse(`Shown folder with ID "${id}" in Notes.app`, { id, separately });
+  }, "Error showing folder")
+);
+
+// --- show-account ---
+
+server.registerTool(
+  "show-account",
+  {
+    description:
+      "Use when: the user wants to reveal a known account in Notes.app by id.\nReturns: confirmation that Notes.app accepted the show command.\nDo not use when: you only need the account list (list-accounts).\nNote: this opens or focuses the Notes UI. Get the id from list-accounts.",
+    inputSchema: {
+      id: z.string().min(1, "Account ID is required"),
+      separately: z
+        .boolean()
+        .optional()
+        .describe("Open in a separate window when supported by Notes.app"),
+    },
+    outputSchema: {
+      id: z.string().optional(),
+      separately: z.boolean().optional(),
+    },
+  },
+  withErrorHandling(({ id, separately = false }) => {
+    const success = notesManager.showAccountById(id, separately);
+    if (!success) {
+      return errorResponse(`Failed to show account with ID "${id}"`);
+    }
+    return successResponse(`Shown account with ID "${id}" in Notes.app`, { id, separately });
+  }, "Error showing account")
+);
+
 // --- update-note ---
 
 server.registerTool(
@@ -1404,6 +1460,46 @@ server.registerTool(
       { name: r.name, contentType: r.contentType, bytes: r.bytes, base64: r.base64 }
     );
   }, "Error fetching attachment")
+);
+
+// --- show-attachment ---
+
+server.registerTool(
+  "show-attachment",
+  {
+    description:
+      "Use when: the user wants to reveal one note attachment in Notes.app.\nReturns: confirmation that Notes.app revealed the attachment.\nDo not use when: you want the bytes (fetch-attachment) or a file on disk (save-attachment).\nNote: this opens or focuses the Notes UI. Get the ids from list-attachments first.",
+    inputSchema: {
+      noteId: z
+        .string()
+        .min(1, "noteId is required")
+        .describe("CoreData note id (from search/list)"),
+      attachmentId: z
+        .string()
+        .min(1, "attachmentId is required")
+        .describe("Attachment id (from list-attachments)"),
+      separately: z
+        .boolean()
+        .optional()
+        .describe("Open in a separate window when supported by Notes.app"),
+    },
+    outputSchema: {
+      noteId: z.string().optional(),
+      attachmentId: z.string().optional(),
+      separately: z.boolean().optional(),
+    },
+  },
+  withErrorHandling(({ noteId, attachmentId, separately = false }) => {
+    const success = notesManager.showAttachmentById(noteId, attachmentId, separately);
+    if (!success) {
+      return errorResponse(`Failed to show attachment "${attachmentId}" on note "${noteId}"`);
+    }
+    return successResponse(`Shown attachment "${attachmentId}" in Notes.app`, {
+      noteId,
+      attachmentId,
+      separately,
+    });
+  }, "Error showing attachment")
 );
 
 // --- export-notes-json ---

--- a/src/services/appleNotesManager.test.ts
+++ b/src/services/appleNotesManager.test.ts
@@ -2087,6 +2087,106 @@ describe("AppleNotesManager", () => {
     });
   });
 
+  describe("showFolderById", () => {
+    it("shows a folder by id", () => {
+      mockExecuteAppleScript.mockReturnValue({ success: true, output: "" });
+
+      expect(manager.showFolderById("x-coredata://ABC/ICFolder/p1")).toBe(true);
+      expect(mockExecuteAppleScript).toHaveBeenCalledWith(
+        expect.stringContaining('show folder id "x-coredata://ABC/ICFolder/p1"')
+      );
+    });
+
+    it("can request a separate window", () => {
+      mockExecuteAppleScript.mockReturnValue({ success: true, output: "" });
+
+      manager.showFolderById("x-coredata://ABC/ICFolder/p1", true);
+      expect(mockExecuteAppleScript).toHaveBeenCalledWith(
+        expect.stringContaining("separately true")
+      );
+    });
+
+    it("returns false when Notes.app rejects the show command", () => {
+      mockExecuteAppleScript.mockReturnValue({
+        success: false,
+        output: "",
+        error: "no such folder",
+      });
+
+      expect(manager.showFolderById("x-coredata://ABC/ICFolder/p1")).toBe(false);
+    });
+  });
+
+  describe("showAccountById", () => {
+    it("shows an account by id", () => {
+      mockExecuteAppleScript.mockReturnValue({ success: true, output: "" });
+
+      expect(manager.showAccountById("x-coredata://ABC/ICAccount/p1")).toBe(true);
+      expect(mockExecuteAppleScript).toHaveBeenCalledWith(
+        expect.stringContaining('show account id "x-coredata://ABC/ICAccount/p1"')
+      );
+    });
+
+    it("can request a separate window", () => {
+      mockExecuteAppleScript.mockReturnValue({ success: true, output: "" });
+
+      manager.showAccountById("x-coredata://ABC/ICAccount/p1", true);
+      expect(mockExecuteAppleScript).toHaveBeenCalledWith(
+        expect.stringContaining("separately true")
+      );
+    });
+
+    it("returns false when Notes.app rejects the show command", () => {
+      mockExecuteAppleScript.mockReturnValue({
+        success: false,
+        output: "",
+        error: "no such account",
+      });
+
+      expect(manager.showAccountById("x-coredata://ABC/ICAccount/p1")).toBe(false);
+    });
+  });
+
+  describe("showAttachmentById", () => {
+    it("resolves the attachment within its note and shows it", () => {
+      mockExecuteAppleScript.mockReturnValue({ success: true, output: "OK" });
+
+      expect(manager.showAttachmentById("x-coredata://ABC/ICNote/p1", "att-123")).toBe(true);
+      const script = mockExecuteAppleScript.mock.calls[0][0] as string;
+      expect(script).toContain('set theNote to note id "x-coredata://ABC/ICNote/p1"');
+      expect(script).toContain('is "att-123"');
+      expect(script).toContain("show theAttachment");
+    });
+
+    it("can request a separate window", () => {
+      mockExecuteAppleScript.mockReturnValue({ success: true, output: "OK" });
+
+      manager.showAttachmentById("x-coredata://ABC/ICNote/p1", "att-123", true);
+      expect(mockExecuteAppleScript).toHaveBeenCalledWith(
+        expect.stringContaining("separately true")
+      );
+    });
+
+    it("returns false when the attachment is not found on the note", () => {
+      mockExecuteAppleScript.mockReturnValue({
+        success: true,
+        output: `ERR${F}attachment not found`,
+      });
+
+      expect(manager.showAttachmentById("x-coredata://ABC/ICNote/p1", "missing")).toBe(false);
+    });
+
+    it("returns false when Notes.app rejects the show command", () => {
+      mockExecuteAppleScript.mockReturnValue({
+        success: false,
+        output: "",
+        error: "no such note",
+      });
+
+      expect(manager.showAttachmentById("x-coredata://ABC/ICNote/p1", "att-123")).toBe(false);
+    });
+  });
+
   // ---------------------------------------------------------------------------
   // Health Check
   // ---------------------------------------------------------------------------

--- a/src/services/appleNotesManager.ts
+++ b/src/services/appleNotesManager.ts
@@ -1877,6 +1877,107 @@ export class AppleNotesManager {
     return true;
   }
 
+  /**
+   * Reveals a folder in the Notes.app UI by its id.
+   *
+   * Wraps the Notes `show` command, which the scripting dictionary exposes for
+   * folders as well as notes. This opens or focuses the Notes UI on the folder.
+   *
+   * @param id - CoreData identifier for the folder (from list-folders)
+   * @param separately - Open in a separate window when supported by Notes.app
+   * @returns true if Notes.app accepted the show command, false otherwise
+   */
+  showFolderById(id: string, separately: boolean = false): boolean {
+    const safeId = sanitizeId(id);
+    const separatelyClause = separately ? " separately true" : "";
+    const result = executeAppleScript(
+      buildAppLevelScript(`show folder id "${safeId}"${separatelyClause}`)
+    );
+
+    if (!result.success) {
+      console.error(`Failed to show folder with ID "${id}":`, result.error);
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Reveals an account in the Notes.app UI by its id.
+   *
+   * Wraps the Notes `show` command, which the scripting dictionary exposes for
+   * accounts as well as notes. This opens or focuses the Notes UI on the account.
+   *
+   * @param id - CoreData identifier for the account (from list-accounts)
+   * @param separately - Open in a separate window when supported by Notes.app
+   * @returns true if Notes.app accepted the show command, false otherwise
+   */
+  showAccountById(id: string, separately: boolean = false): boolean {
+    const safeId = sanitizeId(id);
+    const separatelyClause = separately ? " separately true" : "";
+    const result = executeAppleScript(
+      buildAppLevelScript(`show account id "${safeId}"${separatelyClause}`)
+    );
+
+    if (!result.success) {
+      console.error(`Failed to show account with ID "${id}":`, result.error);
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Reveals an attachment in the Notes.app UI.
+   *
+   * Attachments are elements of a note, so they cannot be referenced at the
+   * application level by id alone. This resolves the attachment within its note
+   * (the same lookup used by save-attachment) and then runs the Notes `show`
+   * command on it, opening or focusing the Notes UI on the attachment.
+   *
+   * @param noteId - CoreData identifier for the note containing the attachment
+   * @param attachmentId - id of the attachment (from list-attachments)
+   * @param separately - Open in a separate window when supported by Notes.app
+   * @returns true if Notes.app revealed the attachment, false otherwise
+   */
+  showAttachmentById(noteId: string, attachmentId: string, separately: boolean = false): boolean {
+    const safeNoteId = sanitizeId(noteId);
+    const safeAttId = escapePlainStringForAppleScript(attachmentId);
+    const separatelyClause = separately ? " separately true" : "";
+
+    const script = `
+      tell application "Notes"
+        set theNote to note id "${safeNoteId}"
+        set theAttachment to missing value
+        repeat with a in attachments of theNote
+          if (id of a as text) is "${safeAttId}" then
+            set theAttachment to a
+            exit repeat
+          end if
+        end repeat
+        if theAttachment is missing value then
+          return "ERR${AS_FIELD_SEP}attachment not found"
+        end if
+        show theAttachment${separatelyClause}
+        return "OK"
+      end tell
+    `;
+
+    const result = executeAppleScript(script);
+    if (!result.success) {
+      console.error(
+        `Failed to show attachment "${attachmentId}" on note "${noteId}":`,
+        result.error
+      );
+      return false;
+    }
+    if ((result.output ?? "").trim().startsWith("ERR")) {
+      console.error(`Attachment "${attachmentId}" not found on note "${noteId}"`);
+      return false;
+    }
+    return true;
+  }
+
   // ===========================================================================
   // Health Check
   // ===========================================================================


### PR DESCRIPTION
The Notes scripting dictionary's `show` command works on a note, folder, account, or attachment, but the server only wrapped it for notes (`show-note`). This adds the three that were missing and closes the "show or reveal a note, folder, account, or attachment" item under AppleScript Surface Gaps in TODO.md.

### What's new

`show-folder` reveals a folder by id, and `show-account` reveals an account by id. The ids come from `list-folders` and `list-accounts`.

`show-attachment` is the more involved one. Attachments are elements of a note, so AppleScript can't reach them by id at the application level the way it can a note or folder. It resolves the attachment inside its note first, using the same lookup `save-attachment` already does, then runs `show` on the matched reference. The inputs are `noteId` and `attachmentId`, matching `save-attachment` and `fetch-attachment`.

Each tool mirrors `show-note`: an optional `separately` flag, AppleScript built through the existing `buildAppLevelScript`, `sanitizeId`, and escape helpers, and a `false` return on failure instead of throwing.

### Backwards compatibility

Everything here is additive. No existing tool, signature, description, or handler behavior changed, so this stays within the "prefer adding new tools" and "all new parameters optional" guidance in the roadmap.

### Tests and docs

There are 10 new tests in `appleNotesManager.test.ts` covering the success path, the `separately` flag, the failure path, and the attachment-not-found case, all against mocked `runAppleScript`. README, CHANGELOG, and both skill manifests (`skills/apple-notes/SKILL.md` and `codex/skills/apple-notes/SKILL.md`) are updated.

One thing I left alone on purpose: the skill manifests were already missing `show-note`, `get-selected-notes`, and `get-default-location` from an earlier release, so those tables had drifted before this change. I added only the three new tools to keep the diff focused. The older gaps are worth a separate cleanup.

`npm run lint`, `npm run typecheck`, `npm test` (408 passing), `npm run build`, and `npm run format:check` all pass.