### PR TITLE
test: lock Notes-normalized HTML to Markdown, and warn about attachments on update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- **Regression fixtures for Notes-normalized HTML to Markdown.** `src/services/__fixtures__/notesNormalizedHtml.ts` captures representative Apple Notes-normalized bodies (div-wrapped paragraphs, `<div><br></div>` spacer rows, headings, native lists, inline emphasis, `<tt>` code spans) alongside the Markdown `getNoteMarkdown` currently produces, and `notesHtmlMarkdown.test.ts` locks it in. These characterization tests pin two existing quirks so future changes are deliberate: a `<div><br></div>` spacer leaves a stray two-space line (the Markdown-side fingerprint of the whitespace-accumulation behavior), and `<tt>` is dropped so code styling does not round-trip.
+
+### Changed
+- **`update-note` now warns about attachments in its tool description.** A full-body replace can drop embedded files, images, scans, PDFs, or audio, so the description (and the README `update-note` section) now tells callers to run `list-attachments` first when a note may hold them. The skill already carried this guidance; this brings the MCP-visible tool description in line. Description and docs only — no behavior change.
 
 ## [2.3.0] - 2026-06-23
 ### Added

--- a/README.md
+++ b/README.md
@@ -376,6 +376,8 @@ Updates an existing note's content and/or title.
 
 **Note:** `newContent` **replaces the entire note body** — it is not appended. To preserve existing content, read it first (e.g. with `get-note-content`) and include it in `newContent`.
 
