### PR TITLE
feat: add get-note-plaintext tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- **`get-note-plaintext` tool.** Reads a note's body as plain text by id or title via the scripting dictionary's read-only `note.plaintext` property, which Notes derives from the body with markup removed. This is more faithful than reading the HTML body and stripping it, and it skips the conversion entirely. `get-note-content` (HTML) and `get-note-markdown` (Markdown with checklist state) are unchanged; this adds a third read shape. Additive — no existing tool changed.
 
 ## [2.3.0] - 2026-06-23
 ### Added

--- a/README.md
+++ b/README.md
@@ -267,6 +267,22 @@ see [docs/APPLESCRIPT-LIMITATIONS.md](../docs/APPLESCRIPT-LIMITATIONS.md#tags--h
 
 ---
 
+#### `get-note-plaintext`
+
+Retrieves a note's body as plain text, with no HTML markup.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | string | No | Note ID (preferred - more reliable than title) |
+| `title` | string | No | Note title (use `id` instead when available) |
+| `account` | string | No | Account containing the note (defaults to iCloud, ignored if `id` is provided) |
+
+**Note:** Either `id` or `title` must be provided. This reads the note's native `plaintext` property, so it skips the HTML-to-text conversion that `get-note-content` plus a Markdown pass would do. Use `get-note-content` when you need the HTML, or `get-note-markdown` when you want Markdown with checklist state.
+
+**Returns:** The plain-text content of the note in `structuredContent.plaintext`, or error if not found.
+
+---
+
 #### `get-note-details`
 
 Retrieves metadata about a note (without full content).

--- a/codex/skills/apple-notes/SKILL.md
+++ b/codex/skills/apple-notes/SKILL.md
@@ -28,6 +28,7 @@ Use this skill when the user:
 | `create-note` | Create a new note with title and content |
 | `search-notes` | Find notes by title or content |
 | `get-note-content` | Read the full content of a note |
+| `get-note-plaintext` | Read a note's body as plain text (no HTML) |
 | `get-note-markdown` | Read note content as Markdown |
 | `get-note-by-id` | Get note metadata by ID |
 | `get-note-details` | Get metadata (created, modified, account) |

--- a/skills/apple-notes/SKILL.md
+++ b/skills/apple-notes/SKILL.md
@@ -28,6 +28,7 @@ Use this skill when the user:
 | `create-note` | Create a new note with title and content |
 | `search-notes` | Find notes by title or content |
 | `get-note-content` | Read the full content of a note |
+| `get-note-plaintext` | Read a note's body as plain text (no HTML) |
 | `get-note-markdown` | Read note content as Markdown |
 | `get-note-by-id` | Get note metadata by ID |
 | `get-note-details` | Get metadata (created, modified, account) |

--- a/src/index.ts
+++ b/src/index.ts
@@ -333,6 +333,69 @@ server.registerTool(
   }, "Error retrieving note content")
 );
 
+// --- get-note-plaintext ---
+
+server.registerTool(
+  "get-note-plaintext",
+  {
+    description:
+      "Use when: reading one note's body as plain text with no HTML, by id (preferred) or title.\nReturns: the note's plaintext exactly as Notes exposes it.\nDo not use when: you need the HTML body (get-note-content) or Markdown with checklist state (get-note-markdown).\nNote: this reads the note's native plaintext property, so it skips the HTML-to-text conversion; password-protected notes must be unlocked in Notes.app first.",
+    inputSchema: {
+      id: z.string().optional().describe("Note ID (preferred - more reliable than title)"),
+      title: z.string().optional().describe("Note title (use id instead when available)"),
+      account: z
+        .string()
+        .optional()
+        .describe("Account name (defaults to iCloud, ignored if id is provided)"),
+    },
+    outputSchema: {
+      title: z.string().optional(),
+      plaintext: z.string().optional(),
+    },
+  },
+  withErrorHandling(({ id, title, account }) => {
+    // Prefer ID-based lookup if provided
+    if (id) {
+      const note = notesManager.getNoteById(id);
+      if (!note) {
+        return errorResponse(`Note with ID "${id}" not found`);
+      }
+      if (note.passwordProtected) {
+        return errorResponse(
+          `Note "${note.title}" is password-protected and cannot be read. Unlock it in Notes.app first.`
+        );
+      }
+      const plaintext = notesManager.getNotePlaintextById(id);
+      if (!plaintext) {
+        return errorResponse(`Failed to read plaintext of note "${note.title}"`);
+      }
+      return successResponse(plaintext, { title: note.title, plaintext });
+    }
+
+    // Fall back to title-based lookup
+    if (!title) {
+      return errorResponse("Either 'id' or 'title' is required");
+    }
+
+    const note = notesManager.getNoteDetails(title, account);
+    if (!note) {
+      return errorResponse(`Note "${title}" not found`);
+    }
+    if (note.passwordProtected) {
+      return errorResponse(
+        `Note "${title}" is password-protected and cannot be read. Unlock it in Notes.app first.`
+      );
+    }
+
+    const plaintext = notesManager.getNotePlaintext(title, account);
+    if (!plaintext) {
+      return errorResponse(`Failed to read plaintext of note "${title}"`);
+    }
+
+    return successResponse(plaintext, { title, plaintext });
+  }, "Error retrieving note plaintext")
+);
+
 // --- get-note-by-id ---
 
 server.registerTool(

--- a/src/services/appleNotesManager.test.ts
+++ b/src/services/appleNotesManager.test.ts
@@ -877,6 +877,65 @@ describe("AppleNotesManager", () => {
     });
   });
 
