### PR TITLE
fix(security): iterate htmlToPlaintext tag-strip until stable (2.5.4)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-notes",
-      "version": "2.5.3",
+      "version": "2.5.4",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-notes",
-      "version": "2.5.3",
+      "version": "2.5.4",
       "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "apple-notes",
       "description": "Manage Apple Notes through natural language - create, search, read, update, delete, and organize notes and folders",
-      "version": "2.5.3",
+      "version": "2.5.4",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, and organize notes and folders (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.4] - 2026-06-25
+### Security
+- **Hardened `htmlToPlaintext` tag stripping (note export).** The HTML-tag strip now loops until the string stabilizes instead of running a single regex pass, so overlapping angle brackets (e.g. `<<i>>`) can no longer leave residue. Clears the open CodeQL `js/incomplete-multi-character-sanitization` (high) on the export helper. It is export-only formatting (not an injection sink), but this keeps the security scan clean.
+
 ## [2.5.3] - 2026-06-25
 ### Fixed
 - Added a process-level uncaughtException/unhandledRejection safety net so a stray error or a broken stdout pipe (EPIPE) on client disconnect can no longer crash the long-lived server; EPIPE now exits cleanly.

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "apple-notes-mcp",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "apple-notes-mcp",
-      "version": "2.5.3",
+      "version": "2.5.4",
       "license": "MIT",
       "os": [
         "darwin"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes-mcp",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "description": "MCP server for Apple Notes - create, search, update, and manage notes via Claude and other AI assistants",
   "type": "module",
   "main": "build/index.js",

--- a/src/services/appleNotesManager.test.ts
+++ b/src/services/appleNotesManager.test.ts
@@ -3116,4 +3116,12 @@ describe("htmlToPlaintext (export helper)", () => {
     expect(toPlaintext("a<br><br><br><br>b")).toBe("a\n\nb");
     expect(toPlaintext("  <div>x</div>  ")).toBe("x");
   });
+
+  it("strips nested/overlapping tags without leaving a tag (iterated strip)", () => {
+    // A single pass can leave residue when removing one tag re-forms another;
+    // the loop keeps stripping until no <...> remains.
+    expect(toPlaintext("a<<i>>b")).not.toMatch(/<[^>]*>/);
+    expect(toPlaintext("<x<y>z>")).not.toMatch(/<[^>]*>/);
+    expect(toPlaintext("plain <b>text</b> here")).toBe("plain text here");
+  });
 });

--- a/src/services/appleNotesManager.ts
+++ b/src/services/appleNotesManager.ts
@@ -2829,12 +2829,24 @@ export class AppleNotesManager {
    * Simple HTML to plaintext conversion for export.
    */
   private htmlToPlaintext(html: string): string {
+    // Convert block/line breaks to newlines first.
+    let text = html
+      .replace(/<br\s*\/?>/gi, "\n")
+      .replace(/<\/div>/gi, "\n")
+      .replace(/<\/p>/gi, "\n");
+
+    // Strip any remaining tags, looping until the string stabilizes. A single
+    // pass can leave residue when removing one tag re-forms another (e.g.
+    // "<<i>>"), so we repeat until there are no more matches — the recognized
+    // fix for CodeQL js/incomplete-multi-character-sanitization.
+    let prev: string;
+    do {
+      prev = text;
+      text = text.replace(/<[^>]*>/g, "");
+    } while (text !== prev);
+
     return (
-      html
-        .replace(/<br\s*\/?>/gi, "\n")
-        .replace(/<\/div>/gi, "\n")
-        .replace(/<\/p>/gi, "\n")
-        .replace(/<[^>]+>/g, "")
+      text
         .replace(/&nbsp;/g, " ")
         .replace(/&lt;/g, "<")
         .replace(/&gt;/g, ">")


### PR DESCRIPTION
## What
`htmlToPlaintext` (note-export helper) stripped HTML tags with a single `/<[^>]+>/g` pass. Removing one tag can re-form another (e.g. `<<i>>`), leaving residue — CodeQL **`js/incomplete-multi-character-sanitization` (high)**, the one open alert on the repo.

## Fix
Loop the tag-strip until the string stabilizes (the recognized remediation for this rule). Entity decoding (with `&amp;` decoded last, from 2.5.2) is unchanged.

- Export-only formatting — not an injection sink — but this keeps the security scan clean.
- Adds a nested/overlapping-tag regression test; full suite 433 pass.
- Version bumped to **2.5.4** + CHANGELOG `### Security` entry.

Branch-based per concurrent-session safety.