### PR TITLE
chore(release): 2.5.5 — switch publish to pnpm publish (Phase 2 pilot)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-notes",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-notes",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "apple-notes",
       "description": "Manage Apple Notes through natural language - create, search, read, update, delete, and organize notes and folders",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, and organize notes and folders (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,20 +41,6 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
 
-      # Phase 1 of the pnpm migration keeps `npm publish` as the release command
-      # (pnpm handles install/build/test); Phase 2 switches this to `pnpm publish`.
-      - name: Upgrade npm (OIDC trusted publishing needs npm >= 11.5.1)
-        # Retry: the global install hits the live registry and has flaked on
-        # transient ECONNRESET, aborting releases. Try up to 3 times.
-        run: |
-          for i in 1 2 3; do
-            npm install -g npm@latest && exit 0
-            echo "npm upgrade attempt $i failed; retrying in 5s…" >&2
-            sleep 5
-          done
-          echo "::error::npm upgrade failed after 3 attempts" >&2
-          exit 1
-
       - name: Check if version is already published
         id: check
         run: |
@@ -84,16 +70,22 @@ jobs:
         if: steps.check.outputs.skip == 'false'
         run: pnpm run build
 
-      - name: Publish to npm
+      - name: Publish to npm (pnpm + OIDC trusted publishing)
         if: steps.check.outputs.skip == 'false'
-        # Tolerate the publish race: a release pushes two commits, so two CI runs
-        # complete and each triggers a publish. The concurrency group serializes
-        # them, but npm's registry read (`npm view`, CDN-cached) lags the write,
-        # so the second run's "already published?" check can still see the old
-        # version, attempt `npm publish`, and get a 403 for the version the first
-        # run just pushed. Treat that specific case as success.
+        # Phase 2: publish via `pnpm publish` over OIDC trusted publishing
+        # (tokenless — no NPM_TOKEN). pnpm 11 supports npm's OIDC flow; the npm
+        # trusted-publisher config is keyed to repo + workflow file, not the CLI,
+        # so it still matches after the npm→pnpm switch. `--provenance` emits the
+        # attestation; `--no-git-checks` because CI publishes from a clean but
+        # detached checkout (pnpm otherwise refuses to publish off a branch).
+        # Tolerate the publish race: a release lands two pushes on main, so two CI
+        # runs complete and each triggers a publish. The concurrency group
+        # serializes them, but the registry read (`npm view`, CDN-cached) lags the
+        # write, so the second run can still see the old version, attempt to
+        # publish, and get a 403 for the version the first run just pushed. Treat
+        # that specific case as success.
         run: |
-          if npm publish --provenance; then
+          if pnpm publish --provenance --no-git-checks; then
             echo "Published."
           else
             LOCAL=$(node -p "require('./package.json').version")
@@ -101,7 +93,7 @@ jobs:
             if [ "$PUBLISHED" = "$LOCAL" ]; then
               echo "Version $LOCAL is already on npm (published by a concurrent run); treating as success."
             else
-              echo "::error::npm publish failed and $LOCAL is not on npm."
+              echo "::error::pnpm publish failed and $LOCAL is not on npm."
               exit 1
             fi
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.5] - 2026-06-26
+### Changed
+- **Release tooling: publish now uses `pnpm publish` over OIDC trusted publishing** (Phase 2 of the npm→pnpm migration), replacing `npm publish`. Still tokenless (no `NPM_TOKEN`) with provenance attestation; the npm trusted-publisher config is keyed to the repo + workflow file, not the CLI, so it is unaffected. **No runtime or library changes** — the published package is byte-for-byte equivalent to 2.5.4; this release exists to validate the pnpm publish pipeline.
+
 ## [2.5.4] - 2026-06-25
 ### Security
 - **Hardened `htmlToPlaintext` tag stripping (note export).** The HTML-tag strip now loops until the string stabilizes instead of running a single regex pass, so overlapping angle brackets (e.g. `<<i>>`) can no longer leave residue. Clears the open CodeQL `js/incomplete-multi-character-sanitization` (high) on the export helper. It is export-only formatting (not an injection sink), but this keeps the security scan clean.

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes-mcp",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Notes - create, search, update, and manage notes via Claude and other AI assistants",
   "type": "module",


### PR DESCRIPTION
**Phase 2 of the npm→pnpm migration — pilot.** Switches the release command from `npm publish` to **`pnpm publish` over OIDC trusted publishing** (still tokenless, still emits a provenance attestation) and drops the now-unneeded `npm install -g npm@latest` step.

- `publish.yml`: `npm publish --provenance` → `pnpm publish --provenance --no-git-checks`; npm-upgrade step removed. Version-check still uses `npm view` (read-only). The npm trusted-publisher config is keyed to **repo + workflow file**, not the CLI, so it matches unchanged.
- Version bump **2.5.4 → 2.5.5** (no runtime/library change — published package is equivalent to 2.5.4) purely to exercise the publish path. Plugin manifests synced.

**Validation:** `pnpm publish --dry-run --no-git-checks` packs `apple-notes-mcp@2.5.5` correctly; 433 tests pass. The OIDC-tokenless + provenance behavior will be confirmed on the real publish after merge — if it works, I roll `pnpm publish` out to numbers/photos/mail. If `pnpm publish` can't do OIDC, the package simply isn't republished (2.5.4 stays live) and we revert.