### PR TITLE
docs(skill): port four field-tested Apple Notes techniques into the skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Documentation
+- **Apple Notes skill: four added techniques.** Ported field-tested guidance into `skills/apple-notes/SKILL.md` (and the Codex mirror): (1) use `get-note-plaintext` as the quickest way to verify rendered text when stored HTML looks off; (2) do not use decorative separators (horizontal rules, repeated dashes, box-drawing) between sections, since they render inconsistently; (3) treat a `stdout maxBuffer length exceeded` error as an attachment-risk signal alongside the existing ones; (4) an optional technique for taking full control of the title HTML without a duplicate sidebar line (create with a styled `<h1>` then `update-note` with `newTitle: " "`), documented with its CoreData-id-resolution caveat and flagged as advanced, not the default.
 
 ## [2.4.0] - 2026-06-23
 ### Added

--- a/codex/skills/apple-notes/SKILL.md
+++ b/codex/skills/apple-notes/SKILL.md
@@ -89,6 +89,8 @@ Action: Use create-note with title="Shopping List" and formatted content
 
 For structured notes, pass `format="html"` and use simple Apple Notes-friendly HTML. The server automatically prepends the `title` as an `<h1>` in both plaintext and HTML modes, so do not include the same `<h1>` title in `content` when creating a note.
 
+**Optional: full control of the title without a duplicate line.** The default approach (pass only `title`, let the server add the `<h1>`) is simplest and is what most notes need. If you instead want to control the title's HTML yourself and find the metadata title rendering as a small duplicate line above your styled `<h1>`, you can put the styled `<h1>Title</h1>` in `content`, then immediately `update-note` on the returned id with `newTitle: " "` (a single space) and the same HTML. Notes then uses the first body line as the sidebar title. Caveat: after blanking the metadata title this way, the note's CoreData id can stop resolving for follow-up calls, so address the note by its display title afterward. Prefer the default title-only approach unless you specifically need this.
+
 ### Finding Notes
 
 When the user wants to find notes:
@@ -155,6 +157,7 @@ Use HTML for predictable rich notes. Apple Notes normalizes HTML internally, but
 - Escape literal `&`, `<`, and `>` in user content as `&amp;`, `&lt;`, and `&gt;`.
 - Avoid nested lists when possible. Apple Notes can flatten or misplace nested list markup.
 - Use bare URLs when updating existing notes if anchor tags are stripped by Notes on save.
+- Do not use decorative separators between sections (horizontal rules, repeated dashes, or box-drawing characters). They render inconsistently in Notes; use an empty `<div><br></div>` spacer instead.
 
 Do not use CDATA sections. They can render literally in Apple Notes.
 
@@ -163,7 +166,7 @@ Do not use CDATA sections. They can render literally in Apple Notes.
 Before updating an existing note, check whether it contains attachments when the user mentions or the note likely includes images, PDFs, scans, audio, files, or other embedded objects.
 
 - Use `list-attachments` before rewriting attachment-risk notes.
-- Treat empty body output, very large content, or attachment listings as a warning that a full-body update may remove embedded objects.
+- Treat empty body output, very large content, a `stdout maxBuffer length exceeded` error, or a non-empty `list-attachments` result as a warning that a full-body update may remove embedded objects.
 - If preserving attachments matters, create a new formatted note instead of overwriting the existing one, or save/fetch the attachments first and explain the limitation to the user.
 
 ## Formatting Limits
@@ -195,6 +198,8 @@ If the user specifically requires those features, create all API-supported conte
 ## Verification
 
 `get-note-content` returns Apple Notes' stored HTML, which may differ from the original HTML while still rendering correctly. Use `get-note-markdown`, `get-note-content`, or a quick reread of the note after create/update to verify the title, line breaks, list spacing, and important content. Do not rewrite normalized HTML just because Notes transformed tags such as headings or monostyled text.
+
+When the stored HTML looks suspicious, `get-note-plaintext` is the quickest check: it returns the note's plain-text body (what Notes itself shows) with no markup, so you can confirm the title, line breaks, and text survived without reading through normalized HTML.
 
 ## Error Handling
 

--- a/skills/apple-notes/SKILL.md
+++ b/skills/apple-notes/SKILL.md
@@ -89,6 +89,8 @@ Action: Use create-note with title="Shopping List" and formatted content
 
 For structured notes, pass `format="html"` and use simple Apple Notes-friendly HTML. The server automatically prepends the `title` as an `<h1>` in both plaintext and HTML modes, so do not include the same `<h1>` title in `content` when creating a note.
 