+  describe("getNotePlaintext", () => {
+    it("reads the note's plaintext property by title", () => {
+      mockExecuteAppleScript.mockReturnValue({
+        success: true,
+        output: "Shopping List\n- Eggs\n- Milk",
+      });
+
+      const text = manager.getNotePlaintext("Shopping List");
+
+      expect(text).toBe("Shopping List\n- Eggs\n- Milk");
+      expect(mockExecuteAppleScript).toHaveBeenCalledWith(
+        expect.stringContaining('get plaintext of note "Shopping List"')
+      );
+    });
+
+    it("returns empty string when the note is not found", () => {
+      mockExecuteAppleScript.mockReturnValue({
+        success: false,
+        output: "",
+        error: 'Can\'t get note "Missing"',
+      });
+
+      expect(manager.getNotePlaintext("Missing Note")).toBe("");
+    });
+
+    it("uses the specified account", () => {
+      mockExecuteAppleScript.mockReturnValue({ success: true, output: "Content" });
+
+      manager.getNotePlaintext("My Note", "Gmail");
+
+      expect(mockExecuteAppleScript).toHaveBeenCalledWith(
+        expect.stringContaining('tell account "Gmail"')
+      );
+    });
+  });
+
+  describe("getNotePlaintextById", () => {
+    it("reads the note's plaintext property by id at the application level", () => {
+      mockExecuteAppleScript.mockReturnValue({ success: true, output: "Just the text" });
+
+      const text = manager.getNotePlaintextById("x-coredata://ABC/ICNote/p1");
+
+      expect(text).toBe("Just the text");
+      expect(mockExecuteAppleScript).toHaveBeenCalledWith(
+        expect.stringContaining('get plaintext of note id "x-coredata://ABC/ICNote/p1"')
+      );
+    });
+
+    it("returns empty string when Notes.app rejects the read", () => {
+      mockExecuteAppleScript.mockReturnValue({ success: false, output: "", error: "no such note" });
+
+      expect(manager.getNotePlaintextById("x-coredata://ABC/ICNote/p1")).toBe("");
+    });
+
+    it("rejects malformed IDs", () => {
+      expect(() => manager.getNotePlaintextById("arbitrary string")).toThrow();
+    });
+  });
+
   // ---------------------------------------------------------------------------
   // Password Protection Helpers
   // ---------------------------------------------------------------------------

--- a/src/services/appleNotesManager.ts
+++ b/src/services/appleNotesManager.ts
@@ -927,6 +927,60 @@ export class AppleNotesManager {
   }
 
   /**
+   * Retrieves the plain-text content of a note by its exact title.
+   *
+   * Reads the note's `plaintext` property, which Notes derives from the body
+   * with all HTML markup removed. This is the text Notes itself exposes, so it
+   * is more faithful than converting the HTML body and skips the markup
+   * round-trip entirely.
+   *
+   * @param title - Exact title of the note
+   * @param account - Account to search in (defaults to iCloud)
+   * @returns Plain-text content of the note, or empty string if not found
+   */
+  getNotePlaintext(title: string, account?: string): string {
+    const targetAccount = this.resolveAccount(account);
+    const safeTitle = escapePlainStringForAppleScript(title);
+
+    const getCommand = `get plaintext of note "${safeTitle}"`;
+    const script = buildAccountScopedScript({ account: targetAccount }, getCommand);
+    const result = executeAppleScript(script);
+
+    if (!result.success) {
+      console.error(`Failed to get plaintext of note "${title}":`, result.error);
+      return "";
+    }
+
+    return result.output;
+  }
+
+  /**
+   * Retrieves the plain-text content of a note by its CoreData ID.
+   *
+   * Reads the read-only `plaintext` property (the body with HTML removed). More
+   * reliable than getNotePlaintext() because IDs are unique across accounts.
+   *
+   * Note: Password-protected notes will fail with an AppleScript error. Callers
+   * should check for password protection beforehand using getNoteById().
+   *
+   * @param id - CoreData URL identifier for the note
+   * @returns Plain-text content of the note, or empty string if not found
+   */
+  getNotePlaintextById(id: string): string {
+    const safeId = sanitizeId(id);
+    const getCommand = `get plaintext of note id "${safeId}"`;
+    const script = buildAppLevelScript(getCommand);
+    const result = executeAppleScript(script);
+
+    if (!result.success) {
+      console.error(`Failed to get plaintext of note with ID "${id}":`, result.error);
+      return "";
+    }
+
+    return result.output;
+  }
+
+  /**
    * Retrieves a note by its unique CoreData ID.
    *
    * Each note has a unique ID in the format:


### PR DESCRIPTION
The scripting dictionary gives every note a read-only `plaintext` property, which is the body with all the HTML stripped out. The server never used it. `get-note-content` returns the raw HTML, and `get-note-markdown` runs that HTML through Turndown, but there was no way to just ask for the text.

`get-note-plaintext` reads that property directly, by id or title, the same shape as `get-note-content`. Because Notes computes the plaintext itself, it is more faithful than stripping the HTML on our end, and it skips the conversion pass.

### Why it's worth having

An agent that only wants the words (to summarize, search, or feed somewhere else) currently has to pull the HTML and clean it up, or take the Markdown and accept the markup. This gives a clean text read with no conversion in the middle.

### Details

- New `getNotePlaintext(title, account)` and `getNotePlaintextById(id)` on the manager, built with the existing `buildAccountScopedScript` / `buildAppLevelScript` / `sanitizeId` / escape helpers, returning an empty string on failure like their `get-note-content` siblings.
- Password-protected notes are checked first and get the same "unlock it in Notes.app" message as `get-note-content`.
- 6 new tests covering the title and id paths, account scoping, the failure path, and the malformed-id guard.
- README, CHANGELOG, and both skill manifests updated.

No existing tool, signature, or behavior changed. `npm run lint`, `npm run typecheck`, `npm test`, `npm run build`, and `npm run format:check` all pass.