### PR TITLE
fix: move-note no longer drops attachments; input bounds + attachment size cap + shutdown handler

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-notes",
-      "version": "2.5.5",
+      "version": "2.5.6",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-notes",
-      "version": "2.5.5",
+      "version": "2.5.6",
       "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "apple-notes",
       "description": "Manage Apple Notes through natural language - create, search, read, update, delete, and organize notes and folders",
-      "version": "2.5.5",
+      "version": "2.5.6",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, and organize notes and folders (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.6] - 2026-06-30
+### Fixed
+- **`move-note` no longer drops attachments or resets note identity (data-loss fix).** The single-note `move-note` was implemented as copy-then-delete: it rebuilt the note from its body HTML in the destination folder and deleted the original, silently discarding every embedded attachment (files, images, PDFs, scans, audio) and resetting the note's creation date and id. It now uses Notes.app's native `move` command — the same one `batch-move-notes` already used — which relocates the note in place, preserving its id, creation date, and all attachments. The destination-folder-must-exist behavior is unchanged. Tests updated to assert the native `move` path (no `make new note`).
+
+### Added
+- **Configurable cap on inline attachment fetch size.** `fetch-attachment` exports an attachment to a temp file and base64-encodes it into the response via `readFileSync`, which previously had no upper bound (`APPLE_NOTES_MCP_MAX_BUFFER` does not apply to `readFileSync`), so a multi-GB attachment could exhaust memory. A size check now runs **before** the read and rejects oversized attachments with a clear error pointing at `save-attachment`. Default 25 MB, overridable via the new `APPLE_NOTES_MCP_MAX_ATTACHMENT_BYTES` env var (documented in the README). Temp-dir cleanup is preserved.
+
+### Changed
+- **All MCP string/array inputs now have upper bounds.** Every Zod input field previously used only `.min(1)`; sane `.max(...)` caps were added to string fields (query, id, title, content, folder, account, savePath, attachmentId, tags entries, etc.) and array caps (`.max(500)`) to the unbounded `ids` arrays in `batch-delete-notes` / `batch-move-notes`. Limits mirror the bounds the manager already enforced internally. Oversized input is now rejected at the schema boundary with a clear message.
+- **`syncDetection` SQLite access converted to `execFileSync`** (argv array, no shell), matching the sibling `checklistParser` / `noteMetadata` callers. The interpolated values were not user-controlled, so this is consistency hardening, not a fix for an exploitable bug.
+- **Graceful shutdown on SIGINT/SIGTERM and stdin EOF.** Added signal and stdin `end`/`close` handlers that exit cleanly, alongside the existing `uncaughtException`/`unhandledRejection` net. This server holds no persistent resources, so the impact is low; it brings shutdown behavior in line with the sibling apple-mail server.
+
+### Docs
+- **`create-note` `tags`: documented as returned-only.** The `tags` parameter was accepted but never written to Notes.app (Apple Notes tags can't be set via AppleScript). Its description now states that values are echoed back in the response but not applied to the note, and points to in-body `#hashtags` as the way to create real tags. The parameter is still accepted (not dropped) to avoid breaking existing callers.
+- **`move-note` tool description** no longer claims a copy-then-delete implementation or warns about attachment loss; it now states the note is relocated in place via the native move.
+
 ## [2.5.5] - 2026-06-26
 ### Changed
 - **Release tooling: publish now uses `pnpm publish` over OIDC trusted publishing** (Phase 2 of the npm→pnpm migration), replacing `npm publish`. Still tokenless (no `NPM_TOKEN`) with provenance attestation; the npm trusted-publisher config is keyed to the repo + workflow file, not the CLI, so it is unaffected. **No runtime or library changes** — the published package is byte-for-byte equivalent to 2.5.4; this release exists to validate the pnpm publish pipeline.

--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ Deletes a note (moves to Recently Deleted in Notes.app).
 
 #### `move-note`
 
-Moves a note to a different folder.
+Moves a note to a different folder. The note is relocated in place via Notes.app's native `move`, so its id, creation date, and all embedded attachments (files, images, scans, PDFs, audio) are preserved. The destination folder must already exist — create it first with [`create-folder`](#create-folder).
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -942,6 +942,7 @@ All configuration is optional — the server works out of the box. Override beha
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `APPLE_NOTES_MCP_MAX_BUFFER` | `67108864` (64 MB) | Max bytes captured from a single AppleScript invocation. Raise it if a very large export/list is truncated; lower it to cap memory. |
+| `APPLE_NOTES_MCP_MAX_ATTACHMENT_BYTES` | `26214400` (25 MB) | Max size of an attachment that [`fetch-attachment`](#fetch-attachment) will base64-encode inline. Larger attachments are rejected with an error pointing at [`save-attachment`](#save-attachment) (which streams to disk and has no such limit). Raise it to fetch bigger attachments inline; lower it to cap memory. |
 | `APPLE_NOTES_MCP_CONFIG_FILE` | `~/Library/Application Support/apple-notes-mcp/config.json` | Path to the JSON config file (see below). |
 | `DEBUG` / `VERBOSE` | unset | Set either to enable verbose diagnostic logging to stderr. |
 

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes-mcp",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Notes - create, search, update, and manage notes via Claude and other AI assistants",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,6 +111,32 @@ function withErrorHandling<T extends Record<string, unknown>>(
 }
 
 // =============================================================================
+// Input Bounds
+// =============================================================================
+
+/**
+ * Upper bounds on string/array inputs (#validation). Zod's `.min(1)` rejected
+ * empty input but nothing capped the maximum, so a caller could pass an
+ * arbitrarily large string/array straight through to AppleScript. These mirror
+ * the limits the AppleNotesManager already enforces internally (title 2000,
+ * content 5 MB, folder path 1000, account 200) and add sane caps for the rest,
+ * so oversized input is rejected at the schema boundary with a clear message.
+ */
+const MAX = {
+  TITLE: 2000,
+  CONTENT: 5 * 1024 * 1024,
+  FOLDER: 1000,
+  ACCOUNT: 200,
+  QUERY: 2000,
+  ID: 2000,
+  SAVE_PATH: 4096,
+  ATTACHMENT_ID: 2000,
+  TAG: 200,
+  TAGS: 100,
+  BATCH_IDS: 500,
+} as const;
+
+// =============================================================================
 // Schema Definitions
 // =============================================================================
 
@@ -118,16 +144,16 @@ function withErrorHandling<T extends Record<string, unknown>>(
  * Common schema for operations requiring a note title.
  */
 const noteTitleSchema = {
-  title: z.string().min(1, "Note title is required"),
-  account: z.string().optional().describe("Account name (defaults to iCloud)"),
+  title: z.string().min(1, "Note title is required").max(MAX.TITLE),
+  account: z.string().max(MAX.ACCOUNT).optional().describe("Account name (defaults to iCloud)"),
 };
 
 /**
  * Common schema for operations requiring a folder name.
  */
 const folderNameSchema = {
-  name: z.string().min(1, "Folder name is required"),
-  account: z.string().optional().describe("Account name (defaults to iCloud)"),
+  name: z.string().min(1, "Folder name is required").max(MAX.FOLDER),
+  account: z.string().max(MAX.ACCOUNT).optional().describe("Account name (defaults to iCloud)"),
 };
 
 // =============================================================================
@@ -142,10 +168,11 @@ server.registerTool(
     description:
       "Use when: the user wants to create a brand-new Apple Note.\nReturns: the new note's title and id — reuse the id for follow-up reads/edits.\nDo not use when: editing an existing note (use update-note).\nNote: the title is prepended as an <h1>; true Apple Notes checklists cannot be created via AppleScript (see the content field).",
     inputSchema: {
-      title: z.string().min(1, "Title is required"),
+      title: z.string().min(1, "Title is required").max(MAX.TITLE),
       content: z
         .string()
         .min(1, "Content is required")
+        .max(MAX.CONTENT)
         .describe(
           'Note body. AppleScript cannot create true Apple Notes checklists — `<input type="checkbox">`, checklist CSS classes, and markdown `- [ ]` lines do not render as checkable items. To produce a checklist, create the note with a plain `<ul>` or `- ` list and convert it in Notes.app with ⇧⌘L.'
         ),
@@ -154,12 +181,19 @@ server.registerTool(
         .optional()
         .default("plaintext")
         .describe("Content format: 'plaintext' (default) or 'html' for rich formatting"),
-      tags: z.array(z.string()).optional().describe("Tags for organization"),
+      tags: z
+        .array(z.string().max(MAX.TAG))
+        .max(MAX.TAGS)
+        .optional()
+        .describe(
+          "Returned-only metadata — NOT written to Notes.app. Apple Notes tags can't be set via AppleScript, so any values passed here are echoed back in the response but do not appear on the created note. Use #hashtags inside the content body instead (Notes.app turns those into real tags)."
+        ),
       folder: z
         .string()
+        .max(MAX.FOLDER)
         .optional()
         .describe("Folder to create the note in (supports nested paths like 'Work/Clients')"),
-      account: z.string().optional().describe("Account name (defaults to iCloud)"),
+      account: z.string().max(MAX.ACCOUNT).optional().describe("Account name (defaults to iCloud)"),
     },
     outputSchema: {
       ok: z.boolean().optional(),
@@ -197,12 +231,13 @@ server.registerTool(
     description:
       "Use when: finding notes by a keyword in the title (or body with searchContent=true) and you need their ids.\nReturns: matching notes with title, folder, and id.\nDo not use when: you already have a note id (use get-note-content) or want every note (use list-notes).\nPrefer this first to obtain ids for subsequent read/update/delete/move calls.",
     inputSchema: {
-      query: z.string().min(1, "Search query is required"),
+      query: z.string().min(1, "Search query is required").max(MAX.QUERY),
       searchContent: z.boolean().optional().describe("Search note content instead of titles"),
-      account: z.string().optional().describe("Account to search in"),
-      folder: z.string().optional().describe("Limit search to a specific folder"),
+      account: z.string().max(MAX.ACCOUNT).optional().describe("Account to search in"),
+      folder: z.string().max(MAX.FOLDER).optional().describe("Limit search to a specific folder"),
       modifiedSince: z
         .string()
+        .max(64)
         .optional()
         .describe(
           "ISO 8601 date string to filter notes modified on or after this date (e.g., '2025-01-01'). Useful for searching only recent notes in large collections."
@@ -274,10 +309,19 @@ server.registerTool(
     description:
       "Use when: reading the full body text of one known note, by id (preferred) or title.\nReturns: the note's content plus parsed hashtags.\nDo not use when: you only need metadata (get-note-details) or Markdown with checklist state (get-note-markdown).\nNote: password-protected notes must be unlocked in Notes.app first.",
     inputSchema: {
-      id: z.string().optional().describe("Note ID (preferred - more reliable than title)"),
-      title: z.string().optional().describe("Note title (use id instead when available)"),
+      id: z
+        .string()
+        .max(MAX.ID)
+        .optional()
+        .describe("Note ID (preferred - more reliable than title)"),
+      title: z
+        .string()
+        .max(MAX.TITLE)
+        .optional()
+        .describe("Note title (use id instead when available)"),
       account: z
         .string()
+        .max(MAX.ACCOUNT)
         .optional()
         .describe("Account name (defaults to iCloud, ignored if id is provided)"),
     },
@@ -342,10 +386,19 @@ server.registerTool(
     description:
       "Use when: reading one note's body as plain text with no HTML, by id (preferred) or title.\nReturns: the note's plaintext exactly as Notes exposes it.\nDo not use when: you need the HTML body (get-note-content) or Markdown with checklist state (get-note-markdown).\nNote: this reads the note's native plaintext property, so it skips the HTML-to-text conversion; password-protected notes must be unlocked in Notes.app first.",
     inputSchema: {
-      id: z.string().optional().describe("Note ID (preferred - more reliable than title)"),
-      title: z.string().optional().describe("Note title (use id instead when available)"),
+      id: z
+        .string()
+        .max(MAX.ID)
+        .optional()
+        .describe("Note ID (preferred - more reliable than title)"),
+      title: z
+        .string()
+        .max(MAX.TITLE)
+        .optional()
+        .describe("Note title (use id instead when available)"),
       account: z
         .string()
+        .max(MAX.ACCOUNT)
         .optional()
         .describe("Account name (defaults to iCloud, ignored if id is provided)"),
     },
@@ -405,7 +458,7 @@ server.registerTool(
     description:
       "Use when: you have a note id and need its metadata only.\nReturns: id, title, created, modified, shared, passwordProtected.\nDo not use when: you need the body text (get-note-content) or only have a title (get-note-details).",
     inputSchema: {
-      id: z.string().min(1, "Note ID is required"),
+      id: z.string().min(1, "Note ID is required").max(MAX.ID),
     },
     outputSchema: {
       id: z.string().optional(),
@@ -485,7 +538,7 @@ server.registerTool(
     description:
       "Use when: the user wants to reveal a known note in Notes.app by id.\nReturns: confirmation that Notes.app accepted the show command.\nDo not use when: you only need note content (get-note-content) or metadata (get-note-by-id).\nNote: this opens or focuses the Notes UI.",
     inputSchema: {
-      id: z.string().min(1, "Note ID is required"),
+      id: z.string().min(1, "Note ID is required").max(MAX.ID),
       separately: z
         .boolean()
         .optional()
@@ -513,7 +566,7 @@ server.registerTool(
     description:
       "Use when: the user wants to reveal a known folder in Notes.app by id.\nReturns: confirmation that Notes.app accepted the show command.\nDo not use when: you only need the folder list (list-folders).\nNote: this opens or focuses the Notes UI. Get the id from list-folders.",
     inputSchema: {
-      id: z.string().min(1, "Folder ID is required"),
+      id: z.string().min(1, "Folder ID is required").max(MAX.ID),
       separately: z
         .boolean()
         .optional()
@@ -541,7 +594,7 @@ server.registerTool(
     description:
       "Use when: the user wants to reveal a known account in Notes.app by id.\nReturns: confirmation that Notes.app accepted the show command.\nDo not use when: you only need the account list (list-accounts).\nNote: this opens or focuses the Notes UI. Get the id from list-accounts.",
     inputSchema: {
-      id: z.string().min(1, "Account ID is required"),
+      id: z.string().min(1, "Account ID is required").max(MAX.ID),
       separately: z
         .boolean()
         .optional()
@@ -569,12 +622,21 @@ server.registerTool(
     description:
       "Use when: changing the title and/or replacing the body of an existing note, by id (preferred) or title.\nReturns: confirmation; warns when the note is shared.\nDo not use when: creating a new note (create-note).\nSafety: newContent REPLACES the entire body — it does not append. Read the note first if you need to preserve existing text, and run list-attachments first when the note may hold files, images, scans, PDFs, or audio, since a full-body replace can drop embedded attachments. Edits to shared notes are immediately visible to all collaborators.",
     inputSchema: {
-      id: z.string().optional().describe("Note ID (preferred - more reliable than title)"),
-      title: z.string().optional().describe("Current note title (use id instead when available)"),
-      newTitle: z.string().optional().describe("New title for the note"),
+      id: z
+        .string()
+        .max(MAX.ID)
+        .optional()
+        .describe("Note ID (preferred - more reliable than title)"),
+      title: z
+        .string()
+        .max(MAX.TITLE)
+        .optional()
+        .describe("Current note title (use id instead when available)"),
+      newTitle: z.string().max(MAX.TITLE).optional().describe("New title for the note"),
       newContent: z
         .string()
         .min(1, "New content is required")
+        .max(MAX.CONTENT)
         .describe(
           "New note body. AppleScript cannot produce true Apple Notes checklists; checkbox inputs and `- [ ]` markdown do not render as checkable items. Use a plain list and convert in Notes.app with ⇧⌘L."
         ),
@@ -585,6 +647,7 @@ server.registerTool(
         .describe("Content format: 'plaintext' (default) or 'html' for rich formatting"),
       account: z
         .string()
+        .max(MAX.ACCOUNT)
         .optional()
         .describe("Account containing the note (ignored if id is provided)"),
     },
@@ -671,10 +734,19 @@ server.registerTool(
     description:
       "Use when: permanently deleting a single note, by id (preferred) or title.\nReturns: confirmation; warns when the note was shared.\nDo not use when: deleting many notes (batch-delete-notes) or just relocating one (move-note).\nSafety: requires explicit user confirmation before deleting. Prefer search-notes/list-notes first to show the affected note id and title. Deleting a shared note removes collaborator access.",
     inputSchema: {
-      id: z.string().optional().describe("Note ID (preferred - more reliable than title)"),
-      title: z.string().optional().describe("Note title (use id instead when available)"),
+      id: z
+        .string()
+        .max(MAX.ID)
+        .optional()
+        .describe("Note ID (preferred - more reliable than title)"),
+      title: z
+        .string()
+        .max(MAX.TITLE)
+        .optional()
+        .describe("Note title (use id instead when available)"),
       account: z
         .string()
+        .max(MAX.ACCOUNT)
         .optional()
         .describe("Account name (defaults to iCloud, ignored if id is provided)"),
     },
@@ -745,12 +817,24 @@ server.registerTool(
   "move-note",
   {
     description:
-      "Use when: moving one note to a different folder, by id (preferred) or title.\nReturns: confirmation of the note and destination folder.\nDo not use when: moving many notes (batch-move-notes).\nNote: implemented as copy-then-delete; the destination folder must already exist (create-folder).",
+      "Use when: moving one note to a different folder, by id (preferred) or title.\nReturns: confirmation of the note and destination folder.\nDo not use when: moving many notes (batch-move-notes).\nNote: the note is relocated in place via Notes.app's native move, preserving its id, creation date, and all attachments. The destination folder must already exist (create-folder).",
     inputSchema: {
-      id: z.string().optional().describe("Note ID (preferred - more reliable than title)"),
-      title: z.string().optional().describe("Note title (use id instead when available)"),
-      folder: z.string().min(1, "Destination folder is required"),
-      account: z.string().optional().describe("Account containing the note/folder"),
+      id: z
+        .string()
+        .max(MAX.ID)
+        .optional()
+        .describe("Note ID (preferred - more reliable than title)"),
+      title: z
+        .string()
+        .max(MAX.TITLE)
+        .optional()
+        .describe("Note title (use id instead when available)"),
+      folder: z.string().min(1, "Destination folder is required").max(MAX.FOLDER),
+      account: z
+        .string()
+        .max(MAX.ACCOUNT)
+        .optional()
+        .describe("Account containing the note/folder"),
     },
     outputSchema: {
       ok: z.boolean().optional(),
@@ -817,10 +901,11 @@ server.registerTool(
     description:
       "Use when: enumerating notes in an account or folder; supports modifiedSince and limit for large collections.\nReturns: note titles only (no content or ids).\nDo not use when: you need content (get-note-content) or ids for follow-up edits (use search-notes).\nNote: warns if iCloud sync is active and results may be partial.",
     inputSchema: {
-      account: z.string().optional().describe("Account to list notes from"),
-      folder: z.string().optional().describe("Filter to specific folder"),
+      account: z.string().max(MAX.ACCOUNT).optional().describe("Account to list notes from"),
+      folder: z.string().max(MAX.FOLDER).optional().describe("Filter to specific folder"),
       modifiedSince: z
         .string()
+        .max(64)
         .optional()
         .describe(
           "ISO 8601 date string to filter notes modified on or after this date (e.g., '2025-01-01'). Useful for listing only recent notes in large collections."
@@ -912,7 +997,7 @@ server.registerTool(
     description:
       "Use when: listing all folders, with full nested paths, for an account.\nReturns: folder names/paths.\nDo not use when: listing notes (list-notes).\nNote: warns if iCloud sync is active.",
     inputSchema: {
-      account: z.string().optional().describe("Account to list folders from"),
+      account: z.string().max(MAX.ACCOUNT).optional().describe("Account to list folders from"),
     },
     outputSchema: {
       folders: z.array(z.object({}).passthrough()).optional(),
@@ -961,10 +1046,11 @@ server.registerTool(
       name: z
         .string()
         .min(1, "Folder name is required")
+        .max(MAX.FOLDER)
         .describe(
           'Folder name or nested path separated by "/". E.g., "Retro Tech/PC/CPUs" creates all intermediate folders. Existing segments are skipped.'
         ),
-      account: z.string().optional().describe("Account name (defaults to iCloud)"),
+      account: z.string().max(MAX.ACCOUNT).optional().describe("Account name (defaults to iCloud)"),
     },
     outputSchema: {
       ok: z.boolean().optional(),
@@ -1293,10 +1379,19 @@ server.registerTool(
     description:
       "Use when: listing the attachments of one note, by id (preferred) or title.\nReturns: each attachment's name, content type, and id (use with save-attachment/fetch-attachment).\nDo not use when: you want the attachment bytes (fetch-attachment) or a file on disk (save-attachment).",
     inputSchema: {
-      id: z.string().optional().describe("Note ID (preferred - more reliable than title)"),
-      title: z.string().optional().describe("Note title (use id instead when available)"),
+      id: z
+        .string()
+        .max(MAX.ID)
+        .optional()
+        .describe("Note ID (preferred - more reliable than title)"),
+      title: z
+        .string()
+        .max(MAX.TITLE)
+        .optional()
+        .describe("Note title (use id instead when available)"),
       account: z
         .string()
+        .max(MAX.ACCOUNT)
         .optional()
         .describe("Account containing the note (ignored if id is provided)"),
     },
@@ -1359,7 +1454,10 @@ server.registerTool(
     description:
       "Use when: permanently deleting multiple notes by id in one call.\nReturns: per-id success/failure counts.\nDo not use when: deleting a single note (delete-note).\nSafety: requires explicit user confirmation; this is destructive and not undoable. Prefer search-notes/list-notes first to confirm the exact ids being deleted.",
     inputSchema: {
-      ids: z.array(z.string()).describe("Array of note IDs to delete"),
+      ids: z
+        .array(z.string().max(MAX.ID))
+        .max(MAX.BATCH_IDS)
+        .describe("Array of note IDs to delete"),
     },
     outputSchema: {
       ok: z.boolean().optional(),
@@ -1405,10 +1503,14 @@ server.registerTool(
     description:
       "Use when: moving multiple notes by id into one destination folder.\nReturns: per-id success/failure counts.\nDo not use when: moving a single note (move-note).\nNote: the destination folder must already exist (create-folder).",
     inputSchema: {
-      ids: z.array(z.string()).describe("Array of note IDs to move"),
-      folder: z.string().describe("Destination folder name"),
+      ids: z
+        .array(z.string().max(MAX.ID))
+        .max(MAX.BATCH_IDS)
+        .describe("Array of note IDs to move"),
+      folder: z.string().max(MAX.FOLDER).describe("Destination folder name"),
       account: z
         .string()
+        .max(MAX.ACCOUNT)
         .optional()
         .describe("Account containing the destination folder (defaults to iCloud)"),
     },
@@ -1461,14 +1563,17 @@ server.registerTool(
       noteId: z
         .string()
         .min(1, "noteId is required")
+        .max(MAX.ID)
         .describe("CoreData note id (from search/list)"),
       attachmentId: z
         .string()
         .min(1, "attachmentId is required")
+        .max(MAX.ATTACHMENT_ID)
         .describe("Attachment id (from list-attachments)"),
       savePath: z
         .string()
         .min(1, "savePath is required")
+        .max(MAX.SAVE_PATH)
         .describe("Absolute destination file path (must be under home, temp, or /Volumes)"),
     },
     outputSchema: {
@@ -1501,10 +1606,12 @@ server.registerTool(
       noteId: z
         .string()
         .min(1, "noteId is required")
+        .max(MAX.ID)
         .describe("CoreData note id (from search/list)"),
       attachmentId: z
         .string()
         .min(1, "attachmentId is required")
+        .max(MAX.ATTACHMENT_ID)
         .describe("Attachment id (from list-attachments)"),
     },
     outputSchema: {
@@ -1537,10 +1644,12 @@ server.registerTool(
       noteId: z
         .string()
         .min(1, "noteId is required")
+        .max(MAX.ID)
         .describe("CoreData note id (from search/list)"),
       attachmentId: z
         .string()
         .min(1, "attachmentId is required")
+        .max(MAX.ATTACHMENT_ID)
         .describe("Attachment id (from list-attachments)"),
       separately: z
         .boolean()
@@ -1609,10 +1718,19 @@ server.registerTool(
     description:
       "Use when: reading a note as Markdown, with checklist items annotated [x]/[ ] when Full Disk Access is granted.\nReturns: the note's Markdown.\nDo not use when: you need the raw HTML/plaintext body (get-note-content) or only metadata (get-note-details).\nNote: falls back to plain lists (no checkmarks) without Full Disk Access.",
     inputSchema: {
-      id: z.string().optional().describe("Note ID (preferred - more reliable than title)"),
-      title: z.string().optional().describe("Note title (use id instead when available)"),
+      id: z
+        .string()
+        .max(MAX.ID)
+        .optional()
+        .describe("Note ID (preferred - more reliable than title)"),
+      title: z
+        .string()
+        .max(MAX.TITLE)
+        .optional()
+        .describe("Note title (use id instead when available)"),
       account: z
         .string()
+        .max(MAX.ACCOUNT)
         .optional()
         .describe("Account containing the note (ignored if id is provided)"),
     },
@@ -1654,7 +1772,10 @@ server.registerTool(
     description:
       "Use when: reading the checked/unchecked state of a note's checklist items, by id.\nReturns: each item's text and done state plus checked/total counts.\nDo not use when: you only have a title (get the id via search-notes first) or want the full body text (get-note-content).\nNote: requires Full Disk Access; reads the NoteStore database directly.",
     inputSchema: {
-      id: z.string().min(1, "Note ID is required. Use search-notes to find the note ID first."),
+      id: z
+        .string()
+        .min(1, "Note ID is required. Use search-notes to find the note ID first.")
+        .max(MAX.ID),
     },
     outputSchema: {
       items: z.array(z.object({}).passthrough()).optional(),
@@ -1699,7 +1820,10 @@ server.registerTool(
     description:
       "[BETA] Use when: reading note metadata AppleScript cannot expose — pinned state, checklist flags, trash/recovery state, preview snippet, password hint — by id.\nReturns: a metadata object; fields vary by macOS version and are omitted when unavailable.\nDo not use when: you need the body (get-note-content) or per-item checklist state (get-checklist-state).\nNote: reads the NoteStore SQLite database read-only and requires Full Disk Access. BETA — the database schema changes between macOS releases, so some fields may be absent. Works on trashed notes that AppleScript can no longer resolve.",
     inputSchema: {
-      id: z.string().min(1, "Note ID is required. Use search-notes to find the note ID first."),
+      id: z
+        .string()
+        .min(1, "Note ID is required. Use search-notes to find the note ID first.")
+        .max(MAX.ID),
     },
     outputSchema: {
       pinned: z.boolean().optional(),
@@ -1754,6 +1878,24 @@ process.on("uncaughtException", (err) => {
 process.on("unhandledRejection", (reason) => {
   console.error("[unhandledRejection]", reason);
 });
+
+// Graceful shutdown. This server holds no persistent resources (AppleScript runs
+// are one-shot via execSync), so there's nothing to drain — but wiring SIGINT/
+// SIGTERM and stdin EOF/close to a clean exit keeps behavior tidy and consistent
+// with the sibling apple-mail server: when the parent kills us (signal) or the
+// MCP client disconnects (stdin 'end'/'close'), exit 0 promptly instead of
+// lingering as an orphan. Idempotent so multiple triggers don't double-exit.
+let _shuttingDown = false;
+const shutdown = (): void => {
+  if (_shuttingDown) return;
+  _shuttingDown = true;
+  process.exit(0);
+};
+for (const sig of ["SIGINT", "SIGTERM"] as const) {
+  process.on(sig, shutdown);
+}
+process.stdin.on("end", shutdown);
+process.stdin.on("close", shutdown);
 
 const transport = new StdioServerTransport();
 await server.connect(transport);

--- a/src/services/appleNotesManager.test.ts
+++ b/src/services/appleNotesManager.test.ts
@@ -1834,37 +1834,41 @@ describe("AppleNotesManager", () => {
   // ---------------------------------------------------------------------------
 
   describe("moveNote", () => {
-    it("returns true when move completes successfully", () => {
-      // Mock sequence: getNoteDetails -> getNoteContent -> createNote -> deleteNote
+    // The note-details lookup output reused by the title-based move tests.
+    const detailsOutput = [
+      "My Note",
+      "x-coredata://ABC/ICNote/p123",
+      "Monday, January 1, 2024 at 12:00:00 PM",
+      "Monday, January 1, 2024 at 12:00:00 PM",
+      "false",
+      "false",
+    ].join(F);
+
+    it("returns true when the native move completes successfully", () => {
+      // Mock sequence: getNoteDetails (resolve id) -> native move
       mockExecuteAppleScript
-        .mockReturnValueOnce({
-          success: true,
-          output: [
-            "My Note",
-            "x-coredata://ABC/ICNote/p123",
-            "Monday, January 1, 2024 at 12:00:00 PM",
-            "Monday, January 1, 2024 at 12:00:00 PM",
-            "false",
-            "false",
-          ].join(F),
-        })
-        .mockReturnValueOnce({
-          success: true,
-          output: "<div>Note Title</div><div>Content</div>",
-        })
-        .mockReturnValueOnce({
-          success: true,
-          output: "note id x-coredata://...",
-        })
-        .mockReturnValueOnce({
-          success: true,
-          output: "",
-        });
+        .mockReturnValueOnce({ success: true, output: detailsOutput })
+        .mockReturnValueOnce({ success: true, output: "" });
 
       const result = manager.moveNote("My Note", "Archive");
 
       expect(result).toBe(true);
-      expect(mockExecuteAppleScript).toHaveBeenCalledTimes(4);
+      // No copy-then-delete: just the details lookup + a single native `move`.
+      expect(mockExecuteAppleScript).toHaveBeenCalledTimes(2);
+    });
+
+    it("uses the native AppleScript `move` command (preserves attachments/identity)", () => {
+      mockExecuteAppleScript
+        .mockReturnValueOnce({ success: true, output: detailsOutput })
+        .mockReturnValueOnce({ success: true, output: "" });
+
+      manager.moveNote("My Note", "Archive");
+
+      // The second call is the move; assert it issues a native `move ... to` and
+      // does NOT rebuild the note via `make new note` (the old lossy path).
+      const moveScript = mockExecuteAppleScript.mock.calls[1][0] as string;
+      expect(moveScript).toContain("move noteRef to destFolder");
+      expect(moveScript).not.toContain("make new note");
     });
 
     it("returns false when source note cannot be found", () => {
@@ -1880,23 +1884,9 @@ describe("AppleNotesManager", () => {
       expect(mockExecuteAppleScript).toHaveBeenCalledTimes(1); // Only tried to get details
     });
 
-    it("returns false when copy to destination fails", () => {
+    it("returns false when the move fails (e.g. destination folder missing)", () => {
       mockExecuteAppleScript
-        .mockReturnValueOnce({
-          success: true,
-          output: [
-            "My Note",
-            "x-coredata://ABC/ICNote/p123",
-            "Monday, January 1, 2024 at 12:00:00 PM",
-            "Monday, January 1, 2024 at 12:00:00 PM",
-            "false",
-            "false",
-          ].join(F),
-        })
-        .mockReturnValueOnce({
-          success: true,
-          output: "<div>Content</div>",
-        })
+        .mockReturnValueOnce({ success: true, output: detailsOutput })
         .mockReturnValueOnce({
           success: false,
           output: "",
@@ -1906,41 +1896,35 @@ describe("AppleNotesManager", () => {
       const result = manager.moveNote("My Note", "Nonexistent Folder");
 
       expect(result).toBe(false);
-      expect(mockExecuteAppleScript).toHaveBeenCalledTimes(3); // Details + Read + failed create
+      expect(mockExecuteAppleScript).toHaveBeenCalledTimes(2); // Details + failed move
+    });
+  });
+
+  describe("moveNoteById", () => {
+    it("returns true when the native move succeeds", () => {
+      mockExecuteAppleScript.mockReturnValueOnce({ success: true, output: "" });
+
+      const result = manager.moveNoteById("x-coredata://ABC/ICNote/p123", "Archive");
+
+      expect(result).toBe(true);
+      // Single native `move` — no getNoteContentById/create/delete fan-out.
+      expect(mockExecuteAppleScript).toHaveBeenCalledTimes(1);
+      const moveScript = mockExecuteAppleScript.mock.calls[0][0] as string;
+      expect(moveScript).toContain("move noteRef to destFolder");
+      expect(moveScript).not.toContain("make new note");
     });
 
-    it("returns true even if delete fails (note exists in new location)", () => {
-      // This is partial success - note was copied but original couldn't be deleted
-      mockExecuteAppleScript
-        .mockReturnValueOnce({
-          success: true,
-          output: [
-            "My Note",
-            "x-coredata://ABC/ICNote/p123",
-            "Monday, January 1, 2024 at 12:00:00 PM",
-            "Monday, January 1, 2024 at 12:00:00 PM",
-            "false",
-            "false",
-          ].join(F),
-        })
-        .mockReturnValueOnce({
-          success: true,
-          output: "<div>Content</div>",
-        })
-        .mockReturnValueOnce({
-          success: true,
-          output: "note id x-coredata://...",
-        })
-        .mockReturnValueOnce({
-          success: false,
-          output: "",
-          error: "Cannot delete original",
-        });
+    it("returns false when the move fails", () => {
+      mockExecuteAppleScript.mockReturnValueOnce({
+        success: false,
+        output: "",
+        error: "Folder not found",
+      });
 
-      const result = manager.moveNote("My Note", "Archive");
+      const result = manager.moveNoteById("x-coredata://ABC/ICNote/p123", "Nonexistent");
 
-      // Should still return true because the note exists in the destination
-      expect(result).toBe(true);
+      expect(result).toBe(false);
+      expect(mockExecuteAppleScript).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/services/appleNotesManager.ts
+++ b/src/services/appleNotesManager.ts
@@ -36,7 +36,7 @@ import { executeAppleScript } from "@/utils/applescript.js";
 import { getChecklistItems, type ChecklistItem } from "@/utils/checklistParser.js";
 import {
   assertSafeSavePath,
-  readFileBase64,
+  readFileBase64Capped,
   fileSize,
   makeTempDir,
   cleanupTempDir,
@@ -1629,26 +1629,27 @@ export class AppleNotesManager {
   }
 
   /**
-   * Moves a note to a different folder.
+   * Moves a note to a different folder, looked up by title.
    *
-   * Since AppleScript doesn't support direct note moves, this operation:
-   * 1. Retrieves the source note's content
-   * 2. Creates a new note with that content in the destination folder
-   * 3. Deletes the original note (only if copy succeeded)
+   * Uses Notes.app's native `move` command (the same one `batchMoveNotes`
+   * uses), which relocates the note in place — preserving its identity, id,
+   * creation date, AND all embedded attachments (files/images/PDFs/scans/audio).
+   * The previous copy-then-delete implementation rebuilt the note from its body
+   * HTML, which silently dropped attachments and reset the note's identity.
    *
-   * This ensures the note is never lost - if the copy fails, the
-   * original remains untouched. If only the delete fails, the note
-   * exists in the new location (success is still returned).
+   * The note is resolved to its id first (titles can be duplicated), then moved
+   * by id so the title-based and id-based paths share the same native move.
    *
    * @param title - Title of the note to move
-   * @param destinationFolder - Name of the folder to move to
+   * @param destinationFolder - Name of the folder to move to (must already exist)
    * @param account - Account containing the note (defaults to iCloud)
-   * @returns true if move succeeded (or copy succeeded but delete failed)
+   * @returns true if the move succeeded, false otherwise
    */
   moveNote(title: string, destinationFolder: string, account?: string): boolean {
     const targetAccount = this.resolveAccount(account);
 
-    // Step 1: Get the original note's ID first (before creating a copy with the same title)
+    // Resolve the note's id first (titles can be duplicated), then delegate to
+    // the id-based native move so both paths preserve attachments + identity.
     const originalNote = this.getNoteDetails(title, targetAccount);
 
     if (!originalNote) {
@@ -1656,98 +1657,45 @@ export class AppleNotesManager {
       return false;
     }
 
-    // Step 2: Retrieve the original note's content
-    const originalContent = this.getNoteContent(title, targetAccount);
-
-    if (!originalContent) {
-      console.error(`Cannot move note "${title}": failed to retrieve content`);
-      return false;
-    }
-
-    // Step 3: Create a copy in the destination folder
-    // Content is already HTML from getNoteContent(), so use escapeHtmlForAppleScript()
-    const folderRef = buildFolderReference(destinationFolder);
-    const safeContent = escapeHtmlForAppleScript(originalContent);
-
-    const createCommand = `make new note at ${folderRef} with properties {body:"${safeContent}"}`;
-    const script = buildAccountScopedScript({ account: targetAccount }, createCommand);
-    const copyResult = executeAppleScript(script);
-
-    if (!copyResult.success) {
-      console.error(
-        `Cannot move note "${title}": failed to create in destination folder:`,
-        copyResult.error
-      );
-      return false;
-    }
-
-    // Step 4: Delete the original by ID (not by title, since there are now two notes with the same title)
-    const safeOrigId = sanitizeId(originalNote.id);
-    const deleteCommand = `delete note id "${safeOrigId}"`;
-    const deleteScript = buildAppLevelScript(deleteCommand);
-    const deleteResult = executeAppleScript(deleteScript);
-
-    if (!deleteResult.success) {
-      // The note was copied successfully but we couldn't delete the original.
-      // This is still a partial success - the note exists in the new location.
-      console.error(
-        `Note "${title}" was copied to "${destinationFolder}" but original could not be deleted:`,
-        deleteResult.error
-      );
-      return true;
-    }
-
-    return true;
+    return this.moveNoteById(originalNote.id, destinationFolder, targetAccount);
   }
 
   /**
    * Moves a note to a different folder by its CoreData ID.
    *
-   * This is more reliable than moveNote() because IDs are unique,
-   * while titles can be duplicated.
+   * Uses Notes.app's native `move <noteRef> to <destFolder>` command — the same
+   * one `batchMoveNotes` uses — which relocates the note in place, preserving its
+   * id, creation date, and all embedded attachments. (The old copy-then-delete
+   * approach rebuilt the note from body HTML and silently lost attachments.)
    *
    * @param id - CoreData URL identifier for the note
-   * @param destinationFolder - Name of the folder to move to
+   * @param destinationFolder - Name of the folder to move to (must already exist)
    * @param account - Account containing the destination folder (defaults to iCloud)
-   * @returns true if move succeeded (or copy succeeded but delete failed)
+   * @returns true if the move succeeded, false otherwise
    */
   moveNoteById(id: string, destinationFolder: string, account?: string): boolean {
     const targetAccount = this.resolveAccount(account);
     const safeId = sanitizeId(id);
+    const safeAccount = sanitizeAccountName(targetAccount);
+    // buildFolderReference validates the destination path; a malformed folder is
+    // a precondition error, so let it throw. The destination folder must already
+    // exist — Notes.app's `move` does not create it.
+    const destFolderRef = `${buildFolderReference(destinationFolder)} of account "${safeAccount}"`;
 
-    // Step 1: Retrieve the original note's content by ID
-    const originalContent = this.getNoteContentById(id);
+    const moveCommand = `
+      set destFolder to ${destFolderRef}
+      set noteRef to note id "${safeId}"
+      move noteRef to destFolder
+    `;
+    const script = buildAppLevelScript(moveCommand);
+    const result = executeAppleScript(script);
 
-    if (!originalContent) {
-      console.error(`Cannot move note: note with ID "${id}" not found`);
-      return false;
-    }
-
-    // Step 2: Create a copy in the destination folder
-    // Content is already HTML from getNoteContentById(), so use escapeHtmlForAppleScript()
-    const folderRef = buildFolderReference(destinationFolder);
-    const safeContent = escapeHtmlForAppleScript(originalContent);
-
-    const createCommand = `make new note at ${folderRef} with properties {body:"${safeContent}"}`;
-    const script = buildAccountScopedScript({ account: targetAccount }, createCommand);
-    const copyResult = executeAppleScript(script);
-
-    if (!copyResult.success) {
-      console.error(`Cannot move note: failed to create in destination folder:`, copyResult.error);
-      return false;
-    }
-
-    // Step 3: Delete the original by ID
-    const deleteCommand = `delete note id "${safeId}"`;
-    const deleteScript = buildAppLevelScript(deleteCommand);
-    const deleteResult = executeAppleScript(deleteScript);
-
-    if (!deleteResult.success) {
+    if (!result.success) {
       console.error(
-        `Note was copied to "${destinationFolder}" but original could not be deleted:`,
-        deleteResult.error
+        `Cannot move note to "${destinationFolder}" (folder may not exist):`,
+        result.error
       );
-      return true; // Partial success - note exists in new location
+      return false;
     }
 
     return true;
@@ -2534,11 +2482,15 @@ export class AppleNotesManager {
       if (!saved.success || !saved.savedPath) {
         return { success: false, error: saved.error };
       }
+      // readFileBase64Capped checks the file size BEFORE reading and throws if it
+      // exceeds APPLE_NOTES_MCP_MAX_ATTACHMENT_BYTES — the throw is caught below
+      // and the temp dir is still cleaned up in `finally`.
+      const base64 = readFileBase64Capped(saved.savedPath);
       return {
         success: true,
         name: saved.name,
         contentType: saved.contentType,
-        base64: readFileBase64(saved.savedPath),
+        base64,
         bytes: fileSize(saved.savedPath),
       };
     } catch (e) {

--- a/src/utils/attachmentFs.test.ts
+++ b/src/utils/attachmentFs.test.ts
@@ -5,6 +5,8 @@ import { join } from "path";
 import {
   assertSafeSavePath,
   readFileBase64,
+  readFileBase64Capped,
+  maxAttachmentBytes,
   fileSize,
   makeTempDir,
   cleanupTempDir,
@@ -59,5 +61,33 @@ describe("base64 / size / temp helpers (#27)", () => {
     cleanupTempDir(dir);
     expect(existsSync(dir)).toBe(false);
     expect(() => cleanupTempDir(dir)).not.toThrow();
+  });
+});
+
+describe("readFileBase64Capped / maxAttachmentBytes (size guard)", () => {
+  it("reads files at or under the cap", () => {
+    const dir = mkdtempSync(join(tmpdir(), "anatt-"));
+    dirs.push(dir);
+    const f = join(dir, "ok.bin");
+    writeFileSync(f, Buffer.from("hello"));
+    expect(readFileBase64Capped(f, 1024)).toBe(Buffer.from("hello").toString("base64"));
+  });
+
+  it("throws (without reading) when the file exceeds the cap", () => {
+    const dir = mkdtempSync(join(tmpdir(), "anatt-"));
+    dirs.push(dir);
+    const f = join(dir, "big.bin");
+    writeFileSync(f, Buffer.alloc(2048));
+    expect(() => readFileBase64Capped(f, 1024)).toThrow(/exceeding the 1024-byte fetch limit/);
+  });
+
+  it("maxAttachmentBytes honors APPLE_NOTES_MCP_MAX_ATTACHMENT_BYTES and falls back to a sane default", () => {
+    expect(maxAttachmentBytes({ APPLE_NOTES_MCP_MAX_ATTACHMENT_BYTES: "12345" })).toBe(12345);
+    // Invalid / non-positive values fall back to the default (25 MB).
+    expect(maxAttachmentBytes({ APPLE_NOTES_MCP_MAX_ATTACHMENT_BYTES: "0" })).toBe(25 * 1024 * 1024);
+    expect(maxAttachmentBytes({ APPLE_NOTES_MCP_MAX_ATTACHMENT_BYTES: "nope" })).toBe(
+      25 * 1024 * 1024
+    );
+    expect(maxAttachmentBytes({})).toBe(25 * 1024 * 1024);
   });
 });

--- a/src/utils/attachmentFs.ts
+++ b/src/utils/attachmentFs.ts
@@ -31,9 +31,51 @@ export function assertSafeSavePath(p: string, roots: string[] = allowedSaveRoots
   return abs;
 }
 
+/**
+ * Default upper bound on an attachment that `fetch-attachment` will base64-encode
+ * into a single MCP response. `readFileSync` loads the whole file into memory and
+ * base64 grows it ~33%, so an unbounded read of a multi-GB attachment (video,
+ * disk image) could exhaust memory. 25 MB is generous for the inline-fetch use
+ * case (docs, images, PDFs); larger attachments should be exported to disk with
+ * `save-attachment` instead. Overridable via APPLE_NOTES_MCP_MAX_ATTACHMENT_BYTES.
+ */
+const DEFAULT_MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024;
+
+/** Resolve the configured max attachment size (bytes) for inline base64 fetch. */
+export function maxAttachmentBytes(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.APPLE_NOTES_MCP_MAX_ATTACHMENT_BYTES;
+  if (raw !== undefined) {
+    const n = Number(raw);
+    if (Number.isFinite(n) && n > 0) return n;
+  }
+  return DEFAULT_MAX_ATTACHMENT_BYTES;
+}
+
 /** Read a file as base64. */
 export function readFileBase64(p: string): string {
   return readFileSync(p).toString("base64");
+}
+
+/**
+ * Read a file as base64, refusing files larger than `maxBytes`.
+ *
+ * Guards `fetch-attachment` against unbounded in-memory reads: the size is
+ * checked from filesystem metadata BEFORE the file is read, so an oversized
+ * attachment is rejected with a clear error instead of loading it (and its
+ * ~33%-larger base64) into memory. (`APPLE_NOTES_MCP_MAX_BUFFER` does not apply
+ * to `readFileSync`.)
+ *
+ * @throws if the file exceeds `maxBytes`
+ */
+export function readFileBase64Capped(p: string, maxBytes: number = maxAttachmentBytes()): string {
+  const size = fileSize(p);
+  if (size > maxBytes) {
+    throw new Error(
+      `Attachment is ${size} bytes, exceeding the ${maxBytes}-byte fetch limit ` +
+        `(APPLE_NOTES_MCP_MAX_ATTACHMENT_BYTES). Use save-attachment to export it to disk instead.`
+    );
+  }
+  return readFileBase64(p);
 }
 
 /** Byte size of a file (0 if missing). */

--- a/src/utils/syncDetection.test.ts
+++ b/src/utils/syncDetection.test.ts
@@ -16,7 +16,7 @@ import {
 
 // Mock child_process
 vi.mock("child_process", () => ({
-  execSync: vi.fn(),
+  execFileSync: vi.fn(),
 }));
 
 // Mock fs
@@ -25,10 +25,10 @@ vi.mock("fs", () => ({
   statSync: vi.fn(),
 }));
 
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import * as fs from "fs";
 
-const mockExecSync = vi.mocked(execSync);
+const mockExecSync = vi.mocked(execFileSync);
 const mockExistsSync = vi.mocked(fs.existsSync);
 const mockStatSync = vi.mocked(fs.statSync);
 

--- a/src/utils/syncDetection.ts
+++ b/src/utils/syncDetection.ts
@@ -12,7 +12,7 @@
  * @module utils/syncDetection
  */
 
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
@@ -126,11 +126,18 @@ export function getSyncStatus(useCache = true): SyncStatus {
       AND ZLATESTVERSIONSYNCEDTOCLOUD IS NOT NULL;
     `;
 
-    const result = execSync(`sqlite3 -readonly "${NOTES_DB_PATH}" "${query.replace(/\n/g, " ")}"`, {
-      encoding: "utf8",
-      timeout: 5000,
-      stdio: ["pipe", "pipe", "pipe"],
-    });
+    // Use execFileSync (argv array, no shell) to match the sibling sqlite callers
+    // (checklistParser.ts, noteMetadata.ts). The values here aren't user-controlled,
+    // but argv form avoids shell quoting/interpolation entirely.
+    const result = execFileSync(
+      "sqlite3",
+      ["-readonly", NOTES_DB_PATH, query.replace(/\n/g, " ")],
+      {
+        encoding: "utf8",
+        timeout: 5000,
+        stdio: ["pipe", "pipe", "pipe"],
+      }
+    );
 
     status.pendingUpload = parseInt(result.trim(), 10) || 0;
 


### PR DESCRIPTION
## Summary

Reviewed, verified hardening and doc fixes for apple-notes-mcp. The headline item is a **HIGH / data-loss** fix in single-note `move-note`. Bumps `2.5.5` → `2.5.6`.

## Changes

### Fixed
- **`move-note` no longer drops attachments or resets note identity (HIGH / data loss).** The single-note `move-note` (both the by-id and by-title paths) was implemented as **copy-then-delete**: it rebuilt the note from its body HTML in the destination folder and deleted the original, silently discarding every embedded attachment (files, images, PDFs, scans, audio) and resetting the note's id and creation date. It now uses Notes.app's **native `move`** command — the same one `batch-move-notes` already used — which relocates the note in place, preserving id, creation date, and all attachments. The by-title path resolves the note to its id first, then shares the id-based native move. Destination-folder-must-exist behavior and error handling are unchanged.

### Added
- **Configurable cap on inline attachment fetch size.** `fetch-attachment` base64-encodes an attachment into the response via `readFileSync`, which had no upper bound (`APPLE_NOTES_MCP_MAX_BUFFER` does not apply to `readFileSync`), so a multi-GB attachment could exhaust memory. A size check now runs **before** the read and rejects oversized attachments with a clear error pointing at `save-attachment`. Default 25 MB, overridable via the new `APPLE_NOTES_MCP_MAX_ATTACHMENT_BYTES` env var (documented in the README). Temp-dir cleanup is preserved.

### Changed
- **All MCP string/array inputs now have upper bounds.** Every Zod input field previously used only `.min(1)`. Added sane `.max(...)` caps to string fields (query, id, title, content, folder, account, savePath, attachmentId, tags entries, modifiedSince) and `.max(500)` array caps to the unbounded `ids` arrays in `batch-delete-notes` / `batch-move-notes`. Limits mirror the bounds the manager already enforced internally; oversized input is now rejected at the schema boundary with a clear message.
- **`syncDetection` SQLite access converted `execSync` → `execFileSync`** (argv array, no shell), matching the sibling `checklistParser` / `noteMetadata` callers. The interpolated values were not user-controlled, so this is consistency hardening, not a fix for an exploitable bug.
- **Graceful shutdown on SIGINT/SIGTERM and stdin EOF.** Added signal and stdin `end`/`close` handlers that exit cleanly, alongside the existing `uncaughtException`/`unhandledRejection` net. This server holds no persistent resources, so the impact is low; it brings shutdown behavior in line with the sibling apple-mail server.

### Docs
- **`create-note` `tags` documented as returned-only.** The parameter was accepted but never written to Notes.app (Apple Notes tags can't be set via AppleScript). Its description now states the values are echoed back but not applied, and points to in-body `#hashtags` as the way to create real tags. The parameter is still accepted (not dropped) to avoid breaking existing callers.
- **`move-note` tool description** no longer claims a copy-then-delete implementation or warns about attachment loss; it now states the note is relocated in place via the native move.

## Tests
- Rewrote the `moveNote` unit tests and added a `moveNoteById` suite asserting the native `move noteRef to destFolder` script (and that it does **not** emit `make new note`).
- Added `attachmentFs` tests for `readFileBase64Capped` (reads under the cap, throws over it without reading) and `maxAttachmentBytes` (env override + sane default).
- Updated `syncDetection` tests to mock `execFileSync`.

## Verification
- `pnpm run lint` — clean
- `pnpm run typecheck` — clean
- `pnpm test` — 438 passed (16 files)

Note: `build/` is gitignored in this repo (shipped to npm via the `files` field + `prepublishOnly` build), so there is no tracked build output to commit.