+**Optional: full control of the title without a duplicate line.** The default approach (pass only `title`, let the server add the `<h1>`) is simplest and is what most notes need. If you instead want to control the title's HTML yourself and find the metadata title rendering as a small duplicate line above your styled `<h1>`, you can put the styled `<h1>Title</h1>` in `content`, then immediately `update-note` on the returned id with `newTitle: " "` (a single space) and the same HTML. Notes then uses the first body line as the sidebar title. Caveat: after blanking the metadata title this way, the note's CoreData id can stop resolving for follow-up calls, so address the note by its display title afterward. Prefer the default title-only approach unless you specifically need this.
+
 ### Finding Notes
 
 When the user wants to find notes:
@@ -155,6 +157,7 @@ Use HTML for predictable rich notes. Apple Notes normalizes HTML internally, but
 - Escape literal `&`, `<`, and `>` in user content as `&amp;`, `&lt;`, and `&gt;`.
 - Avoid nested lists when possible. Apple Notes can flatten or misplace nested list markup.
 - Use bare URLs when updating existing notes if anchor tags are stripped by Notes on save.
+- Do not use decorative separators between sections (horizontal rules, repeated dashes, or box-drawing characters). They render inconsistently in Notes; use an empty `<div><br></div>` spacer instead.
 
 Do not use CDATA sections. They can render literally in Apple Notes.
 
@@ -163,7 +166,7 @@ Do not use CDATA sections. They can render literally in Apple Notes.
 Before updating an existing note, check whether it contains attachments when the user mentions or the note likely includes images, PDFs, scans, audio, files, or other embedded objects.
 
 - Use `list-attachments` before rewriting attachment-risk notes.
-- Treat empty body output, very large content, or attachment listings as a warning that a full-body update may remove embedded objects.
+- Treat empty body output, very large content, a `stdout maxBuffer length exceeded` error, or a non-empty `list-attachments` result as a warning that a full-body update may remove embedded objects.
 - If preserving attachments matters, create a new formatted note instead of overwriting the existing one, or save/fetch the attachments first and explain the limitation to the user.
 
 ## Formatting Limits
@@ -195,6 +198,8 @@ If the user specifically requires those features, create all API-supported conte
 ## Verification
 
 `get-note-content` returns Apple Notes' stored HTML, which may differ from the original HTML while still rendering correctly. Use `get-note-markdown`, `get-note-content`, or a quick reread of the note after create/update to verify the title, line breaks, list spacing, and important content. Do not rewrite normalized HTML just because Notes transformed tags such as headings or monostyled text.
+
+When the stored HTML looks suspicious, `get-note-plaintext` is the quickest check: it returns the note's plain-text body (what Notes itself shows) with no markup, so you can confirm the title, line breaks, and text survived without reading through normalized HTML.
 
 ## Error Handling
 


### PR DESCRIPTION
Working from a personal Apple Notes skill, I pulled four techniques into the repo's bundled skill that were not there yet. All four are generic Notes behavior, nothing tied to a particular setup.

1. **Verify with get-note-plaintext.** The Verification section already notes that stored HTML can look wrong while rendering fine. Now that `get-note-plaintext` is in (#46), it is the fastest way to check: it returns the plain text Notes itself shows, so you can confirm the title and line breaks survived without reading through normalized HTML.

2. **No decorative separators.** Horizontal rules, repeated dashes, and box-drawing characters render inconsistently in Notes. Added a line in Formatting Guidance to use a `<div><br></div>` spacer instead.

3. **maxBuffer as an attachment signal.** A `stdout maxBuffer length exceeded` error usually means the note has large embedded attachments. Added it to the existing list of attachment-risk tells, so an agent treats it as a reason to run `list-attachments` before a full-body replace.

4. **Optional title control without a duplicate.** This one is advanced, so it is written as optional with the default ("pass `title` only") kept front and center. If you do want to control the title HTML and hit the duplicate small-title line, you can create with a styled `<h1>` and then `update-note` with `newTitle: " "` so Notes uses the first body line as the sidebar title. The catch is documented too: after blanking the metadata title, the note's CoreData id can stop resolving, so you address it by display title afterward.

Both the canonical skill and the Codex mirror are updated, and the edited sections are byte-for-byte identical between them. Docs only.