### PR TITLE
fix: format:check drift + create-note returns unusable id (v2.5.7)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-notes",
-      "version": "2.5.6",
+      "version": "2.5.7",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-notes",
-      "version": "2.5.6",
+      "version": "2.5.7",
       "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "apple-notes",
       "description": "Manage Apple Notes through natural language - create, search, read, update, delete, and organize notes and folders",
-      "version": "2.5.6",
+      "version": "2.5.7",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, and organize notes and folders (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.7] - 2026-07-03
+### Fixed
+- **`create-note` now returns a usable note id.** `create-note` returned the raw AppleScript object specifier (`note id x-coredata://<uuid>/ICNote/pN`) — including a literal `note id ` prefix — as the note's `id`. Downstream tools rejected it: `get-note-content id=<that>` failed with `Invalid note ID format: … Expected CoreData URL (x-coredata://...) or temp ID.` The returned specifier is now run through `extractCoreDataId`, so `create-note` returns the bare `x-coredata://` URL that the id validator and all consumers (`get-note-content`, `update-note`, etc.) accept and can round-trip.
+- **CI `format:check` restored to green.** `src/index.ts` and `src/utils/attachmentFs.test.ts` had drifted from Prettier style (unformatted code merged via dependabot PR #63), failing the `format:check` CI gate. Reformatted with `prettier --write`.
+
 ## [2.5.6] - 2026-06-30
 ### Fixed
 - **`move-note` no longer drops attachments or resets note identity (data-loss fix).** The single-note `move-note` was implemented as copy-then-delete: it rebuilt the note from its body HTML in the destination folder and deleted the original, silently discarding every embedded attachment (files, images, PDFs, scans, audio) and resetting the note's creation date and id. It now uses Notes.app's native `move` command — the same one `batch-move-notes` already used — which relocates the note in place, preserving its id, creation date, and all attachments. The destination-folder-must-exist behavior is unchanged. Tests updated to assert the native `move` path (no `make new note`).

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes-mcp",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Notes - create, search, update, and manage notes via Claude and other AI assistants",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1503,10 +1503,7 @@ server.registerTool(
     description:
       "Use when: moving multiple notes by id into one destination folder.\nReturns: per-id success/failure counts.\nDo not use when: moving a single note (move-note).\nNote: the destination folder must already exist (create-folder).",
     inputSchema: {
-      ids: z
-        .array(z.string().max(MAX.ID))
-        .max(MAX.BATCH_IDS)
-        .describe("Array of note IDs to move"),
+      ids: z.array(z.string().max(MAX.ID)).max(MAX.BATCH_IDS).describe("Array of note IDs to move"),
       folder: z.string().max(MAX.FOLDER).describe("Destination folder name"),
       account: z
         .string()

--- a/src/services/appleNotesManager.test.ts
+++ b/src/services/appleNotesManager.test.ts
@@ -424,6 +424,39 @@ describe("AppleNotesManager", () => {
       expect(result?.account).toBe("iCloud"); // Default account
     });
 
+    it("strips the 'note id ' prefix from the returned id (#create-note-id)", () => {
+      // AppleScript's `id of newNote` yields an object specifier with a literal
+      // "note id " prefix. The returned id must be the bare x-coredata:// URL so
+      // downstream tools (get-note-content, update-note) accept it.
+      mockExecuteAppleScript.mockReturnValue({
+        success: true,
+        output: "note id x-coredata://ABC-DEF/ICNote/p42",
+      });
+
+      const result = manager.createNote("Prefixed", "Body");
+
+      expect(result?.id).toBe("x-coredata://ABC-DEF/ICNote/p42");
+      expect(result?.id).not.toMatch(/^note id /);
+    });
+
+    it("returned id round-trips through get-note-content and update-note (#create-note-id)", () => {
+      mockExecuteAppleScript.mockReturnValue({
+        success: true,
+        output: "note id x-coredata://ABC-DEF/ICNote/p99",
+      });
+      const created = manager.createNote("Roundtrip", "Body");
+      const id = created?.id as string;
+      expect(id).toBe("x-coredata://ABC-DEF/ICNote/p99");
+
+      // Reading back by the returned id must not throw "Invalid note ID format".
+      mockExecuteAppleScript.mockReturnValue({ success: true, output: "Body text" });
+      expect(() => manager.getNoteContentById(id)).not.toThrow();
+
+      // Updating by the returned id must not throw either.
+      mockExecuteAppleScript.mockReturnValue({ success: true, output: "" });
+      expect(() => manager.updateNoteById(id, undefined, "New body")).not.toThrow();
+    });
+
     it("returns null when AppleScript fails", () => {
       mockExecuteAppleScript.mockReturnValue({
         success: false,

--- a/src/services/appleNotesManager.ts
+++ b/src/services/appleNotesManager.ts
@@ -704,8 +704,13 @@ export class AppleNotesManager {
       return null;
     }
 
-    // Extract the CoreData ID from the response
-    const noteId = result.output.trim();
+    // Extract the CoreData ID from the response.
+    // AppleScript's `id of newNote` yields an object specifier of the form
+    // "note id x-coredata://<uuid>/ICNote/pN" — with a literal "note id " prefix.
+    // Strip that prefix so we return the bare x-coredata:// URL that the id
+    // validator and downstream tools (get-note-content, update-note) accept.
+    const rawOutput = result.output.trim();
+    const noteId = extractCoreDataId(rawOutput, "note") || rawOutput;
 
     // Return a Note object representing the created note with real ID
     const now = new Date();

--- a/src/utils/attachmentFs.test.ts
+++ b/src/utils/attachmentFs.test.ts
@@ -84,7 +84,9 @@ describe("readFileBase64Capped / maxAttachmentBytes (size guard)", () => {
   it("maxAttachmentBytes honors APPLE_NOTES_MCP_MAX_ATTACHMENT_BYTES and falls back to a sane default", () => {
     expect(maxAttachmentBytes({ APPLE_NOTES_MCP_MAX_ATTACHMENT_BYTES: "12345" })).toBe(12345);
     // Invalid / non-positive values fall back to the default (25 MB).
-    expect(maxAttachmentBytes({ APPLE_NOTES_MCP_MAX_ATTACHMENT_BYTES: "0" })).toBe(25 * 1024 * 1024);
+    expect(maxAttachmentBytes({ APPLE_NOTES_MCP_MAX_ATTACHMENT_BYTES: "0" })).toBe(
+      25 * 1024 * 1024
+    );
     expect(maxAttachmentBytes({ APPLE_NOTES_MCP_MAX_ATTACHMENT_BYTES: "nope" })).toBe(
       25 * 1024 * 1024
     );


### PR DESCRIPTION
Two fixes, one patch bump (v2.5.7).

## BUG 1 — CI \`format:check\` was RED on main (HIGH)
\`src/index.ts\` and \`src/utils/attachmentFs.test.ts\` had drifted from Prettier style (unformatted code merged via dependabot PR #63), failing the \`format:check\` CI gate. Reformatted with \`prettier --write\`.

## BUG 2 — \`create-note\` returned an unusable id (functional)
\`create-note\` returned the raw AppleScript object specifier \`note id x-coredata://<uuid>/ICNote/pN\` — with a literal \`note id \` prefix — as the note's \`id\`. Downstream tools rejected it: \`get-note-content id=<that>\` failed with \`Invalid note ID format: … Expected CoreData URL (x-coredata://...) or temp ID.\`

Fix: \`createNote\` now runs the returned specifier through the existing \`extractCoreDataId\` helper, returning the bare \`x-coredata://\` URL the id validator and all consumers accept.

### Tests
- Added a unit test asserting the returned id has no \`note id \` prefix.
- Added a unit test asserting the returned id round-trips through \`getNoteContentById\` / \`updateNoteById\` without throwing \`Invalid note ID format\`.
- Verified live against real Notes.app: created a REGTEST note, read it back **by the returned id** (body matched), deleted the note and REGTEST folder.

Full gate green: build, lint, typecheck, format:check, unit (440), integration (14).