+**Attachments:** A full-body replace can drop embedded files, images, scans, PDFs, or audio. When a note may hold attachments, run [`list-attachments`](#list-attachments) first, and either save them with `save-attachment` or build a new note rather than overwriting. See the skill's [Attachment-Safe Updates](skills/apple-notes/SKILL.md#attachment-safe-updates) guidance.
+
 ---
 
 #### `delete-note`

--- a/src/index.ts
+++ b/src/index.ts
@@ -447,7 +447,7 @@ server.registerTool(
   "update-note",
   {
     description:
-      "Use when: changing the title and/or replacing the body of an existing note, by id (preferred) or title.\nReturns: confirmation; warns when the note is shared.\nDo not use when: creating a new note (create-note).\nSafety: newContent REPLACES the entire body — it does not append. Read the note first if you need to preserve existing text. Edits to shared notes are immediately visible to all collaborators.",
+      "Use when: changing the title and/or replacing the body of an existing note, by id (preferred) or title.\nReturns: confirmation; warns when the note is shared.\nDo not use when: creating a new note (create-note).\nSafety: newContent REPLACES the entire body — it does not append. Read the note first if you need to preserve existing text, and run list-attachments first when the note may hold files, images, scans, PDFs, or audio, since a full-body replace can drop embedded attachments. Edits to shared notes are immediately visible to all collaborators.",
     inputSchema: {
       id: z.string().optional().describe("Note ID (preferred - more reliable than title)"),
       title: z.string().optional().describe("Current note title (use id instead when available)"),

--- a/src/services/__fixtures__/notesNormalizedHtml.ts
+++ b/src/services/__fixtures__/notesNormalizedHtml.ts
@@ -1,0 +1,65 @@
+/**
+ * Golden fixtures: representative Apple Notes-normalized HTML and the Markdown
+ * the server currently produces from it via `getNoteMarkdown` / Turndown.
+ *
+ * Apple Notes rewrites HTML on save: it wraps blocks in `<div>` instead of `<p>`,
+ * inserts `<div><br></div>` spacer rows between sections, and emits its own tag
+ * soup when a note is read back. These fixtures capture that normalized shape so
+ * the Markdown conversion is regression-locked. If a change to the `notesDivs`
+ * Turndown rule (or a dependency bump) alters the output, the snapshot test that
+ * consumes these fixtures will fail loudly instead of silently shifting behavior.
+ *
+ * The `expectedMarkdown` values are the conversion's *current* output, including
+ * two known quirks worth being explicit about:
+ *   - A `<div><br></div>` spacer becomes a stray `  ` (two-space) line, the
+ *     Markdown-side fingerprint of the whitespace-accumulation behavior the
+ *     project's CLAUDE.md documents.
+ *   - `<tt>` is dropped: its text survives but the code styling does not
+ *     round-trip to Markdown.
+ *
+ * These are characterization tests. They document what the code does today; they
+ * are not an assertion that the current output is ideal.
+ */
+export interface NotesHtmlFixture {
+  /** Short identifier, also used as the test case name. */
+  name: string;
+  /** What normalized shape this case represents. */
+  description: string;
+  /** Notes-normalized HTML, as returned by AppleScript `body of note`. */
+  html: string;
+  /** Markdown currently produced by getNoteMarkdown for the HTML above. */
+  expectedMarkdown: string;
+}
+
+export const NOTES_NORMALIZED_HTML_FIXTURES: NotesHtmlFixture[] = [
+  {
+    name: "headingAndParagraphs",
+    description: "An <h1> title and two <div> paragraphs separated by a spacer row",
+    html: "<div><h1>Meeting Notes</h1></div><div>First line.</div><div><br></div><div>Second line.</div>",
+    expectedMarkdown: "# Meeting Notes\n\nFirst line.\n  \n\nSecond line.",
+  },
+  {
+    name: "bulletList",
+    description: "An <h2> section heading followed by a native <ul> bullet list",
+    html: "<div><h2>Tasks</h2></div><ul><li>Buy milk</li><li>Walk dog</li></ul>",
+    expectedMarkdown: "## Tasks\n\n-   Buy milk\n-   Walk dog",
+  },
+  {
+    name: "inlineEmphasis",
+    description: "Inline <b> and <i> emphasis inside a paragraph div",
+    html: "<div>This is <b>bold</b> and <i>italic</i> text.</div>",
+    expectedMarkdown: "This is **bold** and _italic_ text.",
+  },
+  {
+    name: "codeSpan",
+    description: "A <tt> code span — the tag is dropped, only its text survives",
+    html: "<div>Run <tt>npm install</tt> first.</div>",
+    expectedMarkdown: "Run npm install first.",
+  },
+  {
+    name: "spacerRuns",
+    description: "Consecutive <div><br></div> spacer rows between two paragraphs",
+    html: "<div>A</div><div><br></div><div><br></div><div>B</div>",
+    expectedMarkdown: "A\n  \n\n  \n\nB",
+  },
+];

--- a/src/services/notesHtmlMarkdown.test.ts
+++ b/src/services/notesHtmlMarkdown.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NOTES_NORMALIZED_HTML_FIXTURES } from "@/services/__fixtures__/notesNormalizedHtml.js";
+
+// Mock the same seams the main manager test does: AppleScript execution and the
+// SQLite-backed checklist reader (no Full Disk Access in unit tests).
+vi.mock("@/utils/applescript.js", () => ({
+  executeAppleScript: vi.fn(),
+}));
+vi.mock("@/utils/checklistParser.js", () => ({
+  getChecklistItems: vi.fn().mockReturnValue({ items: null }),
+}));
+
+import { executeAppleScript } from "@/utils/applescript.js";
+import { AppleNotesManager } from "@/services/appleNotesManager.js";
+
+const mockExecuteAppleScript = vi.mocked(executeAppleScript);
+
+const NOTE_ID = "x-coredata://ABC/ICNote/p1";
+
+/**
+ * Regression coverage for Notes-normalized HTML -> Markdown conversion.
+ *
+ * The fixtures encode the HTML shape Apple Notes returns and the Markdown the
+ * server currently emits. Routing through getNoteMarkdownById exercises the real
+ * Turndown pipeline (including the notesDivs rule) with AppleScript mocked to
+ * return the fixture body.
+ */
+describe("Notes-normalized HTML to Markdown", () => {
+  let manager: AppleNotesManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    manager = new AppleNotesManager();
+  });
+
+  for (const fixture of NOTES_NORMALIZED_HTML_FIXTURES) {
+    it(`converts ${fixture.name} (${fixture.description})`, () => {
+      mockExecuteAppleScript.mockReturnValue({ success: true, output: fixture.html });
+
+      const markdown = manager.getNoteMarkdownById(NOTE_ID);
+
+      expect(markdown).toBe(fixture.expectedMarkdown);
+    });
+  }
+
+  it("documents that a <div><br></div> spacer leaves a two-space line", () => {
+    mockExecuteAppleScript.mockReturnValue({
+      success: true,
+      output: "<div>A</div><div><br></div><div>B</div>",
+    });
+
+    const markdown = manager.getNoteMarkdownById(NOTE_ID);
+
+    // The spacer survives as a stray "  " line — the Markdown-side fingerprint of
+    // the whitespace-accumulation behavior CLAUDE.md warns about.
+    expect(markdown).toBe("A\n  \n\nB");
+  });
+
+  it("documents that <tt> is dropped, keeping only its text", () => {
+    mockExecuteAppleScript.mockReturnValue({
+      success: true,
+      output: "<div>Run <tt>npm install</tt> first.</div>",
+    });
+
+    const markdown = manager.getNoteMarkdownById(NOTE_ID);
+
+    expect(markdown).toBe("Run npm install first.");
+    expect(markdown).not.toContain("`");
+  });
+});


### PR DESCRIPTION
The "Formatting and Note-Body Safety" item in TODO.md was mostly handled already by the skill's formatting guidance (#42). Two pieces were still open, and this covers both.

### Regression fixtures for normalized HTML

Apple Notes rewrites HTML when it saves a note. It wraps blocks in `<div>` instead of `<p>`, drops in `<div><br></div>` spacer rows, and hands back its own tag soup when you read the body. Nothing in the suite pinned what `getNoteMarkdown` does with that shape, so a change to the Turndown rules could quietly shift the output.

`src/services/__fixtures__/notesNormalizedHtml.ts` pairs representative normalized bodies with the Markdown the server produces today, and `notesHtmlMarkdown.test.ts` runs them through the real conversion path. These are characterization tests, so they lock current behavior rather than claim it's ideal. Two quirks are now written down where a reviewer will see them:

- A `<div><br></div>` spacer becomes a stray two-space line. That's the Markdown side of the whitespace-accumulation behavior CLAUDE.md already warns about.
- `<tt>` is dropped. The text survives, the code styling doesn't round-trip, even though the skill suggests `<tt>` for code in notes.

### Attachment warning on update-note

The skill's "Attachment-Safe Updates" section tells agents to run `list-attachments` before rewriting a note that might hold files, but the `update-note` tool description itself said nothing about it. An agent reading only the tool metadata wouldn't know a full-body replace can drop embedded images, scans, PDFs, or audio. The description and the README `update-note` section now say so. The skill was already correct; this just brings the MCP-visible text in line.

### Scope

Docs, tests, and one description string. No tool behavior, signature, or parameter changed. 7 new tests, and `npm run lint`, `npm run typecheck`, `npm test`, `npm run build`, and `npm run format:check` all pass.