### PR TITLE
chore: track build/ in git for plugin/git-checkout consistency with mail+numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
 # Dependencies
 node_modules/
 
-# Build output
-build/
+# Build output is intentionally tracked so the marketplace plugin works
+# without an npm install step (Claude Code does not run npm install on
+# path-source plugins). Override the global ~/.gitignore entry.
+!build/
+!build/**
 
 # Test coverage
 coverage/

--- a/build/index.js
+++ b/build/index.js
@@ -1,0 +1,1453 @@
+#!/usr/bin/env node
+/**
+ * Apple Notes MCP Server
+ *
+ * A Model Context Protocol (MCP) server that provides AI assistants
+ * with the ability to interact with Apple Notes on macOS.
+ *
+ * This server exposes tools for:
+ * - Creating, reading, updating, and deleting notes
+ * - Organizing notes into folders
+ * - Searching notes by title or content
+ * - Managing multiple accounts (iCloud, Gmail, Exchange, etc.)
+ *
+ * Architecture:
+ * - Tool definitions are declarative (schema + handler)
+ * - The AppleNotesManager class handles all AppleScript operations
+ * - Error handling is consistent across all tools
+ *
+ * @module apple-notes-mcp
+ * @see https://modelcontextprotocol.io
+ */
+import { createRequire } from "module";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+import { AppleNotesManager } from "./services/appleNotesManager.js";
+import { getSyncStatus, withSyncAwarenessSync } from "./utils/syncDetection.js";
+import { getChecklistItems, hasFullDiskAccess } from "./utils/checklistParser.js";
+import { getNoteMetadata } from "./utils/noteMetadata.js";
+import { detectChecklistAttempt } from "./utils/contentWarnings.js";
+import { parseHashtags } from "./utils/hashtags.js";
+import { runDoctor, formatDoctorReport } from "./tools/doctor.js";
+import { loadFileConfig } from "./services/fileConfig.js";
+import { registerResourcesAndPrompts } from "./tools/resourcesAndPrompts.js";
+// Load file-based config FIRST (#24) — before anything reads APPLE_NOTES_MCP_*.
+// Lets users configure the server when the host app strips the MCP env block.
+loadFileConfig();
+// Read version from package.json to keep it in sync
+const require = createRequire(import.meta.url);
+const { version } = require("../package.json");
+// =============================================================================
+// Server Initialization
+// =============================================================================
+/**
+ * MCP server instance configured for Apple Notes operations.
+ */
+const server = new McpServer({
+    name: "apple-notes",
+    version,
+    description: "MCP server for managing Apple Notes - create, search, update, and organize notes",
+});
+/**
+ * Singleton instance of the Apple Notes manager.
+ * Handles all AppleScript execution and note operations.
+ */
+const notesManager = new AppleNotesManager();
+/**
+ * Creates a successful MCP tool response. Pass `structured` to attach typed JSON
+ * (`structuredContent`) alongside the human-readable text so agents can consume
+ * results without parsing prose (#21).
+ */
+function successResponse(message, structured) {
+    const res = { content: [{ type: "text", text: message }] };
+    if (structured)
+        res.structuredContent = structured;
+    return res;
+}
+/**
+ * Creates an error MCP tool response.
+ */
+function errorResponse(message) {
+    return {
+        content: [{ type: "text", text: message }],
+        isError: true,
+    };
+}
+/**
+ * Wraps a tool handler with consistent error handling.
+ */
+function withErrorHandling(handler, errorPrefix) {
+    return async (params) => {
+        try {
+            return handler(params);
+        }
+        catch (error) {
+            const message = error instanceof Error ? error.message : "Unknown error";
+            return errorResponse(`${errorPrefix}: ${message}`);
+        }
+    };
+}
+// =============================================================================
+// Input Bounds
+// =============================================================================
+/**
+ * Upper bounds on string/array inputs (#validation). Zod's `.min(1)` rejected
+ * empty input but nothing capped the maximum, so a caller could pass an
+ * arbitrarily large string/array straight through to AppleScript. These mirror
+ * the limits the AppleNotesManager already enforces internally (title 2000,
+ * content 5 MB, folder path 1000, account 200) and add sane caps for the rest,
+ * so oversized input is rejected at the schema boundary with a clear message.
+ */
+const MAX = {
+    TITLE: 2000,
+    CONTENT: 5 * 1024 * 1024,
+    FOLDER: 1000,
+    ACCOUNT: 200,
+    QUERY: 2000,
+    ID: 2000,
+    SAVE_PATH: 4096,
+    ATTACHMENT_ID: 2000,
+    TAG: 200,
+    TAGS: 100,
+    BATCH_IDS: 500,
+};
+// =============================================================================
+// Schema Definitions
+// =============================================================================
+/**
+ * Common schema for operations requiring a note title.
+ */
+const noteTitleSchema = {
+    title: z.string().min(1, "Note title is required").max(MAX.TITLE),
+    account: z.string().max(MAX.ACCOUNT).optional().describe("Account name (defaults to iCloud)"),
+};
+/**
+ * Common schema for operations requiring a folder name.
+ */
+const folderNameSchema = {
+    name: z.string().min(1, "Folder name is required").max(MAX.FOLDER),
+    account: z.string().max(MAX.ACCOUNT).optional().describe("Account name (defaults to iCloud)"),
+};
+// =============================================================================
+// Note Tools
+// =============================================================================
+// --- create-note ---
+server.registerTool("create-note", {
+    description: "Use when: the user wants to create a brand-new Apple Note.\nReturns: the new note's title and id — reuse the id for follow-up reads/edits.\nDo not use when: editing an existing note (use update-note).\nNote: the title is prepended as an <h1>; true Apple Notes checklists cannot be created via AppleScript (see the content field).",
+    inputSchema: {
+        title: z.string().min(1, "Title is required").max(MAX.TITLE),
+        content: z
+            .string()
+            .min(1, "Content is required")
+            .max(MAX.CONTENT)
+            .describe('Note body. AppleScript cannot create true Apple Notes checklists — `<input type="checkbox">`, checklist CSS classes, and markdown `- [ ]` lines do not render as checkable items. To produce a checklist, create the note with a plain `<ul>` or `- ` list and convert it in Notes.app with ⇧⌘L.'),
+        format: z
+            .enum(["plaintext", "html"])
+            .optional()
+            .default("plaintext")
+            .describe("Content format: 'plaintext' (default) or 'html' for rich formatting"),
+        tags: z
+            .array(z.string().max(MAX.TAG))
+            .max(MAX.TAGS)
+            .optional()
+            .describe("Returned-only metadata — NOT written to Notes.app. Apple Notes tags can't be set via AppleScript, so any values passed here are echoed back in the response but do not appear on the created note. Use #hashtags inside the content body instead (Notes.app turns those into real tags)."),
+        folder: z
+            .string()
+            .max(MAX.FOLDER)
+            .optional()
+            .describe("Folder to create the note in (supports nested paths like 'Work/Clients')"),
+        account: z.string().max(MAX.ACCOUNT).optional().describe("Account name (defaults to iCloud)"),
+    },
+    outputSchema: {
+        ok: z.boolean().optional(),
+        id: z.string().optional(),
+        title: z.string().optional(),
+        folder: z.string().optional(),
+        account: z.string().optional(),
+    },
+}, withErrorHandling(({ title, content, format = "plaintext", tags = [], folder, account }) => {
+    const note = notesManager.createNote(title, content, tags, folder, account, format);
+    if (!note) {
+        return errorResponse(`Failed to create note "${title}". Check that Notes.app is configured and accessible.`);
+    }
+    const checklistWarning = detectChecklistAttempt(content) ?? "";
+    return successResponse(`Note created: "${note.title}" [id: ${note.id}]${checklistWarning}`, {
+        ok: true,
+        id: note.id,
+        title: note.title,
+        folder,
+        account,
+    });
+}, "Error creating note"));
+// --- search-notes ---
+server.registerTool("search-notes", {
+    description: "Use when: finding notes by a keyword in the title (or body with searchContent=true) and you need their ids.\nReturns: matching notes with title, folder, and id.\nDo not use when: you already have a note id (use get-note-content) or want every note (use list-notes).\nPrefer this first to obtain ids for subsequent read/update/delete/move calls.",
+    inputSchema: {
+        query: z.string().min(1, "Search query is required").max(MAX.QUERY),
+        searchContent: z.boolean().optional().describe("Search note content instead of titles"),
+        account: z.string().max(MAX.ACCOUNT).optional().describe("Account to search in"),
+        folder: z.string().max(MAX.FOLDER).optional().describe("Limit search to a specific folder"),
+        modifiedSince: z
+            .string()
+            .max(64)
+            .optional()
+            .describe("ISO 8601 date string to filter notes modified on or after this date (e.g., '2025-01-01'). Useful for searching only recent notes in large collections."),
+        limit: z.number().int().positive().optional().describe("Maximum number of results to return"),
+    },
+    outputSchema: {
+        notes: z.array(z.object({}).passthrough()).optional(),
+        count: z.number().optional(),
+    },
+}, withErrorHandling(({ query, searchContent = false, account, folder, modifiedSince, limit }) => {
+    // Use sync-aware wrapper for this read operation
+    const { result: notes, syncBefore, syncInterference, } = withSyncAwarenessSync("search-notes", () => notesManager.searchNotes(query, searchContent, account, folder, modifiedSince, limit));
+    const searchType = searchContent ? "content" : "titles";
+    const folderInfo = folder ? ` in folder "${folder}"` : "";
+    const dateInfo = modifiedSince ? ` modified since ${modifiedSince}` : "";
+    const limitInfo = limit ? ` (limit: ${limit})` : "";
+    // Build sync warning if needed
+    const syncWarnings = [];
+    if (syncBefore.syncDetected) {
+        syncWarnings.push(`⚠️ iCloud sync was active during search.`);
+    }
+    if (syncInterference) {
+        syncWarnings.push(`⚠️ Sync activity detected - results may be incomplete.`);
+    }
+    const syncNote = syncWarnings.length > 0 ? `\n\n${syncWarnings.join(" ")}` : "";
+    if (notes.length === 0) {
+        return successResponse(`No notes found matching "${query}" in ${searchType}${folderInfo}${dateInfo}${syncNote}`, { notes: [], count: 0 });
+    }
+    // Format each note with ID and folder info, highlighting Recently Deleted
+    const noteList = notes
+        .map((n) => {
+        const idSuffix = n.id ? ` [id: ${n.id}]` : "";
+        if (n.folder === "Recently Deleted") {
+            return `  - ${n.title} [DELETED]${idSuffix}`;
+        }
+        else if (n.folder) {
+            return `  - ${n.title} (${n.folder})${idSuffix}`;
+        }
+        return `  - ${n.title}${idSuffix}`;
+    })
+        .join("\n");
+    return successResponse(`Found ${notes.length} notes (searched ${searchType}${folderInfo}${dateInfo}${limitInfo}):\n${noteList}${syncNote}`, { notes, count: notes.length });
+}, "Error searching notes"));
+// --- get-note-content ---
+server.registerTool("get-note-content", {
+    description: "Use when: reading the full body text of one known note, by id (preferred) or title.\nReturns: the note's content plus parsed hashtags.\nDo not use when: you only need metadata (get-note-details) or Markdown with checklist state (get-note-markdown).\nNote: password-protected notes must be unlocked in Notes.app first.",
+    inputSchema: {
+        id: z
+            .string()
+            .max(MAX.ID)
+            .optional()
+            .describe("Note ID (preferred - more reliable than title)"),
+        title: z
+            .string()
+            .max(MAX.TITLE)
+            .optional()
+            .describe("Note title (use id instead when available)"),
+        account: z
+            .string()
+            .max(MAX.ACCOUNT)
+            .optional()
+            .describe("Account name (defaults to iCloud, ignored if id is provided)"),
+    },
+    outputSchema: {
+        title: z.string().optional(),
+        content: z.string().optional(),
+        hashtags: z.array(z.string()).optional(),
+    },
+}, withErrorHandling(({ id, title, account }) => {
+    // Prefer ID-based lookup if provided
+    if (id) {
+        // Check for password protection first for better error message
+        const note = notesManager.getNoteById(id);
+        if (!note) {
+            return errorResponse(`Note with ID "${id}" not found`);
+        }
+        if (note.passwordProtected) {
+            return errorResponse(`Note "${note.title}" is password-protected and cannot be read. Unlock it in Notes.app first.`);
+        }
+        const content = notesManager.getNoteContentById(id);
+        if (!content) {
+            return errorResponse(`Failed to read content of note "${note.title}"`);
+        }
+        const hashtags = parseHashtags(content);
+        return successResponse(content, { title: note.title, content, hashtags });
+    }
+    // Fall back to title-based lookup
+    if (!title) {
+        return errorResponse("Either 'id' or 'title' is required");
+    }
+    // Check for password protection first for better error message
+    const note = notesManager.getNoteDetails(title, account);
+    if (!note) {
+        return errorResponse(`Note "${title}" not found`);
+    }
+    if (note.passwordProtected) {
+        return errorResponse(`Note "${title}" is password-protected and cannot be read. Unlock it in Notes.app first.`);
+    }
+    const content = notesManager.getNoteContent(title, account);
+    if (!content) {
+        return errorResponse(`Failed to read content of note "${title}"`);
+    }
+    const hashtags = parseHashtags(content);
+    return successResponse(content, { title, content, hashtags });
+}, "Error retrieving note content"));
+// --- get-note-plaintext ---
+server.registerTool("get-note-plaintext", {
+    description: "Use when: reading one note's body as plain text with no HTML, by id (preferred) or title.\nReturns: the note's plaintext exactly as Notes exposes it.\nDo not use when: you need the HTML body (get-note-content) or Markdown with checklist state (get-note-markdown).\nNote: this reads the note's native plaintext property, so it skips the HTML-to-text conversion; password-protected notes must be unlocked in Notes.app first.",
+    inputSchema: {
+        id: z
+            .string()
+            .max(MAX.ID)
+            .optional()
+            .describe("Note ID (preferred - more reliable than title)"),
+        title: z
+            .string()
+            .max(MAX.TITLE)
+            .optional()
+            .describe("Note title (use id instead when available)"),
+        account: z
+            .string()
+            .max(MAX.ACCOUNT)
+            .optional()
+            .describe("Account name (defaults to iCloud, ignored if id is provided)"),
+    },
+    outputSchema: {
+        title: z.string().optional(),
+        plaintext: z.string().optional(),
+    },
+}, withErrorHandling(({ id, title, account }) => {
+    // Prefer ID-based lookup if provided
+    if (id) {
+        const note = notesManager.getNoteById(id);
+        if (!note) {
+            return errorResponse(`Note with ID "${id}" not found`);
+        }
+        if (note.passwordProtected) {
+            return errorResponse(`Note "${note.title}" is password-protected and cannot be read. Unlock it in Notes.app first.`);
+        }
+        const plaintext = notesManager.getNotePlaintextById(id);
+        if (!plaintext) {
+            return errorResponse(`Failed to read plaintext of note "${note.title}"`);
+        }
+        return successResponse(plaintext, { title: note.title, plaintext });
+    }
+    // Fall back to title-based lookup
+    if (!title) {
+        return errorResponse("Either 'id' or 'title' is required");
+    }
+    const note = notesManager.getNoteDetails(title, account);
+    if (!note) {
+        return errorResponse(`Note "${title}" not found`);
+    }
+    if (note.passwordProtected) {
+        return errorResponse(`Note "${title}" is password-protected and cannot be read. Unlock it in Notes.app first.`);
+    }
+    const plaintext = notesManager.getNotePlaintext(title, account);
+    if (!plaintext) {
+        return errorResponse(`Failed to read plaintext of note "${title}"`);
+    }
+    return successResponse(plaintext, { title, plaintext });
+}, "Error retrieving note plaintext"));
+// --- get-note-by-id ---
+server.registerTool("get-note-by-id", {
+    description: "Use when: you have a note id and need its metadata only.\nReturns: id, title, created, modified, shared, passwordProtected.\nDo not use when: you need the body text (get-note-content) or only have a title (get-note-details).",
+    inputSchema: {
+        id: z.string().min(1, "Note ID is required").max(MAX.ID),
+    },
+    outputSchema: {
+        id: z.string().optional(),
+        title: z.string().optional(),
+        created: z.string().optional(),
+        modified: z.string().optional(),
+        shared: z.boolean().optional(),
+        passwordProtected: z.boolean().optional(),
+    },
+}, withErrorHandling(({ id }) => {
+    const note = notesManager.getNoteById(id);
+    if (!note) {
+        return errorResponse(`Note with ID "${id}" not found`);
+    }
+    // Return structured metadata as JSON
+    const metadata = {
+        id: note.id,
+        title: note.title,
+        created: note.created.toISOString(),
+        modified: note.modified.toISOString(),
+        shared: note.shared,
+        passwordProtected: note.passwordProtected,
+    };
+    return successResponse(JSON.stringify(metadata, null, 2), metadata);
+}, "Error retrieving note"));
+// --- get-note-details ---
+server.registerTool("get-note-details", {
+    description: "Use when: you have a note title (not an id) and need its metadata.\nReturns: id, title, created, modified, shared, passwordProtected, account.\nDo not use when: you have an id (get-note-by-id) or need the body text (get-note-content).\nUse the returned id for reliable follow-up operations.",
+    inputSchema: noteTitleSchema,
+    outputSchema: {
+        id: z.string().optional(),
+        title: z.string().optional(),
+        created: z.string().optional(),
+        modified: z.string().optional(),
+        shared: z.boolean().optional(),
+        passwordProtected: z.boolean().optional(),
+        account: z.string().optional(),
+    },
+}, withErrorHandling(({ title, account }) => {
+    const note = notesManager.getNoteDetails(title, account);
+    if (!note) {
+        return errorResponse(`Note "${title}" not found`);
+    }
+    // Return structured metadata as JSON
+    const metadata = {
+        id: note.id,
+        title: note.title,
+        created: note.created.toISOString(),
+        modified: note.modified.toISOString(),
+        shared: note.shared,
+        passwordProtected: note.passwordProtected,
+        account: note.account,
+    };
+    return successResponse(JSON.stringify(metadata, null, 2), metadata);
+}, "Error retrieving note details"));
+// --- show-note ---
+server.registerTool("show-note", {
+    description: "Use when: the user wants to reveal a known note in Notes.app by id.\nReturns: confirmation that Notes.app accepted the show command.\nDo not use when: you only need note content (get-note-content) or metadata (get-note-by-id).\nNote: this opens or focuses the Notes UI.",
+    inputSchema: {
+        id: z.string().min(1, "Note ID is required").max(MAX.ID),
+        separately: z
+            .boolean()
+            .optional()
+            .describe("Open in a separate note window when supported by Notes.app"),
+    },
+    outputSchema: {
+        id: z.string().optional(),
+        separately: z.boolean().optional(),
+    },
+}, withErrorHandling(({ id, separately = false }) => {
+    const success = notesManager.showNoteById(id, separately);
+    if (!success) {
+        return errorResponse(`Failed to show note with ID "${id}"`);
+    }
+    return successResponse(`Shown note with ID "${id}" in Notes.app`, { id, separately });
+}, "Error showing note"));
+// --- show-folder ---
+server.registerTool("show-folder", {
+    description: "Use when: the user wants to reveal a known folder in Notes.app by id.\nReturns: confirmation that Notes.app accepted the show command.\nDo not use when: you only need the folder list (list-folders).\nNote: this opens or focuses the Notes UI. Get the id from list-folders.",
+    inputSchema: {
+        id: z.string().min(1, "Folder ID is required").max(MAX.ID),
+        separately: z
+            .boolean()
+            .optional()
+            .describe("Open in a separate window when supported by Notes.app"),
+    },
+    outputSchema: {
+        id: z.string().optional(),
+        separately: z.boolean().optional(),
+    },
+}, withErrorHandling(({ id, separately = false }) => {
+    const success = notesManager.showFolderById(id, separately);
+    if (!success) {
+        return errorResponse(`Failed to show folder with ID "${id}"`);
+    }
+    return successResponse(`Shown folder with ID "${id}" in Notes.app`, { id, separately });
+}, "Error showing folder"));
+// --- show-account ---
+server.registerTool("show-account", {
+    description: "Use when: the user wants to reveal a known account in Notes.app by id.\nReturns: confirmation that Notes.app accepted the show command.\nDo not use when: you only need the account list (list-accounts).\nNote: this opens or focuses the Notes UI. Get the id from list-accounts.",
+    inputSchema: {
+        id: z.string().min(1, "Account ID is required").max(MAX.ID),
+        separately: z
+            .boolean()
+            .optional()
+            .describe("Open in a separate window when supported by Notes.app"),
+    },
+    outputSchema: {
+        id: z.string().optional(),
+        separately: z.boolean().optional(),
+    },
+}, withErrorHandling(({ id, separately = false }) => {
+    const success = notesManager.showAccountById(id, separately);
+    if (!success) {
+        return errorResponse(`Failed to show account with ID "${id}"`);
+    }
+    return successResponse(`Shown account with ID "${id}" in Notes.app`, { id, separately });
+}, "Error showing account"));
+// --- update-note ---
+server.registerTool("update-note", {
+    description: "Use when: changing the title and/or replacing the body of an existing note, by id (preferred) or title.\nReturns: confirmation; warns when the note is shared.\nDo not use when: creating a new note (create-note).\nSafety: newContent REPLACES the entire body — it does not append. Read the note first if you need to preserve existing text, and run list-attachments first when the note may hold files, images, scans, PDFs, or audio, since a full-body replace can drop embedded attachments. Edits to shared notes are immediately visible to all collaborators.",
+    inputSchema: {
+        id: z
+            .string()
+            .max(MAX.ID)
+            .optional()
+            .describe("Note ID (preferred - more reliable than title)"),
+        title: z
+            .string()
+            .max(MAX.TITLE)
+            .optional()
+            .describe("Current note title (use id instead when available)"),
+        newTitle: z.string().max(MAX.TITLE).optional().describe("New title for the note"),
+        newContent: z
+            .string()
+            .min(1, "New content is required")
+            .max(MAX.CONTENT)
+            .describe("New note body. AppleScript cannot produce true Apple Notes checklists; checkbox inputs and `- [ ]` markdown do not render as checkable items. Use a plain list and convert in Notes.app with ⇧⌘L."),
+        format: z
+            .enum(["plaintext", "html"])
+            .optional()
+            .default("plaintext")
+            .describe("Content format: 'plaintext' (default) or 'html' for rich formatting"),
+        account: z
+            .string()
+            .max(MAX.ACCOUNT)
+            .optional()
+            .describe("Account containing the note (ignored if id is provided)"),
+    },
+    outputSchema: {
+        ok: z.boolean().optional(),
+        id: z.string().optional(),
+        title: z.string().optional(),
+        shared: z.boolean().optional(),
+    },
+}, withErrorHandling(({ id, title, newTitle, newContent, format = "plaintext", account }) => {
+    // Prefer ID-based update if provided
+    if (id) {
+        // Check for password protection first for better error message
+        const note = notesManager.getNoteById(id);
+        if (!note) {
+            return errorResponse(`Note with ID "${id}" not found`);
+        }
+        if (note.passwordProtected) {
+            return errorResponse(`Note "${note.title}" is password-protected and cannot be updated. Unlock it in Notes.app first.`);
+        }
+        const success = notesManager.updateNoteById(id, newTitle, newContent, format);
+        if (!success) {
+            return errorResponse(`Failed to update note "${note.title}"`);
+        }
+        const displayTitle = newTitle || note.title;
+        // Add collaboration warning if note is shared
+        const sharedWarning = note.shared
+            ? "\n\n⚠️ This note is shared with collaborators. Your changes will be visible to them."
+            : "";
+        const checklistWarning = detectChecklistAttempt(newContent) ?? "";
+        return successResponse(`Note updated: "${displayTitle}"${sharedWarning}${checklistWarning}`, {
+            ok: true,
+            id,
+            title: displayTitle,
+            shared: note.shared ?? false,
+        });
+    }
+    // Fall back to title-based update
+    if (!title) {
+        return errorResponse("Either 'id' or 'title' is required");
+    }
+    // Check for password protection first for better error message
+    const note = notesManager.getNoteDetails(title, account);
+    if (!note) {
+        return errorResponse(`Note "${title}" not found. Use search-notes to find notes, then use the note's ID for reliable operations.`);
+    }
+    if (note.passwordProtected) {
+        return errorResponse(`Note "${title}" is password-protected and cannot be updated. Unlock it in Notes.app first.`);
+    }
+    const success = notesManager.updateNote(title, newTitle, newContent, account, format);
+    if (!success) {
+        return errorResponse(`Failed to update note "${title}"`);
+    }
+    const finalTitle = newTitle || title;
+    // Add collaboration warning if note is shared
+    const sharedWarning = note.shared
+        ? "\n\n⚠️ This note is shared with collaborators. Your changes will be visible to them."
+        : "";
+    const checklistWarning = detectChecklistAttempt(newContent) ?? "";
+    return successResponse(`Note updated: "${finalTitle}"${sharedWarning}${checklistWarning}`, {
+        ok: true,
+        title: finalTitle,
+        shared: note.shared ?? false,
+    });
+}, "Error updating note"));
+// --- delete-note ---
+server.registerTool("delete-note", {
+    description: "Use when: permanently deleting a single note, by id (preferred) or title.\nReturns: confirmation; warns when the note was shared.\nDo not use when: deleting many notes (batch-delete-notes) or just relocating one (move-note).\nSafety: requires explicit user confirmation before deleting. Prefer search-notes/list-notes first to show the affected note id and title. Deleting a shared note removes collaborator access.",
+    inputSchema: {
+        id: z
+            .string()
+            .max(MAX.ID)
+            .optional()
+            .describe("Note ID (preferred - more reliable than title)"),
+        title: z
+            .string()
+            .max(MAX.TITLE)
+            .optional()
+            .describe("Note title (use id instead when available)"),
+        account: z
+            .string()
+            .max(MAX.ACCOUNT)
+            .optional()
+            .describe("Account name (defaults to iCloud, ignored if id is provided)"),
+    },
+    outputSchema: {
+        ok: z.boolean().optional(),
+        id: z.string().optional(),
+        title: z.string().optional(),
+        wasShared: z.boolean().optional(),
+    },
+}, withErrorHandling(({ id, title, account }) => {
+    // Prefer ID-based deletion if provided
+    if (id) {
+        // Verify note exists first for better error message
+        const note = notesManager.getNoteById(id);
+        if (!note) {
+            return errorResponse(`Note with ID "${id}" not found`);
+        }
+        const success = notesManager.deleteNoteById(id);
+        if (!success) {
+            return errorResponse(`Failed to delete note "${note.title}"`);
+        }
+        // Add collaboration warning if note was shared
+        const sharedWarning = note.shared
+            ? "\n\n⚠️ This note was shared with collaborators. They will no longer have access."
+            : "";
+        return successResponse(`Note deleted: "${note.title}"${sharedWarning}`, {
+            ok: true,
+            id,
+            title: note.title,
+            wasShared: note.shared ?? false,
+        });
+    }
+    // Fall back to title-based deletion
+    if (!title) {
+        return errorResponse("Either 'id' or 'title' is required");
+    }
+    // Verify note exists first for better error message
+    const note = notesManager.getNoteDetails(title, account);
+    if (!note) {
+        return errorResponse(`Note "${title}" not found. Use search-notes to find notes, then use the note's ID for reliable operations.`);
+    }
+    const success = notesManager.deleteNote(title, account);
+    if (!success) {
+        return errorResponse(`Failed to delete note "${title}"`);
+    }
+    // Add collaboration warning if note was shared
+    const sharedWarning = note.shared
+        ? "\n\n⚠️ This note was shared with collaborators. They will no longer have access."
+        : "";
+    return successResponse(`Note deleted: "${title}"${sharedWarning}`, {
+        ok: true,
+        title,
+        wasShared: note.shared ?? false,
+    });
+}, "Error deleting note"));
+// --- move-note ---
+server.registerTool("move-note", {
+    description: "Use when: moving one note to a different folder, by id (preferred) or title.\nReturns: confirmation of the note and destination folder.\nDo not use when: moving many notes (batch-move-notes).\nNote: the note is relocated in place via Notes.app's native move, preserving its id, creation date, and all attachments. The destination folder must already exist (create-folder).",
+    inputSchema: {
+        id: z
+            .string()
+            .max(MAX.ID)
+            .optional()
+            .describe("Note ID (preferred - more reliable than title)"),
+        title: z
+            .string()
+            .max(MAX.TITLE)
+            .optional()
+            .describe("Note title (use id instead when available)"),
+        folder: z.string().min(1, "Destination folder is required").max(MAX.FOLDER),
+        account: z
+            .string()
+            .max(MAX.ACCOUNT)
+            .optional()
+            .describe("Account containing the note/folder"),
+    },
+    outputSchema: {
+        ok: z.boolean().optional(),
+        id: z.string().optional(),
+        title: z.string().optional(),
+        folder: z.string().optional(),
+    },
+}, withErrorHandling(({ id, title, folder, account }) => {
+    // Prefer ID-based move if provided
+    if (id) {
+        // Verify note exists first for better error message
+        const note = notesManager.getNoteById(id);
+        if (!note) {
+            return errorResponse(`Note with ID "${id}" not found`);
+        }
+        const success = notesManager.moveNoteById(id, folder, account);
+        if (!success) {
+            return errorResponse(`Failed to move note "${note.title}" to folder "${folder}". Folder may not exist.`);
+        }
+        return successResponse(`Note moved: "${note.title}" -> "${folder}"`, {
+            ok: true,
+            id,
+            title: note.title,
+            folder,
+        });
+    }
+    // Fall back to title-based move
+    if (!title) {
+        return errorResponse("Either 'id' or 'title' is required");
+    }
+    // Verify note exists first for better error message
+    const note = notesManager.getNoteDetails(title, account);
+    if (!note) {
+        return errorResponse(`Note "${title}" not found. Use search-notes to find notes, then use the note's ID for reliable operations.`);
+    }
+    const success = notesManager.moveNote(title, folder, account);
+    if (!success) {
+        return errorResponse(`Failed to move note "${title}" to folder "${folder}". Folder may not exist.`);
+    }
+    return successResponse(`Note moved: "${title}" -> "${folder}"`, {
+        ok: true,
+        title,
+        folder,
+    });
+}, "Error moving note"));
+// --- list-notes ---
+server.registerTool("list-notes", {
+    description: "Use when: enumerating notes in an account or folder; supports modifiedSince and limit for large collections.\nReturns: note titles only (no content or ids).\nDo not use when: you need content (get-note-content) or ids for follow-up edits (use search-notes).\nNote: warns if iCloud sync is active and results may be partial.",
+    inputSchema: {
+        account: z.string().max(MAX.ACCOUNT).optional().describe("Account to list notes from"),
+        folder: z.string().max(MAX.FOLDER).optional().describe("Filter to specific folder"),
+        modifiedSince: z
+            .string()
+            .max(64)
+            .optional()
+            .describe("ISO 8601 date string to filter notes modified on or after this date (e.g., '2025-01-01'). Useful for listing only recent notes in large collections."),
+        limit: z.number().int().positive().optional().describe("Maximum number of notes to return"),
+    },
+    outputSchema: {
+        notes: z.array(z.string()).optional(),
+        count: z.number().optional(),
+    },
+}, withErrorHandling(({ account, folder, modifiedSince, limit }) => {
+    // Use sync-aware wrapper for this read operation
+    const { result: notes, syncBefore, syncInterference, } = withSyncAwarenessSync("list-notes", () => notesManager.listNotes(account, folder, modifiedSince, limit));
+    // Build context string for the response
+    const location = folder ? ` in folder "${folder}"` : "";
+    const acct = account ? ` (${account})` : "";
+    const dateInfo = modifiedSince ? ` modified since ${modifiedSince}` : "";
+    const limitInfo = limit ? ` (limit: ${limit})` : "";
+    // Build sync warning if needed
+    const syncWarnings = [];
+    if (syncBefore.syncDetected) {
+        syncWarnings.push(`⚠️ iCloud sync was active.`);
+    }
+    if (syncInterference) {
+        syncWarnings.push(`Results may be incomplete.`);
+    }
+    const syncNote = syncWarnings.length > 0 ? `\n\n${syncWarnings.join(" ")}` : "";
+    if (notes.length === 0) {
+        return successResponse(`No notes found${location}${acct}${dateInfo}${syncNote}`, {
+            notes: [],
+            count: 0,
+        });
+    }
+    const noteList = notes.map((t) => `  - ${t}`).join("\n");
+    return successResponse(`Found ${notes.length} notes${location}${acct}${dateInfo}${limitInfo}:\n${noteList}${syncNote}`, { notes, count: notes.length });
+}, "Error listing notes"));
+// --- get-selected-notes ---
+server.registerTool("get-selected-notes", {
+    description: "Use when: the user asks what note(s) are currently selected in Notes.app.\nReturns: selected note metadata with ids for follow-up operations.\nDo not use when: searching all notes (search-notes) or listing a folder (list-notes).\nNote: reads Notes.app UI selection; it may be empty if Notes is closed or no note is selected.",
+    inputSchema: {},
+    outputSchema: {
+        notes: z.array(z.object({}).passthrough()).optional(),
+        count: z.number().optional(),
+    },
+}, withErrorHandling(() => {
+    const notes = notesManager.getSelectedNotes();
+    if (notes.length === 0) {
+        return successResponse("No notes are currently selected in Notes.app", {
+            notes: [],
+            count: 0,
+        });
+    }
+    const noteList = notes.map((n) => `  - ${n.title} [id: ${n.id}]`).join("\n");
+    return successResponse(`Selected note(s):\n${noteList}`, { notes, count: notes.length });
+}, "Error getting selected notes"));
+// =============================================================================
+// Folder Tools
+// =============================================================================
+// --- list-folders ---
+server.registerTool("list-folders", {
+    description: "Use when: listing all folders, with full nested paths, for an account.\nReturns: folder names/paths.\nDo not use when: listing notes (list-notes).\nNote: warns if iCloud sync is active.",
+    inputSchema: {
+        account: z.string().max(MAX.ACCOUNT).optional().describe("Account to list folders from"),
+    },
+    outputSchema: {
+        folders: z.array(z.object({}).passthrough()).optional(),
+        count: z.number().optional(),
+    },
+}, withErrorHandling(({ account }) => {
+    // Use sync-aware wrapper for this read operation
+    const { result: folders, syncBefore, syncInterference, } = withSyncAwarenessSync("list-folders", () => notesManager.listFolders(account));
+    const acct = account ? ` (${account})` : "";
+    // Build sync warning if needed
+    const syncWarnings = [];
+    if (syncBefore.syncDetected) {
+        syncWarnings.push(`⚠️ iCloud sync was active.`);
+    }
+    if (syncInterference) {
+        syncWarnings.push(`Results may be incomplete.`);
+    }
+    const syncNote = syncWarnings.length > 0 ? `\n\n${syncWarnings.join(" ")}` : "";
+    if (folders.length === 0) {
+        return successResponse(`No folders found${acct}${syncNote}`, { folders: [], count: 0 });
+    }
+    const folderList = folders.map((f) => `  - ${f.name}`).join("\n");
+    return successResponse(`Found ${folders.length} folders${acct}:\n${folderList}${syncNote}`, {
+        folders,
+        count: folders.length,
+    });
+}, "Error listing folders"));
+// --- create-folder ---
+server.registerTool("create-folder", {
+    description: "Use when: creating a folder, including nested paths like 'Work/Clients' (intermediate folders are created, existing ones skipped).\nReturns: confirmation.\nDo not use when: creating a note (create-note).",
+    inputSchema: {
+        name: z
+            .string()
+            .min(1, "Folder name is required")
+            .max(MAX.FOLDER)
+            .describe('Folder name or nested path separated by "/". E.g., "Retro Tech/PC/CPUs" creates all intermediate folders. Existing segments are skipped.'),
+        account: z.string().max(MAX.ACCOUNT).optional().describe("Account name (defaults to iCloud)"),
+    },
+    outputSchema: {
+        ok: z.boolean().optional(),
+        folder: z.string().optional(),
+    },
+}, withErrorHandling(({ name, account }) => {
+    const folder = notesManager.createFolder(name, account);
+    if (!folder) {
+        return errorResponse(`Failed to create folder "${name}".`);
+    }
+    return successResponse(`Folder created: "${folder.name}"`, {
+        ok: true,
+        folder: folder.name,
+    });
+}, "Error creating folder"));
+// --- delete-folder ---
+server.registerTool("delete-folder", {
+    description: "Use when: deleting an existing folder by name or nested path.\nReturns: confirmation.\nDo not use when: deleting a note (delete-note).\nSafety: requires explicit user confirmation. Deletion fails if the folder still contains notes — list or move those notes first.",
+    inputSchema: folderNameSchema,
+    outputSchema: {
+        ok: z.boolean().optional(),
+        folder: z.string().optional(),
+    },
+}, withErrorHandling(({ name, account }) => {
+    const success = notesManager.deleteFolder(name, account);
+    if (!success) {
+        return errorResponse(`Failed to delete folder "${name}". Folder may not exist or may contain notes.`);
+    }
+    return successResponse(`Folder deleted: "${name}"`, { ok: true, folder: name });
+}, "Error deleting folder"));
+// =============================================================================
+// Account Tools
+// =============================================================================
+// --- list-accounts ---
+server.registerTool("list-accounts", {
+    description: "Use when: discovering which Notes accounts exist (iCloud, Gmail, Exchange, etc.) before targeting one.\nReturns: account names.\nDo not use when: you already know the account, or are working by note id (ids are account-independent).",
+    inputSchema: {},
+    outputSchema: {
+        accounts: z.array(z.object({}).passthrough()).optional(),
+        count: z.number().optional(),
+    },
+}, withErrorHandling(() => {
+    const accounts = notesManager.listAccounts();
+    if (accounts.length === 0) {
+        return successResponse("No Notes accounts found", { accounts: [], count: 0 });
+    }
+    const accountList = accounts
+        .map((a) => {
+        const defaultFolder = a.defaultFolder ? ` (default folder: ${a.defaultFolder})` : "";
+        const upgraded = a.upgraded === undefined ? "" : `, upgraded: ${a.upgraded ? "yes" : "no"}`;
+        return `  - ${a.name}${defaultFolder}${upgraded}`;
+    })
+        .join("\n");
+    return successResponse(`Found ${accounts.length} accounts:\n${accountList}`, {
+        accounts,
+        count: accounts.length,
+    });
+}, "Error listing accounts"));
+// --- get-default-location ---
+server.registerTool("get-default-location", {
+    description: "Use when: discovering where Notes.app will create new notes by default.\nReturns: default account and default folder metadata.\nDo not use when: you already have an explicit account/folder target.",
+    inputSchema: {},
+    outputSchema: {
+        account: z.object({}).passthrough().optional(),
+        folder: z.object({}).passthrough().optional(),
+    },
+}, withErrorHandling(() => {
+    const location = notesManager.getDefaultLocation();
+    const message = `Default account: ${location.account.name} [id: ${location.account.id}]\n` +
+        `Default folder: ${location.folder.name} [id: ${location.folder.id}]`;
+    return successResponse(message, { ...location });
+}, "Error getting default Notes location"));
+// =============================================================================
+// Collaboration Tools
+// =============================================================================
+// --- list-shared-notes ---
+server.registerTool("list-shared-notes", {
+    description: "Use when: finding notes shared with collaborators.\nReturns: shared notes with title, account, and id.\nDo not use when: searching all notes (search-notes).\nNote: edits or deletes to these notes affect all collaborators.",
+    inputSchema: {},
+    outputSchema: {
+        notes: z.array(z.object({}).passthrough()).optional(),
+        count: z.number().optional(),
+    },
+}, withErrorHandling(() => {
+    const sharedNotes = notesManager.listSharedNotes();
+    if (sharedNotes.length === 0) {
+        return successResponse("No shared notes found. You have no notes shared with collaborators.", { notes: [], count: 0 });
+    }
+    const noteList = sharedNotes
+        .map((n) => {
+        const accountInfo = n.account ? ` (${n.account})` : "";
+        return `  - ${n.title}${accountInfo} [id: ${n.id}]`;
+    })
+        .join("\n");
+    return successResponse(`Found ${sharedNotes.length} shared note(s):\n${noteList}\n\n` +
+        `⚠️ Changes to shared notes are visible to all collaborators.`, { notes: sharedNotes, count: sharedNotes.length });
+}, "Error listing shared notes"));
+// =============================================================================
+// Diagnostics Tools
+// =============================================================================
+// --- get-sync-status ---
+server.registerTool("get-sync-status", {
+    description: "Use when: checking whether iCloud sync is in progress before trusting read results.\nReturns: sync active/idle, pending upload count, and seconds since last change.\nDo not use when: you need note data — this is a read-only diagnostics tool.",
+    inputSchema: {},
+    outputSchema: {
+        syncDetected: z.boolean().optional(),
+        pendingUpload: z.number().optional(),
+        secondsSinceLastChange: z.number().optional(),
+        recentActivity: z.boolean().optional(),
+        warning: z.string().optional(),
+        error: z.string().optional(),
+    },
+}, withErrorHandling(() => {
+    const status = getSyncStatus();
+    if (status.error) {
+        return successResponse(`⚠️ Sync status unknown: ${status.error}`, { ...status });
+    }
+    const lines = [];
+    if (status.syncDetected) {
+        lines.push("🔄 iCloud Sync: ACTIVE");
+        lines.push("");
+        if (status.pendingUpload > 0) {
+            lines.push(`  • ${status.pendingUpload} item(s) pending upload`);
+        }
+        if (status.recentActivity) {
+            lines.push(`  • Database modified ${status.secondsSinceLastChange}s ago`);
+        }
+        lines.push("");
+        lines.push("⚠️ Note: Operations may return incomplete results during sync.");
+    }
+    else {
+        lines.push("✓ iCloud Sync: Idle");
+        lines.push("");
+        lines.push(`  Last activity: ${status.secondsSinceLastChange}s ago`);
+    }
+    return successResponse(lines.join("\n"), { ...status });
+}, "Error checking sync status"));
+// --- health-check ---
+server.registerTool("health-check", {
+    description: "Use when: a quick check that Notes.app is reachable and (optionally) Full Disk Access is granted for checklist features.\nReturns: pass/fail per check.\nDo not use when: you need detailed, actionable setup diagnostics (use doctor).\nRead-only.",
+    inputSchema: {},
+    outputSchema: {
+        healthy: z.boolean().optional(),
+        checks: z.array(z.object({}).passthrough()).optional(),
+        fullDiskAccess: z.boolean().optional(),
+    },
+}, withErrorHandling(() => {
+    const result = notesManager.healthCheck();
+    const statusIcon = result.healthy ? "✓" : "✗";
+    const statusText = result.healthy ? "All checks passed" : "Issues detected";
+    const checkLines = result.checks
+        .map((c) => {
+        const icon = c.passed ? "✓" : "✗";
+        return `  ${icon} ${c.name}: ${c.message}`;
+    })
+        .join("\n");
+    // Check Full Disk Access for checklist features
+    const fdaAvailable = hasFullDiskAccess();
+    const fdaLine = fdaAvailable
+        ? "  ✓ full_disk_access: Granted (checklist features available)"
+        : "  ⓘ full_disk_access: Not granted (optional — needed for get-checklist-state and checklist annotations in get-note-markdown). Grant in System Settings > Privacy & Security > Full Disk Access.";
+    return successResponse(`${statusIcon} ${statusText}\n\n${checkLines}\n${fdaLine}`, {
+        healthy: result.healthy,
+        checks: result.checks,
+        fullDiskAccess: fdaAvailable,
+    });
+}, "Error running health check"));
+// --- doctor ---
+server.registerTool("doctor", {
+    description: "Use when: diagnosing setup problems (Notes.app automation permission, account state, Full Disk Access) with actionable guidance.\nReturns: a detailed report plus structured fields.\nDo not use when: you just need a quick pass/fail (health-check).\nRead-only.",
+    inputSchema: {},
+    outputSchema: {
+        healthy: z.boolean().optional(),
+        checks: z.array(z.object({}).passthrough()).optional(),
+    },
+}, withErrorHandling(() => {
+    // Richer than health-check: Notes.app permission, account state, and Full
+    // Disk Access with actionable messages + structuredContent (#22).
+    const report = runDoctor(notesManager);
+    return successResponse(formatDoctorReport(report), { ...report });
+}, "Error running doctor"));
+// --- get-notes-stats ---
+server.registerTool("get-notes-stats", {
+    description: "Use when: summarizing the library — total notes, per-account/folder counts, and recent activity.\nReturns: aggregate statistics; flags partial coverage when some scopes were unreadable.\nDo not use when: you need individual notes (list-notes/search-notes).\nRead-only.",
+    inputSchema: {},
+    outputSchema: {
+        totalNotes: z.number().optional(),
+        accounts: z.array(z.object({}).passthrough()).optional(),
+        recentlyModified: z.object({}).passthrough().optional(),
+        coverage: z.object({}).passthrough().optional(),
+    },
+}, withErrorHandling(() => {
+    const stats = notesManager.getNotesStats();
+    // Format the output
+    const lines = [];
+    lines.push(`📊 Notes Statistics`);
+    lines.push(`═══════════════════`);
+    lines.push(`Total notes: ${stats.totalNotes}`);
+    lines.push(``);
+    // Per-account breakdown
+    lines.push(`📁 By Account:`);
+    for (const account of stats.accounts) {
+        lines.push(`  ${account.name}: ${account.totalNotes} notes, ${account.folderCount} folders`);
+        for (const folder of account.folders) {
+            if (folder.noteCount > 0) {
+                lines.push(`    - ${folder.name}: ${folder.noteCount}`);
+            }
+        }
+    }
+    lines.push(``);
+    // Recently modified
+    lines.push(`📅 Recently Modified:`);
+    lines.push(`  Last 24 hours: ${stats.recentlyModified.last24h}`);
+    lines.push(`  Last 7 days: ${stats.recentlyModified.last7d}`);
+    lines.push(`  Last 30 days: ${stats.recentlyModified.last30d}`);
+    // Partial-coverage diagnostics (#19): if some scopes couldn't be read, say so
+    // explicitly so the numbers above aren't mistaken for a complete picture.
+    if (!stats.coverage.complete) {
+        lines.push(``);
+        lines.push(`⚠️  Partial results: read ${stats.coverage.covered}/${stats.coverage.scanned} scopes. Counts above exclude:`);
+        for (const w of stats.coverage.warnings) {
+            lines.push(`  - ${w.scope}: ${w.reason}`);
+        }
+    }
+    return successResponse(lines.join("\n"), { ...stats });
+}, "Error getting notes statistics"));
+// --- list-attachments ---
+server.registerTool("list-attachments", {
+    description: "Use when: listing the attachments of one note, by id (preferred) or title.\nReturns: each attachment's name, content type, and id (use with save-attachment/fetch-attachment).\nDo not use when: you want the attachment bytes (fetch-attachment) or a file on disk (save-attachment).",
+    inputSchema: {
+        id: z
+            .string()
+            .max(MAX.ID)
+            .optional()
+            .describe("Note ID (preferred - more reliable than title)"),
+        title: z
+            .string()
+            .max(MAX.TITLE)
+            .optional()
+            .describe("Note title (use id instead when available)"),
+        account: z
+            .string()
+            .max(MAX.ACCOUNT)
+            .optional()
+            .describe("Account containing the note (ignored if id is provided)"),
+    },
+    outputSchema: {
+        attachments: z.array(z.object({}).passthrough()).optional(),
+        count: z.number().optional(),
+    },
+}, withErrorHandling(({ id, title, account }) => {
+    // Prefer ID-based lookup if provided
+    if (id) {
+        const note = notesManager.getNoteById(id);
+        if (!note) {
+            return errorResponse(`Note with ID "${id}" not found`);
+        }
+        const attachments = notesManager.listAttachmentsById(id);
+        if (attachments.length === 0) {
+            return successResponse(`Note "${note.title}" has no attachments`, {
+                attachments: [],
+                count: 0,
+            });
+        }
+        const attachmentList = attachments.map((a) => `  - ${a.name} (${a.contentType})`).join("\n");
+        return successResponse(`Found ${attachments.length} attachment(s) in "${note.title}":\n${attachmentList}`, { attachments, count: attachments.length });
+    }
+    // Fall back to title-based lookup
+    if (!title) {
+        return errorResponse("Either 'id' or 'title' is required");
+    }
+    const note = notesManager.getNoteDetails(title, account);
+    if (!note) {
+        return errorResponse(`Note "${title}" not found. Use search-notes to find notes, then use the note's ID for reliable operations.`);
+    }
+    const attachments = notesManager.listAttachments(title, account);
+    if (attachments.length === 0) {
+        return successResponse(`Note "${title}" has no attachments`, { attachments: [], count: 0 });
+    }
+    const attachmentList = attachments.map((a) => `  - ${a.name} (${a.contentType})`).join("\n");
+    return successResponse(`Found ${attachments.length} attachment(s) in "${title}":\n${attachmentList}`, { attachments, count: attachments.length });
+}, "Error listing attachments"));
+// --- batch-delete-notes ---
+server.registerTool("batch-delete-notes", {
+    description: "Use when: permanently deleting multiple notes by id in one call.\nReturns: per-id success/failure counts.\nDo not use when: deleting a single note (delete-note).\nSafety: requires explicit user confirmation; this is destructive and not undoable. Prefer search-notes/list-notes first to confirm the exact ids being deleted.",
+    inputSchema: {
+        ids: z
+            .array(z.string().max(MAX.ID))
+            .max(MAX.BATCH_IDS)
+            .describe("Array of note IDs to delete"),
+    },
+    outputSchema: {
+        ok: z.boolean().optional(),
+        succeeded: z.number().optional(),
+        failed: z.number().optional(),
+        results: z.array(z.object({}).passthrough()).optional(),
+    },
+}, withErrorHandling(({ ids }) => {
+    if (ids.length === 0) {
+        return errorResponse("No note IDs provided");
+    }
+    const results = notesManager.batchDeleteNotes(ids);
+    const succeeded = results.filter((r) => r.success).length;
+    const failed = results.filter((r) => !r.success).length;
+    const lines = [`Batch delete: ${succeeded} succeeded, ${failed} failed`];
+    if (failed > 0) {
+        lines.push("\nFailures:");
+        for (const result of results.filter((r) => !r.success)) {
+            lines.push(`  - ${result.id}: ${result.error}`);
+        }
+    }
+    return succeeded > 0
+        ? successResponse(lines.join("\n"), {
+            ok: failed === 0,
+            succeeded,
+            failed,
+            results,
+        })
+        : errorResponse(lines.join("\n"));
+}, "Error performing batch delete"));
+// --- batch-move-notes ---
+server.registerTool("batch-move-notes", {
+    description: "Use when: moving multiple notes by id into one destination folder.\nReturns: per-id success/failure counts.\nDo not use when: moving a single note (move-note).\nNote: the destination folder must already exist (create-folder).",
+    inputSchema: {
+        ids: z.array(z.string().max(MAX.ID)).max(MAX.BATCH_IDS).describe("Array of note IDs to move"),
+        folder: z.string().max(MAX.FOLDER).describe("Destination folder name"),
+        account: z
+            .string()
+            .max(MAX.ACCOUNT)
+            .optional()
+            .describe("Account containing the destination folder (defaults to iCloud)"),
+    },
+    outputSchema: {
+        ok: z.boolean().optional(),
+        folder: z.string().optional(),
+        succeeded: z.number().optional(),
+        failed: z.number().optional(),
+        results: z.array(z.object({}).passthrough()).optional(),
+    },
+}, withErrorHandling(({ ids, folder, account }) => {
+    if (ids.length === 0) {
+        return errorResponse("No note IDs provided");
+    }
+    const results = notesManager.batchMoveNotes(ids, folder, account);
+    const succeeded = results.filter((r) => r.success).length;
+    const failed = results.filter((r) => !r.success).length;
+    const lines = [`Batch move to "${folder}": ${succeeded} succeeded, ${failed} failed`];
+    if (failed > 0) {
+        lines.push("\nFailures:");
+        for (const result of results.filter((r) => !r.success)) {
+            lines.push(`  - ${result.id}: ${result.error}`);
+        }
+    }
+    return succeeded > 0
+        ? successResponse(lines.join("\n"), {
+            ok: failed === 0,
+            folder,
+            succeeded,
+            failed,
+            results,
+        })
+        : errorResponse(lines.join("\n"));
+}, "Error performing batch move"));
+// --- save-attachment ---
+server.registerTool("save-attachment", {
+    description: "Use when: writing one note attachment to a file on disk.\nReturns: the saved path.\nDo not use when: you want the bytes in-memory as base64 (fetch-attachment).\nSafety: writes a file; savePath must be absolute and under the home directory, a temp dir, or /Volumes. Get the ids from list-attachments first.",
+    inputSchema: {
+        noteId: z
+            .string()
+            .min(1, "noteId is required")
+            .max(MAX.ID)
+            .describe("CoreData note id (from search/list)"),
+        attachmentId: z
+            .string()
+            .min(1, "attachmentId is required")
+            .max(MAX.ATTACHMENT_ID)
+            .describe("Attachment id (from list-attachments)"),
+        savePath: z
+            .string()
+            .min(1, "savePath is required")
+            .max(MAX.SAVE_PATH)
+            .describe("Absolute destination file path (must be under home, temp, or /Volumes)"),
+    },
+    outputSchema: {
+        savedPath: z.string().optional(),
+        name: z.string().optional(),
+        contentType: z.string().optional(),
+    },
+}, withErrorHandling(({ noteId, attachmentId, savePath }) => {
+    const r = notesManager.saveAttachmentById(noteId, attachmentId, savePath);
+    if (!r.success) {
+        return errorResponse(`Failed to save attachment: ${r.error ?? "unknown error"}`);
+    }
+    return successResponse(`Saved "${r.name ?? "attachment"}" to ${r.savedPath}`, {
+        savedPath: r.savedPath,
+        name: r.name,
+        contentType: r.contentType,
+    });
+}, "Error saving attachment"));
+// --- fetch-attachment ---
+server.registerTool("fetch-attachment", {
+    description: "Use when: retrieving one note attachment's bytes inline as base64 (no file written).\nReturns: name, content type, byte count, and base64 data.\nDo not use when: you want it saved to disk (save-attachment).\nNote: get the ids from list-attachments first.",
+    inputSchema: {
+        noteId: z
+            .string()
+            .min(1, "noteId is required")
+            .max(MAX.ID)
+            .describe("CoreData note id (from search/list)"),
+        attachmentId: z
+            .string()
+            .min(1, "attachmentId is required")
+            .max(MAX.ATTACHMENT_ID)
+            .describe("Attachment id (from list-attachments)"),
+    },
+    outputSchema: {
+        name: z.string().optional(),
+        contentType: z.string().optional(),
+        bytes: z.number().optional(),
+        base64: z.string().optional(),
+    },
+}, withErrorHandling(({ noteId, attachmentId }) => {
+    const r = notesManager.getAttachmentBase64ById(noteId, attachmentId);
+    if (!r.success || !r.base64) {
+        return errorResponse(`Failed to fetch attachment: ${r.error ?? "unknown error"}`);
+    }
+    return successResponse(`Fetched "${r.name ?? "attachment"}" (${r.contentType ?? "unknown type"}, ${r.bytes ?? 0} bytes) as base64.`, { name: r.name, contentType: r.contentType, bytes: r.bytes, base64: r.base64 });
+}, "Error fetching attachment"));
+// --- show-attachment ---
+server.registerTool("show-attachment", {
+    description: "Use when: the user wants to reveal one note attachment in Notes.app.\nReturns: confirmation that Notes.app revealed the attachment.\nDo not use when: you want the bytes (fetch-attachment) or a file on disk (save-attachment).\nNote: this opens or focuses the Notes UI. Get the ids from list-attachments first.",
+    inputSchema: {
+        noteId: z
+            .string()
+            .min(1, "noteId is required")
+            .max(MAX.ID)
+            .describe("CoreData note id (from search/list)"),
+        attachmentId: z
+            .string()
+            .min(1, "attachmentId is required")
+            .max(MAX.ATTACHMENT_ID)
+            .describe("Attachment id (from list-attachments)"),
+        separately: z
+            .boolean()
+            .optional()
+            .describe("Open in a separate window when supported by Notes.app"),
+    },
+    outputSchema: {
+        noteId: z.string().optional(),
+        attachmentId: z.string().optional(),
+        separately: z.boolean().optional(),
+    },
+}, withErrorHandling(({ noteId, attachmentId, separately = false }) => {
+    const success = notesManager.showAttachmentById(noteId, attachmentId, separately);
+    if (!success) {
+        return errorResponse(`Failed to show attachment "${attachmentId}" on note "${noteId}"`);
+    }
+    return successResponse(`Shown attachment "${attachmentId}" in Notes.app`, {
+        noteId,
+        attachmentId,
+        separately,
+    });
+}, "Error showing attachment"));
+// --- export-notes-json ---
+server.registerTool("export-notes-json", {
+    description: "Use when: exporting the entire notes library as structured JSON for backup or bulk processing.\nReturns: a summary plus the full JSON of all notes, folders, and accounts.\nDo not use when: you need a single note (get-note-content) — this reads everything and can be large.\nRead-only.",
+    inputSchema: {},
+    outputSchema: {
+        exportDate: z.string().optional(),
+        version: z.string().optional(),
+        accounts: z.array(z.object({}).passthrough()).optional(),
+        summary: z.object({}).passthrough().optional(),
+    },
+}, withErrorHandling(() => {
+    const exportData = notesManager.exportNotesAsJson();
+    const { summary } = exportData;
+    return {
+        content: [
+            {
+                type: "text",
+                text: `Exported ${summary.totalNotes} notes from ${summary.totalFolders} folders across ${summary.totalAccounts} account(s).\n\nFull JSON export:`,
+            },
+            {
+                type: "text",
+                text: JSON.stringify(exportData, null, 2),
+            },
+        ],
+        structuredContent: { ...exportData },
+    };
+}, "Error exporting notes"));
+// --- get-note-markdown ---
+server.registerTool("get-note-markdown", {
+    description: "Use when: reading a note as Markdown, with checklist items annotated [x]/[ ] when Full Disk Access is granted.\nReturns: the note's Markdown.\nDo not use when: you need the raw HTML/plaintext body (get-note-content) or only metadata (get-note-details).\nNote: falls back to plain lists (no checkmarks) without Full Disk Access.",
+    inputSchema: {
+        id: z
+            .string()
+            .max(MAX.ID)
+            .optional()
+            .describe("Note ID (preferred - more reliable than title)"),
+        title: z
+            .string()
+            .max(MAX.TITLE)
+            .optional()
+            .describe("Note title (use id instead when available)"),
+        account: z
+            .string()
+            .max(MAX.ACCOUNT)
+            .optional()
+            .describe("Account containing the note (ignored if id is provided)"),
+    },
+    outputSchema: {
+        markdown: z.string().optional(),
+    },
+}, withErrorHandling(({ id, title, account }) => {
+    // Prefer ID-based lookup if provided
+    if (id) {
+        const markdown = notesManager.getNoteMarkdownById(id);
+        if (!markdown) {
+            return errorResponse(`Note with ID "${id}" not found or has no content`);
+        }
+        return successResponse(markdown, { markdown });
+    }
+    // Fall back to title-based lookup
+    if (!title) {
+        return errorResponse("Either 'id' or 'title' is required");
+    }
+    const markdown = notesManager.getNoteMarkdown(title, account);
+    if (!markdown) {
+        return errorResponse(`Note "${title}" not found or has no content. Use search-notes to find notes, then use the note's ID for reliable operations.`);
+    }
+    return successResponse(markdown, { markdown });
+}, "Error getting note as markdown"));
+// --- get-checklist-state ---
+server.registerTool("get-checklist-state", {
+    description: "Use when: reading the checked/unchecked state of a note's checklist items, by id.\nReturns: each item's text and done state plus checked/total counts.\nDo not use when: you only have a title (get the id via search-notes first) or want the full body text (get-note-content).\nNote: requires Full Disk Access; reads the NoteStore database directly.",
+    inputSchema: {
+        id: z
+            .string()
+            .min(1, "Note ID is required. Use search-notes to find the note ID first.")
+            .max(MAX.ID),
+    },
+    outputSchema: {
+        items: z.array(z.object({}).passthrough()).optional(),
+        checked: z.number().optional(),
+        total: z.number().optional(),
+    },
+}, withErrorHandling(({ id }) => {
+    // Verify the note exists and is accessible
+    const note = notesManager.getNoteById(id);
+    if (!note) {
+        return errorResponse(`Note with ID "${id}" not found`);
+    }
+    if (note.passwordProtected) {
+        return errorResponse(`Note "${note.title}" is password-protected and cannot be read. Unlock it in Notes.app first.`);
+    }
+    const result = getChecklistItems(id);
+    if (!result.items) {
+        return errorResponse(result.message || "Failed to read checklist state.");
+    }
+    const summary = result.items
+        .map((item) => `${item.done ? "[x]" : "[ ]"} ${item.text}`)
+        .join("\n");
+    const checked = result.items.filter((i) => i.done).length;
+    return successResponse(`Checklist for "${note.title}" (${checked}/${result.items.length} done):\n${summary}`, { items: result.items, checked, total: result.items.length });
+}, "Error reading checklist state"));
+// --- get-note-metadata (BETA) ---
+server.registerTool("get-note-metadata", {
+    description: "[BETA] Use when: reading note metadata AppleScript cannot expose — pinned state, checklist flags, trash/recovery state, preview snippet, password hint — by id.\nReturns: a metadata object; fields vary by macOS version and are omitted when unavailable.\nDo not use when: you need the body (get-note-content) or per-item checklist state (get-checklist-state).\nNote: reads the NoteStore SQLite database read-only and requires Full Disk Access. BETA — the database schema changes between macOS releases, so some fields may be absent. Works on trashed notes that AppleScript can no longer resolve.",
+    inputSchema: {
+        id: z
+            .string()
+            .min(1, "Note ID is required. Use search-notes to find the note ID first.")
+            .max(MAX.ID),
+    },
+    outputSchema: {
+        pinned: z.boolean().optional(),
+        hasChecklist: z.boolean().optional(),
+        hasChecklistInProgress: z.boolean().optional(),
+        recoveringFromTrash: z.boolean().optional(),
+        passwordProtected: z.boolean().optional(),
+        passwordHint: z.string().optional(),
+        snippet: z.string().optional(),
+        widgetSnippet: z.string().optional(),
+        smartFolderQuery: z.string().optional(),
+    },
+}, withErrorHandling(({ id }) => {
+    // No AppleScript existence pre-check: reading straight from the database lets
+    // this resolve trashed/recovering notes that `note id ...` can no longer find.
+    const { metadata, message } = getNoteMetadata(id);
+    if (!metadata) {
+        return errorResponse(message || `Failed to read metadata for note "${id}"`);
+    }
+    const keys = Object.keys(metadata);
+    const summary = keys.length === 0
+        ? `No additional metadata is available for note "${id}" on this macOS version.`
+        : keys.map((k) => `${k}: ${String(metadata[k])}`).join("\n");
+    return successResponse(summary, metadata);
+}, "Error reading note metadata"));
+// =============================================================================
+// Server Startup
+// =============================================================================
+/**
+ * Initialize and start the MCP server.
+ *
+ * The server uses stdio transport for communication with MCP clients.
+ * This is the standard transport for CLI-based MCP servers.
+ */
+// Register read-only resources and workflow prompts (#23).
+registerResourcesAndPrompts(server, notesManager);
+// Defense-in-depth: an unhandled rejection or a stray EventEmitter "error" must
+// never take down this long-lived MCP server. EPIPE on stdout means the MCP
+// client disconnected — exit cleanly rather than crash.
+process.on("uncaughtException", (err) => {
+    if (err?.code === "EPIPE")
+        process.exit(0);
+    console.error("[uncaughtException]", err);
+});
+process.on("unhandledRejection", (reason) => {
+    console.error("[unhandledRejection]", reason);
+});
+// Graceful shutdown. This server holds no persistent resources (AppleScript runs
+// are one-shot via execSync), so there's nothing to drain — but wiring SIGINT/
+// SIGTERM and stdin EOF/close to a clean exit keeps behavior tidy and consistent
+// with the sibling apple-mail server: when the parent kills us (signal) or the
+// MCP client disconnects (stdin 'end'/'close'), exit 0 promptly instead of
+// lingering as an orphan. Idempotent so multiple triggers don't double-exit.
+let _shuttingDown = false;
+const shutdown = () => {
+    if (_shuttingDown)
+        return;
+    _shuttingDown = true;
+    process.exit(0);
+};
+for (const sig of ["SIGINT", "SIGTERM"]) {
+    process.on(sig, shutdown);
+}
+process.stdin.on("end", shutdown);
+process.stdin.on("close", shutdown);
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/build/index.test.js
+++ b/build/index.test.js
@@ -1,0 +1,446 @@
+/**
+ * Integration Tests for Apple Notes MCP Server
+ *
+ * These tests verify the MCP tool handlers work correctly.
+ * The AppleNotesManager is mocked to test tool response formatting
+ * and error handling without requiring actual AppleScript execution.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AppleNotesManager } from "./services/appleNotesManager.js";
+// Mock the AppleNotesManager class
+vi.mock("@/services/appleNotesManager.js", () => {
+    return {
+        AppleNotesManager: vi.fn().mockImplementation(() => ({
+            createNote: vi.fn(),
+            searchNotes: vi.fn(),
+            getNoteContent: vi.fn(),
+            getNoteById: vi.fn(),
+            getNoteDetails: vi.fn(),
+            updateNote: vi.fn(),
+            deleteNote: vi.fn(),
+            moveNote: vi.fn(),
+            listNotes: vi.fn(),
+            listFolders: vi.fn(),
+            createFolder: vi.fn(),
+            deleteFolder: vi.fn(),
+            listAccounts: vi.fn(),
+        })),
+    };
+});
+// Create a typed mock manager for testing
+const createMockManager = () => {
+    const manager = new AppleNotesManager();
+    return manager;
+};
+let mockManager;
+// =============================================================================
+// Response Helper Tests
+// =============================================================================
+describe("Response Helpers", () => {
+    // We test these indirectly through the tool handlers since they're not exported
+    // The pattern we're looking for is consistent response formatting
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockManager = createMockManager();
+    });
+    describe("success response format", () => {
+        it("returns content array with text type", async () => {
+            mockManager.createNote.mockReturnValue({
+                id: "123",
+                title: "Test Note",
+                content: "Test content",
+                tags: [],
+                created: new Date(),
+                modified: new Date(),
+                account: "iCloud",
+            });
+            // Simulate what the tool handler would return
+            const response = {
+                content: [{ type: "text", text: 'Note created: "Test Note"' }],
+            };
+            expect(response.content).toHaveLength(1);
+            expect(response.content[0].type).toBe("text");
+            expect(response.content[0].text).toContain("Note created");
+        });
+    });
+    describe("error response format", () => {
+        it("includes isError flag", () => {
+            const errorResponse = {
+                content: [{ type: "text", text: "Failed to create note" }],
+                isError: true,
+            };
+            expect(errorResponse.isError).toBe(true);
+            expect(errorResponse.content[0].text).toContain("Failed");
+        });
+    });
+});
+// =============================================================================
+// Tool Handler Tests
+// =============================================================================
+describe("Tool Handlers", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockManager = createMockManager();
+    });
+    // ---------------------------------------------------------------------------
+    // create-note
+    // ---------------------------------------------------------------------------
+    describe("create-note tool", () => {
+        it("calls createNote with correct parameters", () => {
+            const params = {
+                title: "Shopping List",
+                content: "Eggs, Milk, Bread",
+                tags: ["groceries"],
+            };
+            mockManager.createNote.mockReturnValue({
+                id: "123",
+                title: params.title,
+                content: params.content,
+                tags: params.tags,
+                created: new Date(),
+                modified: new Date(),
+                account: "iCloud",
+            });
+            // Simulate the tool handler call
+            const result = mockManager.createNote(params.title, params.content, params.tags);
+            expect(mockManager.createNote).toHaveBeenCalledWith("Shopping List", "Eggs, Milk, Bread", [
+                "groceries",
+            ]);
+            expect(result).not.toBeNull();
+        });
+        it("handles creation failure gracefully", () => {
+            mockManager.createNote.mockReturnValue(null);
+            const result = mockManager.createNote("Test", "Content", []);
+            expect(result).toBeNull();
+        });
+    });
+    // ---------------------------------------------------------------------------
+    // search-notes
+    // ---------------------------------------------------------------------------
+    describe("search-notes tool", () => {
+        it("returns list of matching note titles", () => {
+            mockManager.searchNotes.mockReturnValue([
+                { title: "Meeting Notes", id: "1" },
+                { title: "Project Notes", id: "2" },
+            ]);
+            const results = mockManager.searchNotes("notes", false, undefined);
+            expect(results).toHaveLength(2);
+            expect(results[0].title).toBe("Meeting Notes");
+        });
+        it("handles empty search results", () => {
+            mockManager.searchNotes.mockReturnValue([]);
+            const results = mockManager.searchNotes("nonexistent", false);
+            expect(results).toHaveLength(0);
+        });
+        it("supports content search", () => {
+            mockManager.searchNotes.mockReturnValue([{ title: "Found Note", id: "1" }]);
+            mockManager.searchNotes("keyword", true, "iCloud");
+            expect(mockManager.searchNotes).toHaveBeenCalledWith("keyword", true, "iCloud");
+        });
+    });
+    // ---------------------------------------------------------------------------
+    // get-note-content
+    // ---------------------------------------------------------------------------
+    describe("get-note-content tool", () => {
+        it("returns note HTML content", () => {
+            const htmlContent = "<div>Shopping List</div><div>- Eggs</div>";
+            mockManager.getNoteContent.mockReturnValue(htmlContent);
+            const result = mockManager.getNoteContent("Shopping List");
+            expect(result).toBe(htmlContent);
+        });
+        it("returns empty string for missing note", () => {
+            mockManager.getNoteContent.mockReturnValue("");
+            const result = mockManager.getNoteContent("Missing");
+            expect(result).toBe("");
+        });
+    });
+    // ---------------------------------------------------------------------------
+    // get-note-by-id
+    // ---------------------------------------------------------------------------
+    describe("get-note-by-id tool", () => {
+        it("returns note metadata as JSON", () => {
+            const note = {
+                id: "x-coredata://ABC123/ICNote/p100",
+                title: "Test Note",
+                content: "",
+                tags: [],
+                created: new Date("2025-01-01"),
+                modified: new Date("2025-01-02"),
+                shared: false,
+                passwordProtected: false,
+            };
+            mockManager.getNoteById.mockReturnValue(note);
+            const result = mockManager.getNoteById("x-coredata://ABC123/ICNote/p100");
+            expect(result).not.toBeNull();
+            expect(result?.id).toBe("x-coredata://ABC123/ICNote/p100");
+            expect(result?.title).toBe("Test Note");
+        });
+        it("returns null for invalid ID", () => {
+            mockManager.getNoteById.mockReturnValue(null);
+            const result = mockManager.getNoteById("invalid-id");
+            expect(result).toBeNull();
+        });
+    });
+    // ---------------------------------------------------------------------------
+    // get-note-details
+    // ---------------------------------------------------------------------------
+    describe("get-note-details tool", () => {
+        it("returns full note metadata", () => {
+            const note = {
+                id: "x-coredata://ABC/ICNote/p1",
+                title: "Project Plan",
+                content: "",
+                tags: [],
+                created: new Date(),
+                modified: new Date(),
+                shared: true,
+                passwordProtected: false,
+                account: "iCloud",
+            };
+            mockManager.getNoteDetails.mockReturnValue(note);
+            const result = mockManager.getNoteDetails("Project Plan");
+            expect(result?.shared).toBe(true);
+            expect(result?.account).toBe("iCloud");
+        });
+    });
+    // ---------------------------------------------------------------------------
+    // update-note
+    // ---------------------------------------------------------------------------
+    describe("update-note tool", () => {
+        it("returns true on successful update", () => {
+            mockManager.updateNote.mockReturnValue(true);
+            const result = mockManager.updateNote("Old Title", "New Title", "New content");
+            expect(result).toBe(true);
+        });
+        it("returns false when note not found", () => {
+            mockManager.updateNote.mockReturnValue(false);
+            const result = mockManager.updateNote("Missing", undefined, "Content");
+            expect(result).toBe(false);
+        });
+        it("preserves title when newTitle is undefined", () => {
+            mockManager.updateNote.mockReturnValue(true);
+            mockManager.updateNote("Keep Title", undefined, "Updated content");
+            expect(mockManager.updateNote).toHaveBeenCalledWith("Keep Title", undefined, "Updated content");
+        });
+    });
+    // ---------------------------------------------------------------------------
+    // delete-note
+    // ---------------------------------------------------------------------------
+    describe("delete-note tool", () => {
+        it("returns true on successful deletion", () => {
+            mockManager.deleteNote.mockReturnValue(true);
+            const result = mockManager.deleteNote("Old Note");
+            expect(result).toBe(true);
+        });
+        it("returns false when deletion fails", () => {
+            mockManager.deleteNote.mockReturnValue(false);
+            const result = mockManager.deleteNote("Protected Note");
+            expect(result).toBe(false);
+        });
+    });
+    // ---------------------------------------------------------------------------
+    // move-note
+    // ---------------------------------------------------------------------------
+    describe("move-note tool", () => {
+        it("returns true when move succeeds", () => {
+            mockManager.moveNote.mockReturnValue(true);
+            const result = mockManager.moveNote("My Note", "Archive");
+            expect(result).toBe(true);
+            expect(mockManager.moveNote).toHaveBeenCalledWith("My Note", "Archive");
+        });
+        it("returns false when source note not found", () => {
+            mockManager.moveNote.mockReturnValue(false);
+            const result = mockManager.moveNote("Missing", "Archive");
+            expect(result).toBe(false);
+        });
+        it("returns false when destination folder not found", () => {
+            mockManager.moveNote.mockReturnValue(false);
+            const result = mockManager.moveNote("My Note", "Nonexistent");
+            expect(result).toBe(false);
+        });
+    });
+    // ---------------------------------------------------------------------------
+    // list-notes
+    // ---------------------------------------------------------------------------
+    describe("list-notes tool", () => {
+        it("returns array of note titles", () => {
+            mockManager.listNotes.mockReturnValue(["Note A", "Note B", "Note C"]);
+            const result = mockManager.listNotes();
+            expect(result).toEqual(["Note A", "Note B", "Note C"]);
+        });
+        it("returns empty array when no notes", () => {
+            mockManager.listNotes.mockReturnValue([]);
+            const result = mockManager.listNotes();
+            expect(result).toEqual([]);
+        });
+        it("filters by folder when specified", () => {
+            mockManager.listNotes.mockReturnValue(["Work Note 1", "Work Note 2"]);
+            mockManager.listNotes("iCloud", "Work");
+            expect(mockManager.listNotes).toHaveBeenCalledWith("iCloud", "Work");
+        });
+    });
+    // ---------------------------------------------------------------------------
+    // list-folders
+    // ---------------------------------------------------------------------------
+    describe("list-folders tool", () => {
+        it("returns array of Folder objects", () => {
+            mockManager.listFolders.mockReturnValue([
+                { id: "", name: "Notes", account: "iCloud" },
+                { id: "", name: "Archive", account: "iCloud" },
+            ]);
+            const result = mockManager.listFolders();
+            expect(result).toHaveLength(2);
+            expect(result[0].name).toBe("Notes");
+        });
+        it("returns empty array when no folders", () => {
+            mockManager.listFolders.mockReturnValue([]);
+            const result = mockManager.listFolders();
+            expect(result).toEqual([]);
+        });
+    });
+    // ---------------------------------------------------------------------------
+    // create-folder
+    // ---------------------------------------------------------------------------
+    describe("create-folder tool", () => {
+        it("returns Folder object on success", () => {
+            mockManager.createFolder.mockReturnValue({
+                id: "folder-123",
+                name: "New Project",
+                account: "iCloud",
+            });
+            const result = mockManager.createFolder("New Project");
+            expect(result).not.toBeNull();
+            expect(result?.name).toBe("New Project");
+        });
+        it("returns null when folder already exists", () => {
+            mockManager.createFolder.mockReturnValue(null);
+            const result = mockManager.createFolder("Existing");
+            expect(result).toBeNull();
+        });
+    });
+    // ---------------------------------------------------------------------------
+    // delete-folder
+    // ---------------------------------------------------------------------------
+    describe("delete-folder tool", () => {
+        it("returns true on successful deletion", () => {
+            mockManager.deleteFolder.mockReturnValue(true);
+            const result = mockManager.deleteFolder("Empty Folder");
+            expect(result).toBe(true);
+        });
+        it("returns false when folder contains notes", () => {
+            mockManager.deleteFolder.mockReturnValue(false);
+            const result = mockManager.deleteFolder("Non-Empty");
+            expect(result).toBe(false);
+        });
+    });
+    // ---------------------------------------------------------------------------
+    // list-accounts
+    // ---------------------------------------------------------------------------
+    describe("list-accounts tool", () => {
+        it("returns array of Account objects", () => {
+            mockManager.listAccounts.mockReturnValue([
+                { name: "iCloud" },
+                { name: "Gmail" },
+                { name: "Exchange" },
+            ]);
+            const result = mockManager.listAccounts();
+            expect(result).toHaveLength(3);
+            expect(result[0].name).toBe("iCloud");
+        });
+        it("returns empty array when no accounts configured", () => {
+            mockManager.listAccounts.mockReturnValue([]);
+            const result = mockManager.listAccounts();
+            expect(result).toEqual([]);
+        });
+    });
+});
+// =============================================================================
+// Error Handling Tests
+// =============================================================================
+describe("Error Handling", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockManager = createMockManager();
+    });
+    it("handles manager throwing exceptions", () => {
+        mockManager.createNote.mockImplementation(() => {
+            throw new Error("Unexpected error");
+        });
+        expect(() => mockManager.createNote("Test", "Content", [])).toThrow("Unexpected error");
+    });
+    it("handles null returns gracefully", () => {
+        mockManager.getNoteById.mockReturnValue(null);
+        mockManager.getNoteDetails.mockReturnValue(null);
+        mockManager.createNote.mockReturnValue(null);
+        mockManager.createFolder.mockReturnValue(null);
+        expect(mockManager.getNoteById("invalid")).toBeNull();
+        expect(mockManager.getNoteDetails("missing")).toBeNull();
+        expect(mockManager.createNote("fail", "content", [])).toBeNull();
+        expect(mockManager.createFolder("exists")).toBeNull();
+    });
+    it("handles empty string returns", () => {
+        mockManager.getNoteContent.mockReturnValue("");
+        expect(mockManager.getNoteContent("missing")).toBe("");
+    });
+    it("handles empty array returns", () => {
+        mockManager.searchNotes.mockReturnValue([]);
+        mockManager.listNotes.mockReturnValue([]);
+        mockManager.listFolders.mockReturnValue([]);
+        mockManager.listAccounts.mockReturnValue([]);
+        expect(mockManager.searchNotes("none")).toEqual([]);
+        expect(mockManager.listNotes()).toEqual([]);
+        expect(mockManager.listFolders()).toEqual([]);
+        expect(mockManager.listAccounts()).toEqual([]);
+    });
+    it("handles false returns for destructive operations", () => {
+        mockManager.deleteNote.mockReturnValue(false);
+        mockManager.deleteFolder.mockReturnValue(false);
+        mockManager.updateNote.mockReturnValue(false);
+        mockManager.moveNote.mockReturnValue(false);
+        expect(mockManager.deleteNote("protected")).toBe(false);
+        expect(mockManager.deleteFolder("non-empty")).toBe(false);
+        expect(mockManager.updateNote("missing", undefined, "content")).toBe(false);
+        expect(mockManager.moveNote("missing", "folder")).toBe(false);
+    });
+});
+// =============================================================================
+// Input Validation Tests
+// =============================================================================
+describe("Input Validation", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockManager = createMockManager();
+    });
+    describe("title parameter", () => {
+        it("handles titles with special characters", () => {
+            mockManager.getNoteContent.mockReturnValue("content");
+            mockManager.getNoteContent('Note\'s "Title" with <special> chars');
+            expect(mockManager.getNoteContent).toHaveBeenCalledWith('Note\'s "Title" with <special> chars');
+        });
+        it("handles titles with unicode", () => {
+            mockManager.getNoteContent.mockReturnValue("content");
+            mockManager.getNoteContent("日本語ノート 🎉");
+            expect(mockManager.getNoteContent).toHaveBeenCalledWith("日本語ノート 🎉");
+        });
+    });
+    describe("account parameter", () => {
+        it("defaults to iCloud when not specified", () => {
+            mockManager.createNote.mockReturnValue({
+                id: "1",
+                title: "Test",
+                content: "Content",
+                tags: [],
+                created: new Date(),
+                modified: new Date(),
+                account: "iCloud",
+            });
+            const result = mockManager.createNote("Test", "Content", []);
+            expect(result?.account).toBe("iCloud");
+        });
+        it("uses specified account", () => {
+            mockManager.listNotes.mockReturnValue(["Gmail Note"]);
+            mockManager.listNotes("Gmail");
+            expect(mockManager.listNotes).toHaveBeenCalledWith("Gmail");
+        });
+    });
+});

--- a/build/services/__fixtures__/notesNormalizedHtml.js
+++ b/build/services/__fixtures__/notesNormalizedHtml.js
@@ -1,0 +1,32 @@
+export const NOTES_NORMALIZED_HTML_FIXTURES = [
+    {
+        name: "headingAndParagraphs",
+        description: "An <h1> title and two <div> paragraphs separated by a spacer row",
+        html: "<div><h1>Meeting Notes</h1></div><div>First line.</div><div><br></div><div>Second line.</div>",
+        expectedMarkdown: "# Meeting Notes\n\nFirst line.\n  \n\nSecond line.",
+    },
+    {
+        name: "bulletList",
+        description: "An <h2> section heading followed by a native <ul> bullet list",
+        html: "<div><h2>Tasks</h2></div><ul><li>Buy milk</li><li>Walk dog</li></ul>",
+        expectedMarkdown: "## Tasks\n\n-   Buy milk\n-   Walk dog",
+    },
+    {
+        name: "inlineEmphasis",
+        description: "Inline <b> and <i> emphasis inside a paragraph div",
+        html: "<div>This is <b>bold</b> and <i>italic</i> text.</div>",
+        expectedMarkdown: "This is **bold** and _italic_ text.",
+    },
+    {
+        name: "codeSpan",
+        description: "A <tt> code span — the tag is dropped, only its text survives",
+        html: "<div>Run <tt>npm install</tt> first.</div>",
+        expectedMarkdown: "Run npm install first.",
+    },
+    {
+        name: "spacerRuns",
+        description: "Consecutive <div><br></div> spacer rows between two paragraphs",
+        html: "<div>A</div><div><br></div><div><br></div><div>B</div>",
+        expectedMarkdown: "A\n  \n\n  \n\nB",
+    },
+];

--- a/build/services/appleNotesManager.js
+++ b/build/services/appleNotesManager.js
@@ -1,0 +1,2634 @@
+/**
+ * Apple Notes Manager
+ *
+ * A comprehensive service for managing Apple Notes through AppleScript.
+ * This module provides a clean TypeScript interface over the Notes.app
+ * AppleScript dictionary, handling all the complexity of script generation,
+ * text escaping, and result parsing.
+ *
+ * Architecture:
+ * - Text escaping is handled by dedicated helper functions
+ * - AppleScript generation uses template builders for consistency
+ * - All public methods return typed results (no raw strings)
+ * - Error handling is consistent across all operations
+ *
+ * @module services/appleNotesManager
+ */
+import { executeAppleScript } from "../utils/applescript.js";
+import { getChecklistItems } from "../utils/checklistParser.js";
+import { assertSafeSavePath, readFileBase64Capped, fileSize, makeTempDir, cleanupTempDir, } from "../utils/attachmentFs.js";
+import { existsSync } from "fs";
+import TurndownService from "turndown";
+// =============================================================================
+// Result delimiters (#18)
+//
+// AppleScript output is delimited with ASCII control characters that cannot
+// appear in user-entered note titles, folder names, or body text — unlike the
+// old printable "|||" / "," / "ITEM" tokens, which collide with ordinary
+// content (a note titled "Groceries, etc." used to split into phantom notes).
+//   FIELD_SEP  (US, \x1f) separates fields within a record
+//   RECORD_SEP (RS, \x1e) separates records within a list
+// In AppleScript these are emitted via `ASCII character 31 / 30`.
+// =============================================================================
+const FIELD_SEP = "\x1f";
+const RECORD_SEP = "\x1e";
+const AS_FIELD_SEP = "(ASCII character 31)";
+const AS_RECORD_SEP = "(ASCII character 30)";
+// =============================================================================
+// Text Processing Utilities
+// =============================================================================
+/**
+ * Escapes text for safe embedding in AppleScript string literals.
+ *
+ * AppleScript strings use double quotes, so we need to escape:
+ * 1. Double quotes (") - escaped as \"
+ * 2. Backslashes (\) - already handled by shell escaping
+ *
+ * Additionally, since our AppleScript is passed through the shell via
+ * `osascript -e '...'`, we need to handle single quotes in the content.
+ *
+ * Finally, Apple Notes uses HTML internally, so we convert control
+ * characters to their HTML equivalents.
+ *
+ * @param text - Raw text to escape
+ * @returns Text safe for AppleScript string embedding
+ *
+ * @example
+ * escapeForAppleScript("Hello \"World\"")
+ * // Returns: Hello \"World\"
+ *
+ * escapeForAppleScript("Line 1\nLine 2")
+ * // Returns: Line 1<br>Line 2
+ */
+export function escapeForAppleScript(text) {
+    // Guard against null/undefined - return empty string
+    if (!text) {
+        return "";
+    }
+    // Content goes inside AppleScript double-quoted strings: body:"content here"
+    // Within double-quoted AppleScript strings, we need to escape:
+    // 1. Backslashes (\ → \\) - AppleScript escape character
+    // 2. Double quotes (" → \") - String delimiter
+    // Single quotes do NOT need escaping in double-quoted AppleScript strings.
+    // Step 1: Encode HTML ampersands FIRST (before adding any HTML entities)
+    let escaped = text.replace(/&/g, "&amp;");
+    // Step 2: Encode backslashes as HTML entities
+    // This avoids AppleScript escaping issues since Notes stores HTML
+    // Must happen AFTER ampersand encoding (so &#92; doesn't become &amp;#92;)
+    // and BEFORE double-quote escaping (so \" doesn't become &#92;")
+    escaped = escaped.replace(/\\/g, "&#92;");
+    // Step 3: Escape double quotes for AppleScript strings
+    // The backslash in \" is for AppleScript, not content, so it's added AFTER
+    // backslash encoding to avoid being HTML-encoded
+    escaped = escaped.replace(/"/g, '\\"');
+    // Step 4: Convert control characters to HTML for Notes.app
+    // - Newlines (\n) to <br> tags
+    // - Tabs (\t) to <br> tags (better than &nbsp; for readability)
+    escaped = escaped.replace(/\n/g, "<br>");
+    escaped = escaped.replace(/\t/g, "<br>");
+    return escaped;
+}
+/**
+ * Escapes already-HTML content for embedding in AppleScript string literals.
+ *
+ * Unlike escapeForAppleScript(), this function is designed for content that
+ * is already HTML (e.g., from getNoteContent()). It only escapes the
+ * AppleScript string delimiter (double quotes) and handles backslashes,
+ * without re-encoding HTML entities.
+ *
+ * @param htmlContent - HTML content from Notes.app
+ * @returns Content safe for AppleScript string embedding
+ *
+ * @example
+ * escapeHtmlForAppleScript('<div>Hello "World"</div>')
+ * // Returns: <div>Hello \"World\"</div>
+ */
+export function escapeHtmlForAppleScript(htmlContent) {
+    if (!htmlContent) {
+        return "";
+    }
+    // For already-HTML content, we only need to:
+    // 1. Escape backslashes for AppleScript (\ → \\)
+    // 2. Escape double quotes for AppleScript (" → \")
+    //
+    // We do NOT re-encode HTML entities since content is already HTML from Notes.app
+    return htmlContent.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+/**
+ * Escapes a plain (non-HTML) string for safe embedding in an AppleScript string literal.
+ *
+ * Use this for folder names, account names, and other metadata that Apple Notes
+ * stores as plain text — NOT for note body content (use escapeForAppleScript instead).
+ * HTML-encoding ampersands here would produce `folder "R&amp;D"`, which Apple Notes
+ * would fail to match against the real folder named "R&D".
+ *
+ * @param text - Plain string (folder name, account name, etc.)
+ * @returns String safe for AppleScript string embedding
+ */
+export function escapePlainStringForAppleScript(text) {
+    if (!text)
+        return "";
+    return text.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+// =============================================================================
+// Input Validation & Sanitization
+// =============================================================================
+/** Maximum allowed length for note titles */
+const MAX_TITLE_LENGTH = 2000;
+/** Maximum allowed length for note content (5 MB of text) */
+const MAX_CONTENT_LENGTH = 5 * 1024 * 1024;
+/** Maximum allowed length for folder names/paths */
+const MAX_FOLDER_PATH_LENGTH = 1000;
+/** Maximum allowed length for account names */
+const MAX_ACCOUNT_LENGTH = 200;
+/** Maximum nesting depth for folder paths */
+const MAX_FOLDER_DEPTH = 20;
+/**
+ * Validates and constrains string input length.
+ *
+ * @param value - The input string
+ * @param maxLength - Maximum allowed length
+ * @param label - Human-readable label for error messages
+ * @returns The validated string
+ * @throws Error if input exceeds maximum length
+ */
+function validateLength(value, maxLength, label) {
+    if (value.length > maxLength) {
+        throw new Error(`${label} exceeds maximum length of ${maxLength} characters (got ${value.length})`);
+    }
+    return value;
+}
+/**
+ * Sanitizes a CoreData ID for safe embedding in AppleScript.
+ *
+ * CoreData IDs follow the pattern: x-coredata://UUID/ICNote/pNNN
+ * This function validates the format and escapes the value for AppleScript.
+ *
+ * @param id - CoreData URL identifier
+ * @returns Escaped ID safe for AppleScript string embedding
+ * @throws Error if ID format is invalid
+ */
+export function sanitizeId(id) {
+    // CoreData IDs should match: x-coredata://hex-hex-hex-hex-hex/ICEntity/pDigits
+    // or temp-timestamp-counter format from generateFallbackId()
+    const coreDataPattern = /^x-coredata:\/\/[0-9A-Fa-f-]+\/IC[A-Za-z]+\/p\d+$/;
+    const tempIdPattern = /^temp-\d+-\d+$/;
+    if (!coreDataPattern.test(id) && !tempIdPattern.test(id)) {
+        throw new Error(`Invalid note ID format: "${id.substring(0, 80)}". Expected CoreData URL (x-coredata://...) or temp ID.`);
+    }
+    // Even with validation, escape for defense-in-depth
+    return escapeForAppleScript(id);
+}
+/**
+ * Sanitizes an account name for safe embedding in AppleScript.
+ *
+ * @param account - Account name string
+ * @returns Escaped account name safe for AppleScript string embedding
+ */
+function sanitizeAccountName(account) {
+    validateLength(account, MAX_ACCOUNT_LENGTH, "Account name");
+    return escapePlainStringForAppleScript(account);
+}
+/**
+ * Counter for generating unique fallback IDs within the same millisecond.
+ */
+let fallbackIdCounter = 0;
+/**
+ * Generates a unique fallback ID when AppleScript doesn't return a valid ID.
+ *
+ * This creates a temporary ID that's unique within this session. Format:
+ * "temp-{timestamp}-{counter}"
+ *
+ * @returns A unique temporary ID string
+ *
+ * @example
+ * generateFallbackId() // Returns: "temp-1704067200000-0"
+ * generateFallbackId() // Returns: "temp-1704067200000-1"
+ */
+export function generateFallbackId() {
+    return `temp-${Date.now()}-${fallbackIdCounter++}`;
+}
+/**
+ * Converts AppleScript date representation to JavaScript Date.
+ *
+ * AppleScript returns dates in a verbose format like:
+ * "date Saturday, December 27, 2025 at 3:44:02 PM"
+ *
+ * This function extracts the parseable portion and converts it
+ * to a JavaScript Date object.
+ *
+ * @param appleScriptDate - Date string from AppleScript
+ * @returns Parsed Date, or current date if parsing fails
+ *
+ * @example
+ * parseAppleScriptDate("date Saturday, December 27, 2025 at 3:44:02 PM")
+ * // Returns: Date object for Dec 27, 2025 3:44:02 PM
+ */
+export function parseAppleScriptDate(appleScriptDate) {
+    const s = appleScriptDate.trim();
+    // Locale-independent numeric form emitted by our producers (#25): "Y-M-D-H-m-s"
+    // built from AppleScript date components, so it never depends on the system's
+    // date-format locale (the old `date as text` form did, silently falling back
+    // to "now" on non-US Macs).
+    const numeric = s.match(/^(\d{1,5})-(\d{1,2})-(\d{1,2})-(\d{1,2})-(\d{1,2})-(\d{1,2})$/);
+    if (numeric) {
+        const [, y, mo, d, h, mi, se] = numeric;
+        const dt = new Date(Number(y), Number(mo) - 1, Number(d), Number(h), Number(mi), Number(se));
+        return isNaN(dt.getTime()) ? new Date() : dt;
+    }
+    // Legacy en-US verbose form: "date Saturday, December 27, 2025 at 3:44:02 PM".
+    // Remove the "date " prefix if present
+    const withoutPrefix = s.replace(/^date\s+/, "");
+    // Replace " at " with a space for standard date parsing
+    // "Saturday, December 27, 2025 at 3:44:02 PM" ->
+    // "Saturday, December 27, 2025 3:44:02 PM"
+    const normalized = withoutPrefix.replace(" at ", " ");
+    // Attempt to parse - JavaScript's Date constructor handles this format
+    const parsed = new Date(normalized);
+    // Return parsed date if valid, otherwise current date as fallback
+    return isNaN(parsed.getTime()) ? new Date() : parsed;
+}
+/**
+ * Generates AppleScript code that creates a date variable with the given values.
+ *
+ * This approach is locale-independent, unlike `date "M/D/YYYY"` coercion which
+ * depends on the system's date format settings and would fail on non-US locales.
+ *
+ * @param date - JavaScript Date object
+ * @param varName - AppleScript variable name to assign (default: "thresholdDate")
+ * @returns AppleScript code that sets up the date variable
+ *
+ * @example
+ * buildAppleScriptDateVar(new Date("2025-06-15T00:00:00"))
+ * // Returns multi-line AppleScript that sets thresholdDate to June 15, 2025 midnight
+ */
+export function buildAppleScriptDateVar(date, varName = "thresholdDate") {
+    const year = date.getFullYear();
+    const month = date.getMonth() + 1;
+    const day = date.getDate();
+    const timeInSeconds = date.getHours() * 3600 + date.getMinutes() * 60 + date.getSeconds();
+    return [
+        `set ${varName} to current date`,
+        `set year of ${varName} to ${year}`,
+        `set month of ${varName} to ${month}`,
+        `set day of ${varName} to ${day}`,
+        `set time of ${varName} to ${timeInSeconds}`,
+    ].join("\n");
+}
+/**
+ * Builds a locale-independent AppleScript expression that renders a date variable
+ * as "Y-M-D-H-m-s" from its numeric components (#25), parsed by
+ * {@link parseAppleScriptDate}. Avoids `(someDate as text)`, whose format depends
+ * on the system locale.
+ *
+ * @param v - name of an AppleScript variable already holding a date
+ */
+export function asDatePartsExpr(v) {
+    return (`((year of ${v}) as text) & "-" & ((month of ${v}) as integer as text) & "-" & ` +
+        `((day of ${v}) as text) & "-" & ((hours of ${v}) as text) & "-" & ` +
+        `((minutes of ${v}) as text) & "-" & ((seconds of ${v}) as text)`);
+}
+/**
+ * Parses AppleScript note properties output into structured data.
+ *
+ * AppleScript returns note properties in a format like:
+ * "title, id, date DayName, Month Day, Year at Time, date..., bool, bool"
+ *
+ * Dates contain commas, so we use regex to extract them safely.
+ *
+ * @param output - Raw AppleScript output string
+ * @returns Parsed properties, or null if format is invalid
+ */
+export function parseNotePropertiesOutput(output) {
+    // Fields are control-char delimited (#18): title, id, created, modified,
+    // shared, passwordProtected — robust against commas in titles, unlike the
+    // old comma/regex parsing.
+    const parts = output.split(FIELD_SEP);
+    if (parts.length < 6) {
+        console.error("Unexpected response format: expected 6 delimited note properties");
+        return null;
+    }
+    const [title, id, createdStr, modifiedStr, sharedStr, ppStr] = parts;
+    return {
+        title: title.trim(),
+        id: id.trim(),
+        created: createdStr?.trim() ? parseAppleScriptDate(createdStr.trim()) : new Date(),
+        modified: modifiedStr?.trim() ? parseAppleScriptDate(modifiedStr.trim()) : new Date(),
+        shared: sharedStr?.trim() === "true",
+        passwordProtected: ppStr?.trim() === "true",
+    };
+}
+/**
+ * Splits a folder path on unescaped `/` separators.
+ *
+ * Folder names may contain literal slashes (e.g., "Spain/Portugal 2023").
+ * In path strings these are escaped as `\/`. This function splits only on
+ * unescaped `/` and restores the literal slashes in each segment.
+ *
+ * @param folderPath - Folder path with `/` as hierarchy separator and `\/` for literal slashes
+ * @returns Array of folder name segments
+ */
+export function splitFolderPath(folderPath) {
+    // Split on `/` that is NOT preceded by `\`
+    // We use a negative lookbehind to avoid splitting on escaped slashes
+    const parts = folderPath.split(/(?<!\\)\//);
+    // Unescape `\/` → `/` in each segment
+    return parts.map((p) => p.replace(/\\\//g, "/")).filter((p) => p.length > 0);
+}
+/**
+ * Escapes literal slashes in a folder name for use in path strings.
+ *
+ * @param name - Raw folder name (may contain `/`)
+ * @returns Folder name with `/` escaped as `\/`
+ */
+function escapeFolderName(name) {
+    return name.replace(/\//g, "\\/");
+}
+/**
+ * Builds an AppleScript folder reference from a path string.
+ *
+ * Converts a folder path like "Work/Clients/Omnia" into the nested
+ * AppleScript syntax: `folder "Omnia" of folder "Clients" of folder "Work"`.
+ *
+ * A simple folder name like "Work" returns `folder "Work"`.
+ * Literal slashes in folder names must be escaped as `\/` (e.g., "Travel/Spain\/Portugal").
+ *
+ * @param folderPath - Folder name or slash-separated path (e.g., "Work/Clients")
+ * @returns AppleScript folder reference string
+ */
+export function buildFolderReference(folderPath) {
+    validateLength(folderPath, MAX_FOLDER_PATH_LENGTH, "Folder path");
+    const parts = splitFolderPath(folderPath);
+    if (parts.length > MAX_FOLDER_DEPTH) {
+        throw new Error(`Folder path exceeds maximum nesting depth of ${MAX_FOLDER_DEPTH} (got ${parts.length})`);
+    }
+    if (parts.length === 0) {
+        throw new Error("Folder path is empty");
+    }
+    // Build inside-out: last part is innermost, first part is outermost
+    return parts
+        .reverse()
+        .map((part) => `folder "${escapePlainStringForAppleScript(part)}"`)
+        .join(" of ");
+}
+/**
+ * Builds an AppleScript command wrapped in account context.
+ *
+ * Most Notes.app operations need to be scoped to an account:
+ * ```applescript
+ * tell application "Notes"
+ *   tell account "iCloud"
+ *     -- command here
+ *   end tell
+ * end tell
+ * ```
+ *
+ * This builder generates that wrapper structure.
+ *
+ * @param scope - Account to target
+ * @param command - The AppleScript command to execute
+ * @returns Complete AppleScript ready for execution
+ */
+function buildAccountScopedScript(scope, command) {
+    const safeAccount = sanitizeAccountName(scope.account);
+    return `
+    tell application "Notes"
+      tell account "${safeAccount}"
+        ${command}
+      end tell
+    end tell
+  `;
+}
+/**
+ * Builds an AppleScript command at the application level.
+ *
+ * Some operations (like listing accounts) don't need account scoping:
+ * ```applescript
+ * tell application "Notes"
+ *   -- command here
+ * end tell
+ * ```
+ *
+ * @param command - The AppleScript command to execute
+ * @returns Complete AppleScript ready for execution
+ */
+function buildAppLevelScript(command) {
+    return `
+    tell application "Notes"
+      ${command}
+    end tell
+  `;
+}
+// =============================================================================
+// Result Parsing Utilities
+// =============================================================================
+/**
+ * Extracts a CoreData ID from AppleScript output.
+ *
+ * Notes.app uses CoreData URLs as unique identifiers:
+ * "note id x-coredata://ABC123-DEF456/ICNote/p789"
+ *
+ * This function extracts the ID portion.
+ *
+ * @param output - AppleScript output containing an ID reference
+ * @param prefix - The object type prefix (e.g., "note", "folder")
+ * @returns Extracted ID or empty string
+ */
+function extractCoreDataId(output, prefix) {
+    const pattern = new RegExp(`${prefix} id ([^\\s]+)`);
+    const match = output.match(pattern);
+    return match ? match[1] : "";
+}
+// =============================================================================
+// Apple Notes Manager Class
+// =============================================================================
+/**
+ * Manages interactions with Apple Notes via AppleScript.
+ *
+ * This class provides a high-level TypeScript interface for all
+ * Notes.app operations. It handles:
+ *
+ * - Note CRUD operations (create, read, update, delete)
+ * - Note organization (folders, moving between folders)
+ * - Multi-account support (iCloud, Gmail, Exchange, etc.)
+ * - Search functionality (by title or content)
+ *
+ * All operations are synchronous since they rely on AppleScript
+ * execution via osascript. Error handling is consistent: methods
+ * return null/false/empty-array on failure rather than throwing.
+ *
+ * @example
+ * ```typescript
+ * const notes = new AppleNotesManager();
+ *
+ * // Create a note in the default (iCloud) account
+ * const note = notes.createNote("Shopping List", "Eggs, Milk, Bread");
+ *
+ * // Search across all notes
+ * const results = notes.searchNotes("shopping", true); // searches content
+ *
+ * // Work with a different account
+ * const gmailNotes = notes.listNotes("Gmail");
+ * ```
+ */
+export class AppleNotesManager {
+    /**
+     * Default account used when no account is specified.
+     * iCloud is the primary account for most Apple Notes users.
+     */
+    defaultAccount = "iCloud";
+    /**
+     * Resolves the account to use for an operation.
+     * Falls back to default if not specified.
+     */
+    resolveAccount(account) {
+        return account || this.defaultAccount;
+    }
+    /**
+     * Checks if a note is password-protected by its ID.
+     *
+     * Password-protected notes cannot have their content read or modified
+     * via AppleScript when locked. This method allows checking before
+     * attempting operations that would fail.
+     *
+     * @param id - CoreData URL identifier for the note
+     * @returns true if the note is password-protected, false otherwise
+     */
+    isNotePasswordProtectedById(id) {
+        const note = this.getNoteById(id);
+        return note?.passwordProtected === true;
+    }
+    /**
+     * Checks if a note is password-protected by its title.
+     *
+     * @param title - Exact title of the note
+     * @param account - Account to search in (defaults to iCloud)
+     * @returns true if the note is password-protected, false otherwise
+     */
+    isNotePasswordProtected(title, account) {
+        const note = this.getNoteDetails(title, account);
+        return note?.passwordProtected === true;
+    }
+    // ===========================================================================
+    // Note Operations
+    // ===========================================================================
+    /**
+     * Creates a new note in Apple Notes.
+     *
+     * The note is created with the specified title and content. If a folder
+     * is specified, the note is created in that folder; otherwise it goes
+     * to the account's default location.
+     *
+     * @param title - Display title for the note
+     * @param content - Body content (plain text that will be HTML-escaped, or raw HTML when format is "html")
+     * @param tags - Optional tags (stored in returned object, not used by Notes.app)
+     * @param folder - Optional folder name to create the note in
+     * @param account - Account to use (defaults to iCloud)
+     * @param format - Content format: "plaintext" escapes and wraps in div tags (default), "html" uses content as-is
+     * @returns Created Note object with metadata, or null on failure
+     *
+     * @example
+     * ```typescript
+     * // Simple note creation
+     * const note = manager.createNote("Meeting Notes", "Discussed Q4 plans");
+     *
+     * // Create in a specific folder
+     * const work = manager.createNote("Task List", "1. Review PR", [], "Work");
+     *
+     * // Create in a different account
+     * const gmail = manager.createNote("Draft", "...", [], undefined, "Gmail");
+     *
+     * // Create with HTML formatting (no need for <h1> — title is auto-prepended)
+     * const html = manager.createNote("Report", "<p>Details here</p>",
+     *   [], undefined, undefined, "html");
+     * ```
+     */
+    createNote(title, content, tags = [], folder, account, format = "plaintext") {
+        validateLength(title, MAX_TITLE_LENGTH, "Note title");
+        validateLength(content, MAX_CONTENT_LENGTH, "Note content");
+        const targetAccount = this.resolveAccount(account);
+        // Build body HTML: title as <h1>, content follows.
+        // We set only 'body' (not 'name') to avoid title duplication —
+        // Notes.app auto-uses the first line of body as the note's display title.
+        const htmlTitle = title.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+        const bodyContent = format === "html"
+            ? content
+            : content
+                .replace(/&/g, "&amp;")
+                .replace(/\\/g, "&#92;")
+                .replace(/</g, "&lt;")
+                .replace(/>/g, "&gt;")
+                .replace(/\n/g, "<br>")
+                .replace(/\t/g, "<br>");
+        const safeBody = escapeHtmlForAppleScript(`<h1>${htmlTitle}</h1>${bodyContent}`);
+        // Build the AppleScript command
+        let createCommand;
+        if (folder) {
+            // Create note in specific folder (supports nested paths like "Work/Clients")
+            // Note: We avoid `set newNote` + `return id of newNote` because AppleScript
+            // fails to resolve the note reference in deeply nested folder contexts (-1728).
+            // The implicit return from `make new note` includes the ID which we parse.
+            const folderRef = buildFolderReference(folder);
+            createCommand = `make new note at ${folderRef} with properties {body:"${safeBody}"}`;
+        }
+        else {
+            // Create note in default location
+            createCommand = `
+        set newNote to make new note with properties {body:"${safeBody}"}
+        return id of newNote
+      `;
+        }
+        // Execute the script
+        const script = buildAccountScopedScript({ account: targetAccount }, createCommand);
+        const result = executeAppleScript(script);
+        if (!result.success) {
+            console.error(`Failed to create note "${title}":`, result.error);
+            return null;
+        }
+        // Extract the CoreData ID from the response.
+        // AppleScript's `id of newNote` yields an object specifier of the form
+        // "note id x-coredata://<uuid>/ICNote/pN" — with a literal "note id " prefix.
+        // Strip that prefix so we return the bare x-coredata:// URL that the id
+        // validator and downstream tools (get-note-content, update-note) accept.
+        const rawOutput = result.output.trim();
+        const noteId = extractCoreDataId(rawOutput, "note") || rawOutput;
+        // Return a Note object representing the created note with real ID
+        const now = new Date();
+        return {
+            id: noteId || generateFallbackId(), // Use real ID, fallback to unique temp ID
+            title,
+            content,
+            tags,
+            created: now,
+            modified: now,
+            folder,
+            account: targetAccount,
+        };
+    }
+    /**
+     * Searches for notes matching a query.
+     *
+     * By default, searches note titles. Set searchContent=true to search
+     * the body text instead. Optionally filter to a specific folder.
+     *
+     * @param query - Text to search for
+     * @param searchContent - If true, search note bodies; if false, search titles
+     * @param account - Account to search in (defaults to iCloud)
+     * @param folder - Optional folder to limit search to
+     * @param modifiedSince - Optional ISO 8601 date string to filter notes modified on or after this date
+     * @param limit - Optional maximum number of results to return (default: no limit)
+     * @returns Array of matching notes (with minimal metadata)
+     *
+     * @example
+     * ```typescript
+     * // Search by title
+     * const meetingNotes = manager.searchNotes("meeting");
+     *
+     * // Search in note content
+     * const projectRefs = manager.searchNotes("Project Alpha", true);
+     *
+     * // Search within a specific folder
+     * const workNotes = manager.searchNotes("deadline", false, "iCloud", "Work");
+     *
+     * // Search only recently modified notes
+     * const recentNotes = manager.searchNotes("todo", true, undefined, undefined, "2025-01-01");
+     *
+     * // Search with a result limit
+     * const topResults = manager.searchNotes("project", false, undefined, undefined, undefined, 10);
+     * ```
+     */
+    searchNotes(query, searchContent = false, account, folder, modifiedSince, limit) {
+        const targetAccount = this.resolveAccount(account);
+        const safeQuery = escapePlainStringForAppleScript(query);
+        const safeLimit = limit !== undefined && limit > 0 ? Math.floor(limit) : undefined;
+        // Build the where clause based on search type
+        // AppleScript uses 'name' for title and 'body' for content
+        const whereParts = [];
+        if (searchContent) {
+            whereParts.push(`body contains "${safeQuery}"`);
+        }
+        else {
+            whereParts.push(`name contains "${safeQuery}"`);
+        }
+        // Add date filter if specified (uses locale-safe date variable)
+        let dateSetup = "";
+        if (modifiedSince) {
+            const date = new Date(modifiedSince);
+            if (!isNaN(date.getTime())) {
+                dateSetup = buildAppleScriptDateVar(date) + "\n";
+                whereParts.push(`modification date >= thresholdDate`);
+            }
+        }
+        const whereClause = whereParts.join(" and ");
+        // Build the notes source - either all notes or notes in a specific folder
+        const notesSource = folder ? `notes of ${buildFolderReference(folder)}` : "notes";
+        // Build the limit logic for the repeat loop
+        // Note: The limit only reduces iteration over already-matched results from the whose clause,
+        // not the query itself. It controls output size, not AppleScript query performance.
+        const limitCheck = safeLimit !== undefined
+            ? `
+          if (count of resultList) >= ${safeLimit} then exit repeat`
+            : "";
+        // Get names, IDs, and folder for each matching note.
+        // Notes.app can return the same CoreData note more than once when asking
+        // an account for all notes, so dedupe on note ID before adding results.
+        const searchCommand = `
+      ${dateSetup}set matchingNotes to ${notesSource} where ${whereClause}
+      set resultList to {}
+      set seenIds to {}
+      repeat with n in matchingNotes
+        try
+          set noteName to name of n
+          set noteId to id of n
+          if seenIds does not contain noteId then
+            set end of seenIds to noteId
+            try
+              set noteFolder to name of container of n
+            on error
+              set noteFolder to "Notes"
+            end try
+            set end of resultList to noteName & ${AS_FIELD_SEP} & noteId & ${AS_FIELD_SEP} & noteFolder${limitCheck}
+          end if
+        end try
+      end repeat
+      set AppleScript's text item delimiters to ${AS_RECORD_SEP}
+      return resultList as text
+    `;
+        const script = buildAccountScopedScript({ account: targetAccount }, searchCommand);
+        const result = executeAppleScript(script);
+        if (!result.success) {
+            // Surface the failure (#19) — an empty array would look like "no matches".
+            throw new Error(`Failed to search notes for "${query}": ${result.error ?? "unknown error"}`);
+        }
+        // Handle empty results
+        if (!result.output.trim()) {
+            return [];
+        }
+        // Parse the control-char-delimited output (#18): fields by FIELD_SEP, records by RECORD_SEP.
+        const items = result.output.split(RECORD_SEP);
+        const notes = [];
+        const seenIds = new Set();
+        for (const item of items) {
+            const [title, id, folder] = item.split(FIELD_SEP);
+            if (!title?.trim())
+                continue;
+            const noteId = id?.trim() || generateFallbackId();
+            if (seenIds.has(noteId))
+                continue;
+            seenIds.add(noteId);
+            notes.push({
+                id: noteId,
+                title: title.trim(),
+                content: "", // Not fetched in search
+                tags: [],
+                created: new Date(),
+                modified: new Date(),
+                folder: folder?.trim(),
+                account: targetAccount,
+            });
+        }
+        return notes;
+    }
+    /**
+     * Retrieves the HTML content of a note by its title.
+     *
+     * Note: Password-protected notes will fail with an AppleScript error.
+     * Callers should check for password protection beforehand using
+     * getNoteDetails() or isNotePasswordProtected().
+     *
+     * @param title - Exact title of the note
+     * @param account - Account to search in (defaults to iCloud)
+     * @returns HTML content of the note, or empty string if not found
+     *
+     * @example
+     * ```typescript
+     * const content = manager.getNoteContent("Shopping List");
+     * if (content) {
+     *   console.log("Note found:", content);
+     * }
+     * ```
+     */
+    getNoteContent(title, account) {
+        const targetAccount = this.resolveAccount(account);
+        const safeTitle = escapePlainStringForAppleScript(title);
+        // Retrieve the body property of the note
+        const getCommand = `get body of note "${safeTitle}"`;
+        const script = buildAccountScopedScript({ account: targetAccount }, getCommand);
+        const result = executeAppleScript(script);
+        if (!result.success) {
+            console.error(`Failed to get content of note "${title}":`, result.error);
+            return "";
+        }
+        return result.output;
+    }
+    /**
+     * Retrieves the HTML content of a note by its CoreData ID.
+     *
+     * This is more reliable than getNoteContent() because IDs are unique
+     * across all accounts, while titles can be duplicated.
+     *
+     * Note: Password-protected notes will fail with an AppleScript error.
+     * Callers should check for password protection beforehand using
+     * getNoteById() or isNotePasswordProtectedById().
+     *
+     * @param id - CoreData URL identifier for the note
+     * @returns HTML content of the note, or empty string if not found
+     */
+    getNoteContentById(id) {
+        const safeId = sanitizeId(id);
+        // Note IDs work at the application level, not scoped to account
+        const getCommand = `get body of note id "${safeId}"`;
+        const script = buildAppLevelScript(getCommand);
+        const result = executeAppleScript(script);
+        if (!result.success) {
+            console.error(`Failed to get content of note with ID "${id}":`, result.error);
+            return "";
+        }
+        return result.output;
+    }
+    /**
+     * Retrieves the plain-text content of a note by its exact title.
+     *
+     * Reads the note's `plaintext` property, which Notes derives from the body
+     * with all HTML markup removed. This is the text Notes itself exposes, so it
+     * is more faithful than converting the HTML body and skips the markup
+     * round-trip entirely.
+     *
+     * @param title - Exact title of the note
+     * @param account - Account to search in (defaults to iCloud)
+     * @returns Plain-text content of the note, or empty string if not found
+     */
+    getNotePlaintext(title, account) {
+        const targetAccount = this.resolveAccount(account);
+        const safeTitle = escapePlainStringForAppleScript(title);
+        const getCommand = `get plaintext of note "${safeTitle}"`;
+        const script = buildAccountScopedScript({ account: targetAccount }, getCommand);
+        const result = executeAppleScript(script);
+        if (!result.success) {
+            console.error(`Failed to get plaintext of note "${title}":`, result.error);
+            return "";
+        }
+        return result.output;
+    }
+    /**
+     * Retrieves the plain-text content of a note by its CoreData ID.
+     *
+     * Reads the read-only `plaintext` property (the body with HTML removed). More
+     * reliable than getNotePlaintext() because IDs are unique across accounts.
+     *
+     * Note: Password-protected notes will fail with an AppleScript error. Callers
+     * should check for password protection beforehand using getNoteById().
+     *
+     * @param id - CoreData URL identifier for the note
+     * @returns Plain-text content of the note, or empty string if not found
+     */
+    getNotePlaintextById(id) {
+        const safeId = sanitizeId(id);
+        const getCommand = `get plaintext of note id "${safeId}"`;
+        const script = buildAppLevelScript(getCommand);
+        const result = executeAppleScript(script);
+        if (!result.success) {
+            console.error(`Failed to get plaintext of note with ID "${id}":`, result.error);
+            return "";
+        }
+        return result.output;
+    }
+    /**
+     * Retrieves a note by its unique CoreData ID.
+     *
+     * Each note has a unique ID in the format:
+     * "x-coredata://DEVICE-UUID/ICNote/pXXXX"
+     *
+     * This method fetches the note and its metadata using this ID.
+     *
+     * @param id - CoreData URL identifier for the note
+     * @returns Note object with metadata, or null if not found
+     */
+    getNoteById(id) {
+        const safeId = sanitizeId(id);
+        // Note IDs work at the application level, not scoped to account
+        const getCommand = `
+      set n to note id "${safeId}"
+      set cd to creation date of n
+      set md to modification date of n
+      set noteProps to {name of n, id of n, ${asDatePartsExpr("cd")}, ${asDatePartsExpr("md")}, (shared of n as text), (password protected of n as text)}
+      set AppleScript's text item delimiters to ${AS_FIELD_SEP}
+      return noteProps as text
+    `;
+        const script = buildAppLevelScript(getCommand);
+        const result = executeAppleScript(script);
+        if (!result.success) {
+            console.error(`Failed to get note with ID "${id}":`, result.error);
+            return null;
+        }
+        // Parse the AppleScript output using the shared helper
+        const parsed = parseNotePropertiesOutput(result.output);
+        if (!parsed) {
+            return null;
+        }
+        return {
+            id: parsed.id,
+            title: parsed.title,
+            content: "", // Not fetched to keep response small
+            tags: [],
+            created: parsed.created,
+            modified: parsed.modified,
+            shared: parsed.shared,
+            passwordProtected: parsed.passwordProtected,
+        };
+    }
+    /**
+     * Retrieves detailed metadata for a note by title.
+     *
+     * Similar to getNoteContent but returns structured metadata
+     * including creation date, modification date, and sharing status.
+     *
+     * @param title - Exact title of the note
+     * @param account - Account to search in (defaults to iCloud)
+     * @returns Note object with full metadata, or null if not found
+     */
+    getNoteDetails(title, account) {
+        const targetAccount = this.resolveAccount(account);
+        const safeTitle = escapePlainStringForAppleScript(title);
+        // Fetch multiple properties at once
+        const getCommand = `
+      set n to note "${safeTitle}"
+      set cd to creation date of n
+      set md to modification date of n
+      set noteProps to {name of n, id of n, ${asDatePartsExpr("cd")}, ${asDatePartsExpr("md")}, (shared of n as text), (password protected of n as text)}
+      set AppleScript's text item delimiters to ${AS_FIELD_SEP}
+      return noteProps as text
+    `;
+        const script = buildAccountScopedScript({ account: targetAccount }, getCommand);
+        const result = executeAppleScript(script);
+        if (!result.success) {
+            console.error(`Failed to get details for note "${title}":`, result.error);
+            return null;
+        }
+        // Parse the AppleScript output using the shared helper
+        const parsed = parseNotePropertiesOutput(result.output);
+        if (!parsed) {
+            return null;
+        }
+        return {
+            id: parsed.id,
+            title: parsed.title,
+            content: "", // Not fetched
+            tags: [],
+            created: parsed.created,
+            modified: parsed.modified,
+            shared: parsed.shared,
+            passwordProtected: parsed.passwordProtected,
+            account: targetAccount,
+        };
+    }
+    /**
+     * Deletes a note by its title.
+     *
+     * Note: This permanently deletes the note. It may be recoverable
+     * from the "Recently Deleted" folder in Notes.app.
+     *
+     * @param title - Exact title of the note to delete
+     * @param account - Account containing the note (defaults to iCloud)
+     * @returns true if deletion succeeded, false otherwise
+     */
+    deleteNote(title, account) {
+        const targetAccount = this.resolveAccount(account);
+        const safeTitle = escapePlainStringForAppleScript(title);
+        const deleteCommand = `delete note "${safeTitle}"`;
+        const script = buildAccountScopedScript({ account: targetAccount }, deleteCommand);
+        const result = executeAppleScript(script);
+        if (!result.success) {
+            console.error(`Failed to delete note "${title}":`, result.error);
+            return false;
+        }
+        return true;
+    }
+    /**
+     * Deletes a note by its CoreData ID.
+     *
+     * This is more reliable than deleteNote() because IDs are unique
+     * across all accounts, while titles can be duplicated.
+     *
+     * @param id - CoreData URL identifier for the note
+     * @returns true if deletion succeeded, false otherwise
+     */
+    deleteNoteById(id) {
+        const safeId = sanitizeId(id);
+        const deleteCommand = `delete note id "${safeId}"`;
+        const script = buildAppLevelScript(deleteCommand);
+        const result = executeAppleScript(script);
+        if (!result.success) {
+            console.error(`Failed to delete note with ID "${id}":`, result.error);
+            return false;
+        }
+        return true;
+    }
+    /**
+     * Updates an existing note's content and optionally its title.
+     *
+     * Apple Notes derives the title from the first line of the body,
+     * so updating content also allows title changes. If newTitle is
+     * not provided, the original title is preserved.
+     *
+     * When format is 'html', newTitle is ignored — the caller must include
+     * the title in the HTML content.
+     *
+     * Note: Password-protected notes will fail with an AppleScript error.
+     * Callers should check for password protection beforehand using
+     * getNoteDetails() or isNotePasswordProtected().
+     *
+     * @param title - Current title of the note to update
+     * @param newTitle - New title (optional, keeps existing if not provided; ignored in html format)
+     * @param newContent - New content for the note body
+     * @param account - Account containing the note (defaults to iCloud)
+     * @param format - Content format: "plaintext" wraps in div tags (default), "html" uses content as-is
+     * @returns true if update succeeded, false otherwise
+     */
+    updateNote(title, newTitle, newContent, account, format = "plaintext") {
+        if (newTitle)
+            validateLength(newTitle, MAX_TITLE_LENGTH, "Note title");
+        validateLength(newContent, MAX_CONTENT_LENGTH, "Note content");
+        const targetAccount = this.resolveAccount(account);
+        const safeCurrentTitle = escapePlainStringForAppleScript(title);
+        let fullBody;
+        if (format === "html") {
+            // HTML mode: content is the complete body, escaped only for AppleScript string
+            fullBody = escapeHtmlForAppleScript(newContent);
+        }
+        else {
+            // Plaintext mode: wrap title + content in <div> tags (existing behavior)
+            const effectiveTitle = newTitle || title;
+            const safeEffectiveTitle = escapeForAppleScript(effectiveTitle);
+            const safeContent = escapeForAppleScript(newContent);
+            fullBody = `<div>${safeEffectiveTitle}</div><div>${safeContent}</div>`;
+        }
+        const updateCommand = `set body of note "${safeCurrentTitle}" to "${fullBody}"`;
+        const script = buildAccountScopedScript({ account: targetAccount }, updateCommand);
+        const result = executeAppleScript(script);
+        if (!result.success) {
+            console.error(`Failed to update note "${title}":`, result.error);
+            return false;
+        }
+        return true;
+    }
+    /**
+     * Updates an existing note by its CoreData ID.
+     *
+     * This is more reliable than updateNote() because IDs are unique,
+     * while titles can be duplicated.
+     *
+     * When format is 'html', newTitle is ignored — the caller must include
+     * the title in the HTML content.
+     *
+     * Note: Password-protected notes will fail with an AppleScript error.
+     * Callers should check for password protection beforehand using
+     * getNoteById() or isNotePasswordProtectedById().
+     *
+     * @param id - CoreData URL identifier for the note
+     * @param newTitle - New title (optional, keeps existing if not provided; ignored in html format)
+     * @param newContent - New content for the note body
+     * @param format - Content format: "plaintext" wraps in div tags (default), "html" uses content as-is
+     * @returns true if update succeeded, false otherwise
+     */
+    updateNoteById(id, newTitle, newContent, format = "plaintext") {
+        if (newTitle)
+            validateLength(newTitle, MAX_TITLE_LENGTH, "Note title");
+        validateLength(newContent, MAX_CONTENT_LENGTH, "Note content");
+        let fullBody;
+        if (format === "html") {
+            // HTML mode: content is the complete body, escaped only for AppleScript string
+            fullBody = escapeHtmlForAppleScript(newContent);
+        }
+        else {
+            // Plaintext mode: wrap title + content in <div> tags (existing behavior)
+            // Get the note to retrieve current title if newTitle not provided
+            let effectiveTitle = newTitle;
+            if (!effectiveTitle) {
+                const note = this.getNoteById(id);
+                if (!note) {
+                    console.error(`Cannot update note: note with ID "${id}" not found`);
+                    return false;
+                }
+                effectiveTitle = note.title;
+            }
+            const safeEffectiveTitle = escapeForAppleScript(effectiveTitle);
+            const safeContent = escapeForAppleScript(newContent);
+            fullBody = `<div>${safeEffectiveTitle}</div><div>${safeContent}</div>`;
+        }
+        const safeId = sanitizeId(id);
+        const updateCommand = `set body of note id "${safeId}" to "${fullBody}"`;
+        const script = buildAppLevelScript(updateCommand);
+        const result = executeAppleScript(script);
+        if (!result.success) {
+            console.error(`Failed to update note with ID "${id}":`, result.error);
+            return false;
+        }
+        return true;
+    }
+    /**
+     * Lists all notes in an account, optionally filtered by folder, date, and limit.
+     *
+     * @param account - Account to list notes from (defaults to iCloud)
+     * @param folder - Optional folder to filter by
+     * @param modifiedSince - Optional ISO 8601 date string to filter notes modified on or after this date
+     * @param limit - Optional maximum number of results to return (default: no limit)
+     * @returns Array of note titles
+     */
+    listNotes(account, folder, modifiedSince, limit) {
+        const targetAccount = this.resolveAccount(account);
+        const safeLimit = limit !== undefined && limit > 0 ? Math.floor(limit) : undefined;
+        // When date or limit filters are needed, use a repeat loop for fine-grained control
+        if (modifiedSince || safeLimit !== undefined) {
+            const baseNotesSource = folder ? `notes of ${buildFolderReference(folder)}` : "notes";
+            // Use whose clause for date filtering (locale-safe, no sort order assumption)
+            let dateSetup = "";
+            let notesSource = baseNotesSource;
+            if (modifiedSince) {
+                const date = new Date(modifiedSince);
+                if (!isNaN(date.getTime())) {
+                    dateSetup = buildAppleScriptDateVar(date) + "\n";
+                    notesSource = `(${baseNotesSource} whose modification date >= thresholdDate)`;
+                }
+            }
+            // Build the limit check. Check after appending so deduped results,
+            // rather than duplicate AppleScript references, determine the limit.
+            const limitCheck = safeLimit !== undefined
+                ? `
+            if (count of resultList) >= ${safeLimit} then exit repeat`
+                : "";
+            const listCommand = `
+        ${dateSetup}set resultList to {}
+        set seenIds to {}
+        repeat with n in ${notesSource}
+          try
+            set noteName to name of n
+            set noteId to id of n
+            if seenIds does not contain noteId then
+              set end of seenIds to noteId
+              set end of resultList to noteName & ${AS_FIELD_SEP} & noteId${limitCheck}
+            end if
+          end try
+        end repeat
+        set AppleScript's text item delimiters to ${AS_RECORD_SEP}
+        return resultList as text
+      `;
+            const script = buildAccountScopedScript({ account: targetAccount }, listCommand);
+            const result = executeAppleScript(script);
+            if (!result.success) {
+                throw new Error(`Failed to list notes: ${result.error ?? "unknown error"}`);
+            }
+            if (!result.output.trim()) {
+                return [];
+            }
+            const seenIds = new Set();
+            const titles = [];
+            for (const item of result.output.split(RECORD_SEP)) {
+                const [title, id] = item.split(FIELD_SEP);
+                if (!title?.trim())
+                    continue;
+                const noteId = id?.trim() || generateFallbackId();
+                if (seenIds.has(noteId))
+                    continue;
+                seenIds.add(noteId);
+                titles.push(title.trim());
+            }
+            return titles;
+        }
+        // Simple path: no date or limit filters. Use a repeat loop so duplicate
+        // CoreData note references can be deduped by ID before returning titles.
+        const notesRef = folder ? `notes of ${buildFolderReference(folder)}` : `notes`;
+        const listCommand = `
+      set resultList to {}
+      set seenIds to {}
+      repeat with n in ${notesRef}
+        try
+          set noteName to name of n
+          set noteId to id of n
+          if seenIds does not contain noteId then
+            set end of seenIds to noteId
+            set end of resultList to noteName & ${AS_FIELD_SEP} & noteId
+          end if
+        end try
+      end repeat
+      set AppleScript's text item delimiters to ${AS_RECORD_SEP}
+      return resultList as text
+    `;
+        const script = buildAccountScopedScript({ account: targetAccount }, listCommand);
+        const result = executeAppleScript(script);
+        if (!result.success) {
+            throw new Error(`Failed to list notes: ${result.error ?? "unknown error"}`);
+        }
+        if (!result.output.trim())
+            return [];
+        const seenIds = new Set();
+        const titles = [];
+        for (const item of result.output.split(RECORD_SEP)) {
+            const [title, id] = item.split(FIELD_SEP);
+            if (!title?.trim())
+                continue;
+            const noteId = id?.trim() || generateFallbackId();
+            if (seenIds.has(noteId))
+                continue;
+            seenIds.add(noteId);
+            titles.push(title.trim());
+        }
+        return titles;
+    }
+    /**
+     * Lists all shared (collaborative) notes across all accounts.
+     *
+     * Returns notes that are shared with other users. These notes require
+     * extra caution when modifying or deleting as changes affect collaborators.
+     *
+     * @returns Array of Note objects for all shared notes
+     *
+     * @example
+     * ```typescript
+     * const shared = manager.listSharedNotes();
+     * console.log(`You have ${shared.length} shared notes`);
+     * ```
+     */
+    listSharedNotes() {
+        const sharedNotes = [];
+        // Query each account for shared notes
+        const accounts = this.listAccounts();
+        for (const account of accounts) {
+            // Use delimited output to avoid fragile comma-based parsing.
+            // Format: name|||id|||createdDate|||modifiedDate|||shared|||passwordProtected
+            const script = buildAccountScopedScript({ account: account.name }, `
+        set resultList to {}
+        repeat with n in notes
+          if shared of n is true then
+            set cd to creation date of n
+            set md to modification date of n
+            set end of resultList to (name of n) & ${AS_FIELD_SEP} & (id of n) & ${AS_FIELD_SEP} & ${asDatePartsExpr("cd")} & ${AS_FIELD_SEP} & ${asDatePartsExpr("md")} & ${AS_FIELD_SEP} & (shared of n as text) & ${AS_FIELD_SEP} & (password protected of n as text)
+          end if
+        end repeat
+        set AppleScript's text item delimiters to ${AS_RECORD_SEP}
+        return resultList as text
+        `);
+            const result = executeAppleScript(script);
+            if (!result.success) {
+                console.error(`Failed to list shared notes for ${account.name}:`, result.error);
+                continue;
+            }
+            const output = result.output.trim();
+            if (!output) {
+                continue;
+            }
+            // Parse control-char-delimited output (#18): fields by FIELD_SEP, records by RECORD_SEP.
+            const items = output.split(RECORD_SEP);
+            for (const item of items) {
+                const parts = item.split(FIELD_SEP);
+                if (parts.length >= 6) {
+                    const title = parts[0].trim();
+                    const id = parts[1].trim();
+                    const createdStr = parts[2].trim();
+                    const modifiedStr = parts[3].trim();
+                    const shared = parts[4].trim() === "true";
+                    const passwordProtected = parts[5].trim() === "true";
+                    sharedNotes.push({
+                        id,
+                        title,
+                        content: "",
+                        tags: [],
+                        created: parseAppleScriptDate(createdStr),
+                        modified: parseAppleScriptDate(modifiedStr),
+                        account: account.name,
+                        shared,
+                        passwordProtected,
+                    });
+                }
+            }
+        }
+        return sharedNotes;
+    }
+    // ===========================================================================
+    // Folder Operations
+    // ===========================================================================
+    /**
+     * Lists all folders in an account with full hierarchical paths.
+     *
+     * Each folder's `name` field contains the full path (e.g., "Work/Clients/Omnia")
+     * so that duplicate folder names (e.g., multiple "Archive" folders) are
+     * distinguishable and can be used directly in other operations.
+     *
+     * @param account - Account to list folders from (defaults to iCloud)
+     * @returns Array of Folder objects with path-based names
+     */
+    listFolders(account) {
+        const targetAccount = this.resolveAccount(account);
+        // Get each folder's ID, name, parent ID, and shared state in a single AppleScript call.
+        // Using IDs enables correct tree building even with duplicate folder names.
+        const listCommand = `
+      set folderList to {}
+      set allFolders to every folder
+      repeat with f in allFolders
+        set fRef to contents of f
+        set cRef to container of fRef
+        set parentId to ""
+        if class of cRef is folder then
+          set parentId to id of cRef
+        end if
+        set sharedFlag to shared of fRef as text
+        set end of folderList to (id of fRef) & ${AS_FIELD_SEP} & (name of fRef) & ${AS_FIELD_SEP} & parentId & ${AS_FIELD_SEP} & sharedFlag
+      end repeat
+      set AppleScript's text item delimiters to ${AS_RECORD_SEP}
+      return folderList as text
+    `;
+        const script = buildAccountScopedScript({ account: targetAccount }, listCommand);
+        const result = executeAppleScript(script);
+        if (!result.success) {
+            throw new Error(`Failed to list folders: ${result.error ?? "unknown error"}`);
+        }
+        if (!result.output.trim()) {
+            return [];
+        }
+        const recordSeparator = result.output.includes(RECORD_SEP) ? RECORD_SEP : "\n";
+        const entries = result.output.split(recordSeparator).map((line) => {
+            const parts = line.includes(FIELD_SEP) ? line.split(FIELD_SEP) : line.split("\t");
+            return {
+                id: (parts[0] || "").trim(),
+                name: (parts[1] || "").trim(),
+                parentId: (parts[2] || "").trim(),
+                shared: (parts[3] || "").trim().toLowerCase() === "true",
+            };
+        });
+        // Build an ID-to-entry map for efficient parent lookups
+        const byId = new Map(entries.map((e) => [e.id, e]));
+        // Build full path by walking up the parent chain using unique IDs
+        // Build full path by walking up the parent chain using unique IDs.
+        // Literal slashes in folder names are escaped as `\/` so they don't
+        // collide with the `/` path separator.
+        const buildPath = (entry) => {
+            const safeName = escapeFolderName(entry.name);
+            if (!entry.parentId)
+                return safeName;
+            const parent = byId.get(entry.parentId);
+            if (parent) {
+                return buildPath(parent) + "/" + safeName;
+            }
+            return safeName;
+        };
+        return entries.map((entry) => ({
+            id: entry.id,
+            name: buildPath(entry),
+            account: targetAccount,
+            shared: entry.shared,
+        }));
+    }
+    /**
+     * Creates a new folder in an account.
+     *
+     * @param name - Name for the new folder
+     * @param account - Account to create folder in (defaults to iCloud)
+     * @returns Created Folder object, or null on failure
+     */
+    createFolder(name, account) {
+        const targetAccount = this.resolveAccount(account);
+        const parts = splitFolderPath(name);
+        if (parts.length === 0) {
+            console.error(`Invalid folder name: "${name}"`);
+            return null;
+        }
+        // Create each segment of the path, checking existence first to avoid duplicates.
+        // For "A/B/C": ensure "A" exists, then "A/B", then "A/B/C".
+        for (let i = 0; i < parts.length; i++) {
+            const currentPath = parts
+                .slice(0, i + 1)
+                .map((p) => escapeFolderName(p))
+                .join("/");
+            const currentRef = buildFolderReference(currentPath);
+            // Check if this folder already exists
+            const checkScript = buildAccountScopedScript({ account: targetAccount }, `return id of ${currentRef}`);
+            const checkResult = executeAppleScript(checkScript);
+            if (checkResult.success) {
+                // Folder exists, move to next segment
+                continue;
+            }
+            // Folder doesn't exist — create it
+            const segmentName = escapePlainStringForAppleScript(parts[i]);
+            let createCommand;
+            if (i === 0) {
+                createCommand = `make new folder with properties {name:"${segmentName}"}`;
+            }
+            else {
+                const parentPath = parts
+                    .slice(0, i)
+                    .map((p) => escapeFolderName(p))
+                    .join("/");
+                const parentRef = buildFolderReference(parentPath);
+                createCommand = `make new folder at ${parentRef} with properties {name:"${segmentName}"}`;
+            }
+            const script = buildAccountScopedScript({ account: targetAccount }, createCommand);
+            const result = executeAppleScript(script);
+            if (!result.success) {
+                console.error(`Failed to create folder "${name}":`, result.error);
+                return null;
+            }
+        }
+        // Get the ID of the final (deepest) folder
+        const fullRef = buildFolderReference(name);
+        const idScript = buildAccountScopedScript({ account: targetAccount }, `return id of ${fullRef}`);
+        const idResult = executeAppleScript(idScript);
+        const folderId = idResult.success ? extractCoreDataId(idResult.output, "folder") : "";
+        return {
+            id: folderId,
+            name,
+            account: targetAccount,
+        };
+    }
+    /**
+     * Deletes a folder from an account.
+     *
+     * Note: This may fail if the folder contains notes.
+     *
+     * @param name - Name of the folder to delete
+     * @param account - Account containing the folder (defaults to iCloud)
+     * @returns true if deletion succeeded, false otherwise
+     */
+    deleteFolder(name, account) {
+        const targetAccount = this.resolveAccount(account);
+        const deleteCommand = `delete ${buildFolderReference(name)}`;
+        const script = buildAccountScopedScript({ account: targetAccount }, deleteCommand);
+        const result = executeAppleScript(script);
+        if (!result.success) {
+            console.error(`Failed to delete folder "${name}":`, result.error);
+            return false;
+        }
+        return true;
+    }
+    /**
+     * Moves a note to a different folder, looked up by title.
+     *
+     * Uses Notes.app's native `move` command (the same one `batchMoveNotes`
+     * uses), which relocates the note in place — preserving its identity, id,
+     * creation date, AND all embedded attachments (files/images/PDFs/scans/audio).
+     * The previous copy-then-delete implementation rebuilt the note from its body
+     * HTML, which silently dropped attachments and reset the note's identity.
+     *
+     * The note is resolved to its id first (titles can be duplicated), then moved
+     * by id so the title-based and id-based paths share the same native move.
+     *
+     * @param title - Title of the note to move
+     * @param destinationFolder - Name of the folder to move to (must already exist)
+     * @param account - Account containing the note (defaults to iCloud)
+     * @returns true if the move succeeded, false otherwise
+     */
+    moveNote(title, destinationFolder, account) {
+        const targetAccount = this.resolveAccount(account);
+        // Resolve the note's id first (titles can be duplicated), then delegate to
+        // the id-based native move so both paths preserve attachments + identity.
+        const originalNote = this.getNoteDetails(title, targetAccount);
+        if (!originalNote) {
+            console.error(`Cannot move note "${title}": note not found`);
+            return false;
+        }
+        return this.moveNoteById(originalNote.id, destinationFolder, targetAccount);
+    }
+    /**
+     * Moves a note to a different folder by its CoreData ID.
+     *
+     * Uses Notes.app's native `move <noteRef> to <destFolder>` command — the same
+     * one `batchMoveNotes` uses — which relocates the note in place, preserving its
+     * id, creation date, and all embedded attachments. (The old copy-then-delete
+     * approach rebuilt the note from body HTML and silently lost attachments.)
+     *
+     * @param id - CoreData URL identifier for the note
+     * @param destinationFolder - Name of the folder to move to (must already exist)
+     * @param account - Account containing the destination folder (defaults to iCloud)
+     * @returns true if the move succeeded, false otherwise
+     */
+    moveNoteById(id, destinationFolder, account) {
+        const targetAccount = this.resolveAccount(account);
+        const safeId = sanitizeId(id);
+        const safeAccount = sanitizeAccountName(targetAccount);
+        // buildFolderReference validates the destination path; a malformed folder is
+        // a precondition error, so let it throw. The destination folder must already
+        // exist — Notes.app's `move` does not create it.
+        const destFolderRef = `${buildFolderReference(destinationFolder)} of account "${safeAccount}"`;
+        const moveCommand = `
+      set destFolder to ${destFolderRef}
+      set noteRef to note id "${safeId}"
+      move noteRef to destFolder
+    `;
+        const script = buildAppLevelScript(moveCommand);
+        const result = executeAppleScript(script);
+        if (!result.success) {
+            console.error(`Cannot move note to "${destinationFolder}" (folder may not exist):`, result.error);
+            return false;
+        }
+        return true;
+    }
+    // ===========================================================================
+    // Account Operations
+    // ===========================================================================
+    /**
+     * Lists all available Notes accounts.
+     *
+     * Common accounts include iCloud, Gmail, Exchange, and other
+     * email providers configured on the Mac.
+     *
+     * @returns Array of Account objects
+     */
+    listAccounts() {
+        // Coerce account records to text with control-char delimiters so names
+        // containing commas or tabs can't split into phantom accounts (#18).
+        const listCommand = `
+      set resultList to {}
+      repeat with a in accounts
+        set aRef to contents of a
+        set defaultFolderId to ""
+        set defaultFolderName to ""
+        try
+          set fRef to default folder of aRef
+          set defaultFolderId to id of fRef
+          set defaultFolderName to name of fRef
+        end try
+        set upgradedFlag to upgraded of aRef as text
+        set end of resultList to (id of aRef) & ${AS_FIELD_SEP} & (name of aRef) & ${AS_FIELD_SEP} & upgradedFlag & ${AS_FIELD_SEP} & defaultFolderId & ${AS_FIELD_SEP} & defaultFolderName
+      end repeat
+      set AppleScript's text item delimiters to ${AS_RECORD_SEP}
+      return resultList as text
+    `;
+        const script = buildAppLevelScript(listCommand);
+        const result = executeAppleScript(script);
+        if (!result.success) {
+            throw new Error(`Failed to list accounts: ${result.error ?? "unknown error"}`);
+        }
+        return result.output
+            .split(RECORD_SEP)
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0)
+            .map((item) => {
+            const parts = item.split(FIELD_SEP);
+            if (parts.length === 1) {
+                return { name: parts[0].trim() };
+            }
+            return {
+                id: (parts[0] || "").trim(),
+                name: (parts[1] || "").trim(),
+                upgraded: (parts[2] || "").trim().toLowerCase() === "true",
+                defaultFolderId: (parts[3] || "").trim() || undefined,
+                defaultFolder: (parts[4] || "").trim() || undefined,
+            };
+        });
+    }
+    /**
+     * Gets the default account and folder used by Notes.app for new notes.
+     *
+     * @returns Default account and folder metadata
+     */
+    getDefaultLocation() {
+        const command = `
+      set aRef to default account
+      set fRef to default folder of aRef
+      return (id of aRef) & ${AS_FIELD_SEP} & (name of aRef) & ${AS_FIELD_SEP} & (upgraded of aRef as text) & ${AS_FIELD_SEP} & (id of fRef) & ${AS_FIELD_SEP} & (name of fRef) & ${AS_FIELD_SEP} & (shared of fRef as text)
+    `;
+        const result = executeAppleScript(buildAppLevelScript(command));
+        if (!result.success) {
+            throw new Error(`Failed to get default Notes location: ${result.error ?? "unknown error"}`);
+        }
+        const parts = result.output.split(FIELD_SEP);
+        if (parts.length < 6) {
+            throw new Error(`Failed to parse default Notes location: ${result.output}`);
+        }
+        const accountName = (parts[1] || "").trim();
+        return {
+            account: {
+                id: (parts[0] || "").trim(),
+                name: accountName,
+                upgraded: (parts[2] || "").trim().toLowerCase() === "true",
+                defaultFolderId: (parts[3] || "").trim(),
+                defaultFolder: (parts[4] || "").trim(),
+            },
+            folder: {
+                id: (parts[3] || "").trim(),
+                name: (parts[4] || "").trim(),
+                account: accountName,
+                shared: (parts[5] || "").trim().toLowerCase() === "true",
+            },
+        };
+    }
+    /**
+     * Lists the currently selected Notes in the Notes.app UI.
+     *
+     * @returns Array of selected notes, or an empty array when nothing is selected
+     */
+    getSelectedNotes() {
+        const command = `
+      set selectedNotes to selection
+      set noteList to {}
+      repeat with n in selectedNotes
+        set nRef to contents of n
+        set createdDate to creation date of nRef
+        set modifiedDate to modification date of nRef
+        set createdParts to ${asDatePartsExpr("createdDate")}
+        set modifiedParts to ${asDatePartsExpr("modifiedDate")}
+        set folderName to ""
+        set accountName to ""
+        try
+          set fRef to container of nRef
+          set folderName to name of fRef
+          set aRef to container of fRef
+          set accountName to name of aRef
+        end try
+        set end of noteList to (id of nRef) & ${AS_FIELD_SEP} & (name of nRef) & ${AS_FIELD_SEP} & createdParts & ${AS_FIELD_SEP} & modifiedParts & ${AS_FIELD_SEP} & (shared of nRef as text) & ${AS_FIELD_SEP} & (password protected of nRef as text) & ${AS_FIELD_SEP} & folderName & ${AS_FIELD_SEP} & accountName
+      end repeat
+      set AppleScript's text item delimiters to ${AS_RECORD_SEP}
+      return noteList as text
+    `;
+        const result = executeAppleScript(buildAppLevelScript(command));
+        if (!result.success) {
+            throw new Error(`Failed to get selected notes: ${result.error ?? "unknown error"}`);
+        }
+        if (!result.output.trim()) {
+            return [];
+        }
+        return result.output
+            .split(RECORD_SEP)
+            .filter((s) => s.trim())
+            .map((item) => {
+            const parts = item.split(FIELD_SEP);
+            return {
+                id: (parts[0] || "").trim(),
+                title: (parts[1] || "").trim(),
+                content: "",
+                tags: [],
+                created: parseAppleScriptDate((parts[2] || "").trim()),
+                modified: parseAppleScriptDate((parts[3] || "").trim()),
+                shared: (parts[4] || "").trim().toLowerCase() === "true",
+                passwordProtected: (parts[5] || "").trim().toLowerCase() === "true",
+                folder: (parts[6] || "").trim() || undefined,
+                account: (parts[7] || "").trim() || undefined,
+            };
+        });
+    }
+    /**
+     * Reveals a note in the Notes.app UI by ID.
+     *
+     * @param id - CoreData URL identifier for the note
+     * @param separately - Whether to open the note in a separate window
+     * @returns true if Notes.app accepted the show command
+     */
+    showNoteById(id, separately = false) {
+        const safeId = sanitizeId(id);
+        const separatelyClause = separately ? " separately true" : "";
+        const result = executeAppleScript(buildAppLevelScript(`show note id "${safeId}"${separatelyClause}`));
+        if (!result.success) {
+            console.error(`Failed to show note with ID "${id}":`, result.error);
+            return false;
+        }
+        return true;
+    }
+    /**
+     * Reveals a folder in the Notes.app UI by its id.
+     *
+     * Wraps the Notes `show` command, which the scripting dictionary exposes for
+     * folders as well as notes. This opens or focuses the Notes UI on the folder.
+     *
+     * @param id - CoreData identifier for the folder (from list-folders)
+     * @param separately - Open in a separate window when supported by Notes.app
+     * @returns true if Notes.app accepted the show command, false otherwise
+     */
+    showFolderById(id, separately = false) {
+        const safeId = sanitizeId(id);
+        const separatelyClause = separately ? " separately true" : "";
+        const result = executeAppleScript(buildAppLevelScript(`show folder id "${safeId}"${separatelyClause}`));
+        if (!result.success) {
+            console.error(`Failed to show folder with ID "${id}":`, result.error);
+            return false;
+        }
+        return true;
+    }
+    /**
+     * Reveals an account in the Notes.app UI by its id.
+     *
+     * Wraps the Notes `show` command, which the scripting dictionary exposes for
+     * accounts as well as notes. This opens or focuses the Notes UI on the account.
+     *
+     * @param id - CoreData identifier for the account (from list-accounts)
+     * @param separately - Open in a separate window when supported by Notes.app
+     * @returns true if Notes.app accepted the show command, false otherwise
+     */
+    showAccountById(id, separately = false) {
+        const safeId = sanitizeId(id);
+        const separatelyClause = separately ? " separately true" : "";
+        const result = executeAppleScript(buildAppLevelScript(`show account id "${safeId}"${separatelyClause}`));
+        if (!result.success) {
+            console.error(`Failed to show account with ID "${id}":`, result.error);
+            return false;
+        }
+        return true;
+    }
+    /**
+     * Reveals an attachment in the Notes.app UI.
+     *
+     * Attachments are elements of a note, so they cannot be referenced at the
+     * application level by id alone. This resolves the attachment within its note
+     * (the same lookup used by save-attachment) and then runs the Notes `show`
+     * command on it, opening or focusing the Notes UI on the attachment.
+     *
+     * @param noteId - CoreData identifier for the note containing the attachment
+     * @param attachmentId - id of the attachment (from list-attachments)
+     * @param separately - Open in a separate window when supported by Notes.app
+     * @returns true if Notes.app revealed the attachment, false otherwise
+     */
+    showAttachmentById(noteId, attachmentId, separately = false) {
+        const safeNoteId = sanitizeId(noteId);
+        const safeAttId = escapePlainStringForAppleScript(attachmentId);
+        const separatelyClause = separately ? " separately true" : "";
+        const script = `
+      tell application "Notes"
+        set theNote to note id "${safeNoteId}"
+        set theAttachment to missing value
+        repeat with a in attachments of theNote
+          if (id of a as text) is "${safeAttId}" then
+            set theAttachment to a
+            exit repeat
+          end if
+        end repeat
+        if theAttachment is missing value then
+          return "ERR${AS_FIELD_SEP}attachment not found"
+        end if
+        show theAttachment${separatelyClause}
+        return "OK"
+      end tell
+    `;
+        const result = executeAppleScript(script);
+        if (!result.success) {
+            console.error(`Failed to show attachment "${attachmentId}" on note "${noteId}":`, result.error);
+            return false;
+        }
+        if ((result.output ?? "").trim().startsWith("ERR")) {
+            console.error(`Attachment "${attachmentId}" not found on note "${noteId}"`);
+            return false;
+        }
+        return true;
+    }
+    // ===========================================================================
+    // Health Check
+    // ===========================================================================
+    /**
+     * Performs a health check on Notes.app accessibility and functionality.
+     *
+     * This method verifies:
+     * - Notes.app is installed and accessible
+     * - AppleScript automation permissions are granted
+     * - At least one account is available
+     * - Basic list operations work
+     *
+     * Use this to diagnose connection issues or verify setup.
+     *
+     * @returns HealthCheckResult with overall status and individual check details
+     *
+     * @example
+     * ```typescript
+     * const health = manager.healthCheck();
+     * if (!health.healthy) {
+     *   console.log("Issues found:");
+     *   health.checks.filter(c => !c.passed).forEach(c => console.log(`- ${c.message}`));
+     * }
+     * ```
+     */
+    healthCheck() {
+        const checks = [];
+        // Check 1: Notes.app is accessible
+        const appCheck = executeAppleScript('tell application "Notes" to return "ok"');
+        if (appCheck.success && appCheck.output === "ok") {
+            checks.push({
+                name: "notes_app",
+                passed: true,
+                message: "Notes.app is accessible",
+            });
+        }
+        else {
+            const errorHint = appCheck.error?.includes("not authorized")
+                ? " (check Automation permissions in System Preferences)"
+                : "";
+            checks.push({
+                name: "notes_app",
+                passed: false,
+                message: `Notes.app is not accessible${errorHint}`,
+            });
+            // If Notes.app isn't accessible, skip other checks
+            return { healthy: false, checks };
+        }
+        // Check 2: AppleScript permissions (can we execute commands?)
+        const permCheck = executeAppleScript('tell application "Notes" to get name of account 1');
+        if (permCheck.success) {
+            checks.push({
+                name: "permissions",
+                passed: true,
+                message: "AppleScript automation permissions granted",
+            });
+        }
+        else {
+            const isPermError = permCheck.error?.includes("not authorized") || permCheck.error?.includes("not permitted");
+            checks.push({
+                name: "permissions",
+                passed: !isPermError,
+                message: isPermError
+                    ? "AppleScript permissions denied. Grant access in System Preferences > Privacy & Security > Automation"
+                    : `Permission check returned: ${permCheck.error}`,
+            });
+            if (isPermError) {
+                return { healthy: false, checks };
+            }
+        }
+        // Check 3: At least one account accessible
+        const accounts = this.listAccounts();
+        if (accounts.length > 0) {
+            const accountNames = accounts.map((a) => a.name).join(", ");
+            checks.push({
+                name: "accounts",
+                passed: true,
+                message: `Found ${accounts.length} account(s): ${accountNames}`,
+            });
+        }
+        else {
+            checks.push({
+                name: "accounts",
+                passed: false,
+                message: "No Notes accounts found. Set up an account in Notes.app first.",
+            });
+            return { healthy: false, checks };
+        }
+        // Check 4: Basic operations work (list notes in default account)
+        const defaultAccount = accounts[0]?.name || "iCloud";
+        const notes = this.listNotes(defaultAccount);
+        // Even 0 notes is fine - we just want to verify the operation works
+        checks.push({
+            name: "operations",
+            passed: true,
+            message: `Basic operations working (${notes.length} note(s) in ${defaultAccount})`,
+        });
+        const allPassed = checks.every((c) => c.passed);
+        return { healthy: allPassed, checks };
+    }
+    // ===========================================================================
+    // Statistics
+    // ===========================================================================
+    /**
+     * Gets comprehensive statistics about notes across all accounts.
+     *
+     * Returns total note counts, per-account breakdowns, folder statistics,
+     * and counts of recently modified notes.
+     *
+     * @returns NotesStats object with comprehensive statistics
+     *
+     * @example
+     * ```typescript
+     * const stats = manager.getNotesStats();
+     * console.log(`Total notes: ${stats.totalNotes}`);
+     * console.log(`Modified today: ${stats.recentlyModified.last24h}`);
+     * ```
+     */
+    getNotesStats() {
+        const accounts = this.listAccounts();
+        const accountStats = [];
+        const warnings = [];
+        let totalNotes = 0;
+        // Collect stats per account with ONE bounded script per account (#20/#26):
+        // count notes server-side per folder instead of fetching every note's name
+        // (unbounded) via a listNotes call per folder (N+1 osascript spawns).
+        //
+        // Per-account failures degrade gracefully (#19): a single unreachable or
+        // locked account is recorded as a coverage warning and skipped, rather than
+        // discarding the stats for every healthy account. Only a total wipeout
+        // (no account readable) is escalated to a thrown error below.
+        for (const account of accounts) {
+            const countScript = buildAccountScopedScript({ account: account.name }, `
+        set out to ""
+        repeat with fldr in folders
+          set out to out & (name of fldr) & ${AS_FIELD_SEP} & (count of notes of fldr) & ${AS_RECORD_SEP}
+        end repeat
+        return out
+        `);
+            const res = executeAppleScript(countScript);
+            if (!res.success) {
+                warnings.push({ scope: account.name, reason: res.error ?? "unknown error" });
+                continue;
+            }
+            const folderStats = [];
+            let accountTotal = 0;
+            for (const rec of res.output.split(RECORD_SEP)) {
+                if (!rec.trim())
+                    continue;
+                const [fname, cnt] = rec.split(FIELD_SEP);
+                const noteCount = parseInt((cnt ?? "").trim(), 10) || 0;
+                accountTotal += noteCount;
+                folderStats.push({ name: (fname ?? "").trim(), noteCount });
+            }
+            totalNotes += accountTotal;
+            accountStats.push({
+                name: account.name,
+                totalNotes: accountTotal,
+                folderCount: folderStats.length,
+                folders: folderStats,
+            });
+        }
+        // If every account failed, there is no data to report — surface the error
+        // (#19) rather than returning a deceptively empty stats object.
+        if (accounts.length > 0 && accountStats.length === 0) {
+            throw new Error(`Failed to read folder stats for any of ${accounts.length} account(s): ${warnings
+                .map((w) => `${w.scope} (${w.reason})`)
+                .join("; ")}`);
+        }
+        // Get recently modified notes counts. A failure here is non-fatal — record a
+        // coverage warning and report zeros, flagged as not-covered (#19), instead of
+        // passing off fake zero activity as real.
+        const recent = this.getRecentlyModifiedCounts();
+        if (recent.error) {
+            warnings.push({ scope: "recent-activity", reason: recent.error });
+        }
+        // scopes = each account + the recent-activity scan
+        const scanned = accounts.length + 1;
+        const covered = scanned - warnings.length;
+        return {
+            totalNotes,
+            accounts: accountStats,
+            recentlyModified: recent.counts,
+            coverage: {
+                complete: warnings.length === 0,
+                scanned,
+                covered,
+                warnings,
+            },
+        };
+    }
+    /**
+     * Helper to get counts of recently modified notes.
+     */
+    getRecentlyModifiedCounts() {
+        // Count server-side with locale-safe date variables (#20/#25): instead of
+        // streaming every note's modification date to JS (unbounded, ENOBUFS-prone,
+        // locale-fragile), let AppleScript count matches via a `whose` filter — three
+        // counts per account, regardless of library size.
+        const now = new Date();
+        const d1 = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+        const d7 = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+        const d30 = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+        const script = `
+      tell application "Notes"
+        ${buildAppleScriptDateVar(d1, "d1")}
+        ${buildAppleScriptDateVar(d7, "d7")}
+        ${buildAppleScriptDateVar(d30, "d30")}
+        set c1 to 0
+        set c7 to 0
+        set c30 to 0
+        repeat with acct in accounts
+          set c1 to c1 + (count of (notes of acct whose modification date >= d1))
+          set c7 to c7 + (count of (notes of acct whose modification date >= d7))
+          set c30 to c30 + (count of (notes of acct whose modification date >= d30))
+        end repeat
+        return (c1 as text) & ${AS_FIELD_SEP} & (c7 as text) & ${AS_FIELD_SEP} & (c30 as text)
+      end tell
+    `;
+        const result = executeAppleScript(script);
+        if (!result.success) {
+            // Non-fatal (#19): report the error to the caller so it becomes a coverage
+            // warning, with zeroed counts, instead of throwing away the whole stats
+            // result or passing off fake zero activity as real.
+            return {
+                counts: { last24h: 0, last7d: 0, last30d: 0 },
+                error: result.error ?? "unknown error",
+            };
+        }
+        const parts = result.output.trim().split(FIELD_SEP);
+        const toInt = (s) => {
+            const n = parseInt((s ?? "").trim(), 10);
+            return Number.isFinite(n) ? n : 0;
+        };
+        return {
+            counts: { last24h: toInt(parts[0]), last7d: toInt(parts[1]), last30d: toInt(parts[2]) },
+        };
+    }
+    // ===========================================================================
+    // Attachments
+    // ===========================================================================
+    /**
+     * Lists attachments for a note by its ID.
+     *
+     * Returns metadata about each attachment including name and content type.
+     * Note: The position within the note cannot be determined via AppleScript.
+     *
+     * @param id - CoreData URL identifier for the note
+     * @returns Array of Attachment objects, or empty array if none found
+     *
+     * @example
+     * ```typescript
+     * const attachments = manager.listAttachmentsById("x-coredata://ABC/ICNote/p123");
+     * attachments.forEach(a => console.log(`${a.name}: ${a.contentType}`));
+     * ```
+     */
+    listAttachmentsById(id) {
+        const safeId = sanitizeId(id);
+        const script = `
+      tell application "Notes"
+        set theNote to note id "${safeId}"
+        set attachmentList to {}
+        repeat with a in attachments of theNote
+          set attachId to id of a
+          set attachName to name of a
+          set attachContentId to content identifier of a
+          set attachUrl to ""
+          try
+            set attachUrl to URL of a as text
+          end try
+          set createdDate to creation date of a
+          set modifiedDate to modification date of a
+          set createdParts to ${asDatePartsExpr("createdDate")}
+          set modifiedParts to ${asDatePartsExpr("modifiedDate")}
+          set sharedFlag to shared of a as text
+          set end of attachmentList to attachId & ${AS_FIELD_SEP} & attachName & ${AS_FIELD_SEP} & attachContentId & ${AS_FIELD_SEP} & attachUrl & ${AS_FIELD_SEP} & createdParts & ${AS_FIELD_SEP} & modifiedParts & ${AS_FIELD_SEP} & sharedFlag
+        end repeat
+        set output to ""
+        repeat with item in attachmentList
+          set output to output & item & ${AS_RECORD_SEP}
+        end repeat
+        return output
+      end tell
+    `;
+        const result = executeAppleScript(script);
+        if (!result.success || !result.output) {
+            if (result.error) {
+                console.error(`Failed to list attachments for note ID "${id}":`, result.error);
+            }
+            return [];
+        }
+        // Parse the results
+        const attachments = [];
+        const items = result.output.split(RECORD_SEP).filter((s) => s.trim());
+        for (const item of items) {
+            const parts = item.split(FIELD_SEP);
+            if (parts.length >= 3) {
+                attachments.push({
+                    id: parts[0].trim(),
+                    name: parts[1].trim(),
+                    contentType: parts[2].trim(),
+                    contentId: parts[2].trim() || undefined,
+                    url: parts[3]?.trim() || undefined,
+                    created: parts[4] ? parseAppleScriptDate(parts[4].trim()) : undefined,
+                    modified: parts[5] ? parseAppleScriptDate(parts[5].trim()) : undefined,
+                    shared: parts[6] ? parts[6].trim().toLowerCase() === "true" : undefined,
+                });
+            }
+        }
+        return attachments;
+    }
+    /**
+     * Lists attachments for a note by its title.
+     *
+     * @param title - Title of the note
+     * @param account - Account containing the note (defaults to iCloud)
+     * @returns Array of Attachment objects, or empty array if none found
+     */
+    listAttachments(title, account) {
+        const targetAccount = this.resolveAccount(account);
+        const safeAccount = escapePlainStringForAppleScript(targetAccount);
+        const safeTitle = escapePlainStringForAppleScript(title);
+        const script = `
+      tell application "Notes"
+        tell account "${safeAccount}"
+          set theNote to note "${safeTitle}"
+        set attachmentList to {}
+        repeat with a in attachments of theNote
+          set attachId to id of a
+          set attachName to name of a
+          set attachContentId to content identifier of a
+          set attachUrl to ""
+          try
+            set attachUrl to URL of a as text
+          end try
+          set createdDate to creation date of a
+          set modifiedDate to modification date of a
+          set createdParts to ${asDatePartsExpr("createdDate")}
+          set modifiedParts to ${asDatePartsExpr("modifiedDate")}
+          set sharedFlag to shared of a as text
+          set end of attachmentList to attachId & ${AS_FIELD_SEP} & attachName & ${AS_FIELD_SEP} & attachContentId & ${AS_FIELD_SEP} & attachUrl & ${AS_FIELD_SEP} & createdParts & ${AS_FIELD_SEP} & modifiedParts & ${AS_FIELD_SEP} & sharedFlag
+        end repeat
+          set output to ""
+          repeat with item in attachmentList
+            set output to output & item & ${AS_RECORD_SEP}
+          end repeat
+          return output
+        end tell
+      end tell
+    `;
+        const result = executeAppleScript(script);
+        if (!result.success || !result.output) {
+            if (result.error) {
+                console.error(`Failed to list attachments for note "${title}":`, result.error);
+            }
+            return [];
+        }
+        // Parse the results
+        const attachments = [];
+        const items = result.output.split(RECORD_SEP).filter((s) => s.trim());
+        for (const item of items) {
+            const parts = item.split(FIELD_SEP);
+            if (parts.length >= 3) {
+                attachments.push({
+                    id: parts[0].trim(),
+                    name: parts[1].trim(),
+                    contentType: parts[2].trim(),
+                    contentId: parts[2].trim() || undefined,
+                    url: parts[3]?.trim() || undefined,
+                    created: parts[4] ? parseAppleScriptDate(parts[4].trim()) : undefined,
+                    modified: parts[5] ? parseAppleScriptDate(parts[5].trim()) : undefined,
+                    shared: parts[6] ? parts[6].trim().toLowerCase() === "true" : undefined,
+                });
+            }
+        }
+        return attachments;
+    }
+    /**
+     * Saves a single attachment of a note (identified by attachment id) to a file
+     * on disk via Notes.app's AppleScript `save` (#27).
+     *
+     * @param noteId - CoreData URL identifier for the note
+     * @param attachmentId - id of the attachment (from list-attachments)
+     * @param savePath - absolute destination file path (within home / temp / /Volumes)
+     * @returns { success, savedPath?, name?, contentType?, error? }
+     */
+    saveAttachmentById(noteId, attachmentId, savePath) {
+        let abs;
+        try {
+            abs = assertSafeSavePath(savePath);
+        }
+        catch (e) {
+            return { success: false, error: e instanceof Error ? e.message : String(e) };
+        }
+        const safeNoteId = sanitizeId(noteId);
+        const safeAttId = escapePlainStringForAppleScript(attachmentId);
+        const safePath = escapePlainStringForAppleScript(abs);
+        const script = `
+      tell application "Notes"
+        set theNote to note id "${safeNoteId}"
+        set theAttachment to missing value
+        repeat with a in attachments of theNote
+          if (id of a as text) is "${safeAttId}" then
+            set theAttachment to a
+            exit repeat
+          end if
+        end repeat
+        if theAttachment is missing value then
+          return "ERR${AS_FIELD_SEP}attachment not found"
+        end if
+        save theAttachment in (POSIX file "${safePath}")
+        return "OK${AS_FIELD_SEP}" & (name of theAttachment) & "${AS_FIELD_SEP}" & (content identifier of theAttachment)
+      end tell
+    `;
+        const result = executeAppleScript(script);
+        if (!result.success) {
+            return { success: false, error: result.error ?? "unknown error" };
+        }
+        const parts = (result.output ?? "").trim().split(FIELD_SEP);
+        if (parts[0] !== "OK") {
+            return { success: false, error: parts[1]?.trim() || "attachment not found" };
+        }
+        if (!existsSync(abs) || fileSize(abs) === 0) {
+            return { success: false, error: `Notes reported success but no file was written to ${abs}` };
+        }
+        return {
+            success: true,
+            savedPath: abs,
+            name: parts[1]?.trim(),
+            contentType: parts[2]?.trim(),
+        };
+    }
+    /**
+     * Fetches a note attachment as base64 (#27). Exports to a private temp file,
+     * reads it, then deletes the temp copy.
+     *
+     * @param noteId - CoreData URL identifier for the note
+     * @param attachmentId - id of the attachment
+     * @returns { success, name?, contentType?, base64?, bytes?, error? }
+     */
+    getAttachmentBase64ById(noteId, attachmentId) {
+        const dir = makeTempDir();
+        try {
+            const dest = `${dir}/attachment.bin`;
+            const saved = this.saveAttachmentById(noteId, attachmentId, dest);
+            if (!saved.success || !saved.savedPath) {
+                return { success: false, error: saved.error };
+            }
+            // readFileBase64Capped checks the file size BEFORE reading and throws if it
+            // exceeds APPLE_NOTES_MCP_MAX_ATTACHMENT_BYTES — the throw is caught below
+            // and the temp dir is still cleaned up in `finally`.
+            const base64 = readFileBase64Capped(saved.savedPath);
+            return {
+                success: true,
+                name: saved.name,
+                contentType: saved.contentType,
+                base64,
+                bytes: fileSize(saved.savedPath),
+            };
+        }
+        catch (e) {
+            return { success: false, error: e instanceof Error ? e.message : String(e) };
+        }
+        finally {
+            cleanupTempDir(dir);
+        }
+    }
+    // ===========================================================================
+    // Batch Operations
+    // ===========================================================================
+    /**
+     * Result of a batch operation on a single item.
+     */
+    createBatchResult(id, success, error) {
+        return error ? { id, success, error } : { id, success };
+    }
+    /**
+     * Deletes multiple notes by their IDs.
+     *
+     * Each deletion is attempted independently; failures don't stop other deletions.
+     * Returns results for each note indicating success or failure.
+     *
+     * @param ids - Array of CoreData URL identifiers for notes to delete
+     * @returns Array of results with id, success status, and optional error message
+     *
+     * @example
+     * ```typescript
+     * const results = manager.batchDeleteNotes([
+     *   "x-coredata://ABC/ICNote/p1",
+     *   "x-coredata://ABC/ICNote/p2"
+     * ]);
+     * results.forEach(r => {
+     *   if (r.success) console.log(`Deleted ${r.id}`);
+     *   else console.log(`Failed to delete ${r.id}: ${r.error}`);
+     * });
+     * ```
+     */
+    batchDeleteNotes(ids) {
+        if (ids.length === 0)
+            return [];
+        // Collapse the whole batch into ONE osascript spawn (#26): a single
+        // app-level script loops over every id, with a per-id `try` so one bad note
+        // can't abort the rest. The old path spawned 3 processes per note
+        // (getNoteById + isNotePasswordProtectedById + deleteNoteById) — i.e. 3N
+        // spawns for N notes. This is one spawn total, with the same per-item
+        // isolation and result semantics.
+        const results = new Array(ids.length);
+        const runnable = [];
+        ids.forEach((id, i) => {
+            try {
+                runnable.push({ index: i, safe: sanitizeId(id) });
+            }
+            catch (e) {
+                results[i] = this.createBatchResult(id, false, e instanceof Error ? e.message : "Invalid note ID");
+            }
+        });
+        if (runnable.length > 0) {
+            const idList = runnable.map((r) => `"${r.safe}"`).join(", ");
+            const script = buildAppLevelScript(`
+        set out to ""
+        repeat with rawId in {${idList}}
+          set theId to (rawId as text)
+          set noteRef to missing value
+          try
+            set noteRef to note id theId
+          end try
+          if noteRef is missing value then
+            set out to out & "missing" & ${AS_RECORD_SEP}
+          else
+            set isPw to false
+            try
+              set isPw to (password protected of noteRef)
+            end try
+            if isPw then
+              set out to out & "pw" & ${AS_RECORD_SEP}
+            else
+              try
+                delete noteRef
+                set out to out & "ok" & ${AS_RECORD_SEP}
+              on error
+                set out to out & "fail" & ${AS_RECORD_SEP}
+              end try
+            end if
+          end if
+        end repeat
+        return out
+      `);
+            const res = executeAppleScript(script);
+            if (!res.success) {
+                // Whole-batch failure (e.g. Notes.app not responding): can't isolate,
+                // so mark every runnable note as failed with the underlying error.
+                for (const r of runnable) {
+                    results[r.index] = this.createBatchResult(ids[r.index], false, res.error ?? "Batch delete failed");
+                }
+            }
+            else {
+                const statuses = res.output
+                    .split(RECORD_SEP)
+                    .map((s) => s.trim())
+                    .filter((s) => s.length > 0);
+                runnable.forEach((r, k) => {
+                    results[r.index] = this.mapBatchStatus(ids[r.index], statuses[k], "delete");
+                });
+            }
+        }
+        return results;
+    }
+    /**
+     * Maps a per-item status token emitted by a batch AppleScript loop to a
+     * BatchResult, preserving the human-readable error messages of the original
+     * per-note implementation. See {@link batchDeleteNotes} / {@link batchMoveNotes}.
+     */
+    mapBatchStatus(id, status, op) {
+        switch (status) {
+            case "ok":
+                return this.createBatchResult(id, true);
+            case "pw":
+                return this.createBatchResult(id, false, "Note is password-protected");
+            case "missing":
+                return this.createBatchResult(id, false, "Note not found");
+            case "fail":
+                return this.createBatchResult(id, false, op === "delete" ? "Deletion failed" : "Move failed");
+            default:
+                return this.createBatchResult(id, false, "Unknown error");
+        }
+    }
+    /**
+     * Moves multiple notes to a folder by their IDs.
+     *
+     * Each move is attempted independently; failures don't stop other moves.
+     * Returns results for each note indicating success or failure.
+     *
+     * @param ids - Array of CoreData URL identifiers for notes to move
+     * @param folder - Destination folder name
+     * @param account - Account containing the folder (defaults to iCloud)
+     * @returns Array of results with id, success status, and optional error message
+     *
+     * @example
+     * ```typescript
+     * const results = manager.batchMoveNotes(
+     *   ["x-coredata://ABC/ICNote/p1", "x-coredata://ABC/ICNote/p2"],
+     *   "Archive"
+     * );
+     * ```
+     */
+    batchMoveNotes(ids, folder, account) {
+        if (ids.length === 0)
+            return [];
+        // Collapse the whole batch into ONE osascript spawn (#26). The old path
+        // spawned 5+ processes per note (getNoteById + isNotePasswordProtectedById +
+        // moveNoteById's copy-then-delete fan-out). This uses the native `move`
+        // command — which preserves the note's identity and metadata rather than
+        // copy+delete — inside a single app-level loop with per-id `try` isolation.
+        const targetAccount = this.resolveAccount(account);
+        const safeAccount = sanitizeAccountName(targetAccount);
+        // buildFolderReference validates the (single, shared) destination path; a
+        // malformed folder is a precondition error for the whole call, so let it throw.
+        const destFolderRef = `${buildFolderReference(folder)} of account "${safeAccount}"`;
+        const results = new Array(ids.length);
+        const runnable = [];
+        ids.forEach((id, i) => {
+            try {
+                runnable.push({ index: i, safe: sanitizeId(id) });
+            }
+            catch (e) {
+                results[i] = this.createBatchResult(id, false, e instanceof Error ? e.message : "Invalid note ID");
+            }
+        });
+        if (runnable.length > 0) {
+            const idList = runnable.map((r) => `"${r.safe}"`).join(", ");
+            const script = buildAppLevelScript(`
+        set destFolder to ${destFolderRef}
+        set out to ""
+        repeat with rawId in {${idList}}
+          set theId to (rawId as text)
+          set noteRef to missing value
+          try
+            set noteRef to note id theId
+          end try
+          if noteRef is missing value then
+            set out to out & "missing" & ${AS_RECORD_SEP}
+          else
+            set isPw to false
+            try
+              set isPw to (password protected of noteRef)
+            end try
+            if isPw then
+              set out to out & "pw" & ${AS_RECORD_SEP}
+            else
+              try
+                move noteRef to destFolder
+                set out to out & "ok" & ${AS_RECORD_SEP}
+              on error
+                set out to out & "fail" & ${AS_RECORD_SEP}
+              end try
+            end if
+          end if
+        end repeat
+        return out
+      `);
+            const res = executeAppleScript(script);
+            if (!res.success) {
+                // Whole-batch failure (e.g. destination folder unresolved, Notes not
+                // responding): can't isolate, so fail every runnable note.
+                for (const r of runnable) {
+                    results[r.index] = this.createBatchResult(ids[r.index], false, res.error ?? "Batch move failed");
+                }
+            }
+            else {
+                const statuses = res.output
+                    .split(RECORD_SEP)
+                    .map((s) => s.trim())
+                    .filter((s) => s.length > 0);
+                runnable.forEach((r, k) => {
+                    results[r.index] = this.mapBatchStatus(ids[r.index], statuses[k], "move");
+                });
+            }
+        }
+        return results;
+    }
+    // ===========================================================================
+    // Export Operations
+    // ===========================================================================
+    /**
+     * Export structure for a single note.
+     */
+    exportNote(note, content) {
+        return {
+            id: note.id,
+            title: note.title,
+            content: content,
+            plaintext: this.htmlToPlaintext(content),
+            folder: note.folder || "Notes",
+            account: note.account || "iCloud",
+            created: note.created.toISOString(),
+            modified: note.modified.toISOString(),
+            shared: note.shared || false,
+            passwordProtected: note.passwordProtected || false,
+        };
+    }
+    /**
+     * Simple HTML to plaintext conversion for export.
+     */
+    htmlToPlaintext(html) {
+        // Convert block/line breaks to newlines first.
+        let text = html
+            .replace(/<br\s*\/?>/gi, "\n")
+            .replace(/<\/div>/gi, "\n")
+            .replace(/<\/p>/gi, "\n");
+        // Strip any remaining tags, looping until the string stabilizes. A single
+        // pass can leave residue when removing one tag re-forms another (e.g.
+        // "<<i>>"), so we repeat until there are no more matches — the recognized
+        // fix for CodeQL js/incomplete-multi-character-sanitization.
+        let prev;
+        do {
+            prev = text;
+            text = text.replace(/<[^>]*>/g, "");
+        } while (text !== prev);
+        return (text
+            .replace(/&nbsp;/g, " ")
+            .replace(/&lt;/g, "<")
+            .replace(/&gt;/g, ">")
+            .replace(/&quot;/g, '"')
+            .replace(/&#92;/g, "\\")
+            // Decode &amp; LAST so an encoded entity like "&amp;lt;" round-trips to the
+            // literal "&lt;" instead of being double-unescaped to "<".
+            .replace(/&amp;/g, "&")
+            .replace(/\n{3,}/g, "\n\n")
+            .trim());
+    }
+    /**
+     * Exports all notes as a JSON structure for backup/migration.
+     *
+     * Exports complete note data including:
+     * - Metadata (id, title, dates, flags)
+     * - Content (HTML and plaintext)
+     * - Organization (folder, account)
+     *
+     * Note: Password-protected notes are included with metadata only (no content).
+     *
+     * @returns JSON-serializable export object
+     *
+     * @example
+     * ```typescript
+     * const snapshot = manager.exportNotesAsJson();
+     * fs.writeFileSync('notes-backup.json', JSON.stringify(snapshot, null, 2));
+     * ```
+     */
+    exportNotesAsJson() {
+        const accounts = this.listAccounts();
+        const exportData = {
+            exportDate: new Date().toISOString(),
+            version: "1.0",
+            accounts: [],
+            summary: { totalNotes: 0, totalFolders: 0, totalAccounts: accounts.length },
+        };
+        for (const account of accounts) {
+            const folders = this.listFolders(account.name);
+            const accountData = {
+                name: account.name,
+                folders: [],
+            };
+            for (const folder of folders) {
+                const folderData = {
+                    name: folder.name,
+                    notes: [],
+                };
+                // Get all note titles in this folder
+                const noteTitles = this.listNotes(account.name, folder.name);
+                for (const title of noteTitles) {
+                    // Get note details
+                    const note = this.getNoteDetails(title, account.name);
+                    if (!note)
+                        continue;
+                    // Skip password-protected notes' content but include metadata
+                    let content = "";
+                    if (!note.passwordProtected) {
+                        content = this.getNoteContent(title, account.name);
+                    }
+                    folderData.notes.push(this.exportNote(note, content));
+                    exportData.summary.totalNotes++;
+                }
+                accountData.folders.push(folderData);
+                exportData.summary.totalFolders++;
+            }
+            exportData.accounts.push(accountData);
+        }
+        return exportData;
+    }
+    // ===========================================================================
+    // Markdown Conversion
+    // ===========================================================================
+    /**
+     * Turndown service instance for HTML to Markdown conversion.
+     * Configured for Apple Notes HTML quirks.
+     * Initialized lazily on first use.
+     */
+    turndownService;
+    /**
+     * Initialize the Turndown service with Apple Notes-specific rules.
+     */
+    initTurndownService() {
+        if (this.turndownService)
+            return;
+        this.turndownService = new TurndownService({
+            headingStyle: "atx",
+            codeBlockStyle: "fenced",
+            bulletListMarker: "-",
+        });
+        // Handle Apple Notes-specific HTML patterns
+        // Notes.app uses <div> instead of <p> for paragraphs
+        this.turndownService.addRule("notesDivs", {
+            filter: "div",
+            replacement: (content) => {
+                return content + "\n";
+            },
+        });
+    }
+    /**
+     * Converts HTML content to Markdown.
+     *
+     * @param html - HTML content from Notes.app
+     * @returns Markdown formatted content
+     */
+    htmlToMarkdown(html) {
+        this.initTurndownService();
+        return this.turndownService.turndown(html).trim();
+    }
+    /**
+     * Enriches markdown with checklist state from the NoteStore database.
+     *
+     * Apple Notes checklists appear as plain list items in the AppleScript HTML
+     * output. This method reads the protobuf data to get done/undone state and
+     * annotates matching list items with [x] or [ ] prefixes.
+     *
+     * Fails silently (returns original markdown) if the database is inaccessible
+     * or the note has no checklists.
+     *
+     * @param markdown - The base markdown content
+     * @param checklistItems - Checklist items with done state
+     * @returns Markdown with checklist annotations
+     */
+    enrichMarkdownWithChecklists(markdown, checklistItems) {
+        if (checklistItems.length === 0)
+            return markdown;
+        // Build a map of checklist text → done state
+        const checklistMap = new Map();
+        for (const item of checklistItems) {
+            checklistMap.set(item.text.trim(), item.done);
+        }
+        // Replace matching list items with checkbox syntax
+        const lines = markdown.split("\n");
+        const enriched = lines.map((line) => {
+            // Match markdown list items: "- text" or "* text"
+            const listMatch = line.match(/^(\s*[-*])\s+(.+)$/);
+            if (!listMatch)
+                return line;
+            const [, prefix, text] = listMatch;
+            const done = checklistMap.get(text.trim());
+            if (done === undefined)
+                return line;
+            // Remove from map so duplicate text lines aren't all converted
+            checklistMap.delete(text.trim());
+            return `${prefix} ${done ? "[x]" : "[ ]"} ${text}`;
+        });
+        return enriched.join("\n");
+    }
+    /**
+     * Gets note content as Markdown by title.
+     *
+     * If the note contains checklists and the NoteStore database is accessible
+     * (Full Disk Access required), checklist items will be annotated with
+     * [x] (done) or [ ] (undone) prefixes.
+     *
+     * @param title - Exact title of the note
+     * @param account - Account containing the note (defaults to iCloud)
+     * @returns Markdown content, or empty string if not found
+     *
+     * @example
+     * ```typescript
+     * const md = manager.getNoteMarkdown("Shopping List");
+     * console.log(md); // "# Shopping List\n\n- [x] Eggs\n- [ ] Milk"
+     * ```
+     */
+    getNoteMarkdown(title, account) {
+        const html = this.getNoteContent(title, account);
+        if (!html)
+            return "";
+        let markdown = this.htmlToMarkdown(html);
+        // Try to enrich with checklist state (requires note ID)
+        const note = this.getNoteDetails(title, account);
+        if (note?.id) {
+            const result = getChecklistItems(note.id);
+            if (result.items) {
+                markdown = this.enrichMarkdownWithChecklists(markdown, result.items);
+            }
+        }
+        return markdown;
+    }
+    /**
+     * Gets note content as Markdown by ID.
+     *
+     * This is more reliable than getNoteMarkdown() because IDs are unique
+     * across all accounts, while titles can be duplicated.
+     *
+     * If the note contains checklists and the NoteStore database is accessible
+     * (Full Disk Access required), checklist items will be annotated with
+     * [x] (done) or [ ] (undone) prefixes.
+     *
+     * @param id - CoreData URL identifier for the note
+     * @returns Markdown content, or empty string if not found
+     */
+    getNoteMarkdownById(id) {
+        const html = this.getNoteContentById(id);
+        if (!html)
+            return "";
+        let markdown = this.htmlToMarkdown(html);
+        // Try to enrich with checklist state
+        const result = getChecklistItems(id);
+        if (result.items) {
+            markdown = this.enrichMarkdownWithChecklists(markdown, result.items);
+        }
+        return markdown;
+    }
+}

--- a/build/services/appleNotesManager.test.js
+++ b/build/services/appleNotesManager.test.js
@@ -1,0 +1,2416 @@
+/**
+ * Unit Tests for Apple Notes Manager
+ *
+ * These tests verify the AppleNotesManager class and its helper functions.
+ * The AppleScript execution is mocked to allow testing without macOS.
+ *
+ * Test Strategy:
+ * - Helper functions (escapeForAppleScript, parseAppleScriptDate) are tested
+ *   with various inputs to ensure correct escaping and parsing
+ * - Manager methods are tested for success/failure paths
+ * - Script generation is verified by checking for expected AppleScript patterns
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AppleNotesManager, escapeForAppleScript, escapeHtmlForAppleScript, buildAppleScriptDateVar, buildFolderReference, splitFolderPath, parseAppleScriptDate, sanitizeId, } from "./appleNotesManager.js";
+// Mock the AppleScript execution module
+// This prevents actual osascript calls during testing
+vi.mock("@/utils/applescript.js", () => ({
+    executeAppleScript: vi.fn(),
+}));
+// Mock the checklist parser to avoid SQLite access during tests
+vi.mock("@/utils/checklistParser.js", () => ({
+    getChecklistItems: vi.fn().mockReturnValue({ items: null }),
+}));
+import { executeAppleScript } from "../utils/applescript.js";
+const mockExecuteAppleScript = vi.mocked(executeAppleScript);
+import { getChecklistItems } from "../utils/checklistParser.js";
+const mockGetChecklistItems = vi.mocked(getChecklistItems);
+// Result delimiters (#18) — must match appleNotesManager.ts.
+// FIELD_SEP (US, \x1f) separates fields within a record;
+// RECORD_SEP (RS, \x1e) separates records within a list.
+const F = "\x1f";
+const R = "\x1e";
+// =============================================================================
+// Text Escaping Tests
+// =============================================================================
+describe("escapeForAppleScript", () => {
+    describe("empty and null handling", () => {
+        it("returns empty string for empty input", () => {
+            expect(escapeForAppleScript("")).toBe("");
+        });
+        it("returns empty string for null-like input", () => {
+            // TypeScript prevents actual null, but runtime might have undefined
+            expect(escapeForAppleScript(undefined)).toBe("");
+        });
+    });
+    describe("single quote handling", () => {
+        it("preserves single quotes (no escaping needed in AppleScript double-quoted strings)", () => {
+            // Single quotes don't need escaping inside AppleScript double-quoted strings
+            const result = escapeForAppleScript("it's working");
+            expect(result).toBe("it's working");
+        });
+        it("handles multiple single quotes", () => {
+            const result = escapeForAppleScript("Rob's mom's note");
+            expect(result).toBe("Rob's mom's note");
+        });
+    });
+    describe("double quote escaping (AppleScript strings)", () => {
+        it("escapes double quotes for AppleScript", () => {
+            // AppleScript strings: "hello \"quoted\" world"
+            const result = escapeForAppleScript('say "hello"');
+            expect(result).toBe('say \\"hello\\"');
+        });
+        it("handles mixed quotes", () => {
+            const result = escapeForAppleScript('He said "it\'s fine"');
+            expect(result).toBe('He said \\"it\'s fine\\"');
+        });
+    });
+    describe("control character conversion (HTML for Notes.app)", () => {
+        it("converts newlines to <br> tags", () => {
+            const result = escapeForAppleScript("line 1\nline 2\nline 3");
+            expect(result).toBe("line 1<br>line 2<br>line 3");
+        });
+        it("converts tabs to <br> tags", () => {
+            const result = escapeForAppleScript("col1\tcol2\tcol3");
+            expect(result).toBe("col1<br>col2<br>col3");
+        });
+        it("handles mixed control characters", () => {
+            const result = escapeForAppleScript("row1\tcol2\nrow2\tcol2");
+            expect(result).toBe("row1<br>col2<br>row2<br>col2");
+        });
+    });
+    describe("complex content", () => {
+        it("handles real-world note content", () => {
+            const content = 'John\'s "Meeting Notes"\n- Item 1\n- Item 2';
+            const result = escapeForAppleScript(content);
+            expect(result).toBe('John\'s \\"Meeting Notes\\"<br>- Item 1<br>- Item 2');
+        });
+    });
+    describe("unicode and special characters", () => {
+        it("preserves unicode characters", () => {
+            const result = escapeForAppleScript("日本語テスト 🎉");
+            expect(result).toBe("日本語テスト 🎉");
+        });
+        it("preserves emoji in content", () => {
+            const result = escapeForAppleScript("Shopping 🛒\n- Eggs 🥚\n- Milk 🥛");
+            expect(result).toBe("Shopping 🛒<br>- Eggs 🥚<br>- Milk 🥛");
+        });
+        it("handles accented characters", () => {
+            const result = escapeForAppleScript("Café résumé naïve");
+            expect(result).toBe("Café résumé naïve");
+        });
+        it("handles backslashes", () => {
+            // Backslashes are HTML-encoded to avoid AppleScript escaping issues
+            const result = escapeForAppleScript("path\\to\\file");
+            expect(result).toBe("path&#92;to&#92;file");
+        });
+        it("handles ampersands", () => {
+            // Ampersands are HTML-encoded for Notes.app (& becomes &amp;)
+            const result = escapeForAppleScript("A && B & C");
+            expect(result).toBe("A &amp;&amp; B &amp; C");
+        });
+        it("handles angle brackets (HTML-like content)", () => {
+            // Single quotes pass through unchanged
+            const result = escapeForAppleScript("<script>alert('xss')</script>");
+            expect(result).toBe("<script>alert('xss')</script>");
+        });
+    });
+    describe("boundary conditions", () => {
+        it("handles very short strings", () => {
+            expect(escapeForAppleScript("a")).toBe("a");
+            expect(escapeForAppleScript("'")).toBe("'");
+            expect(escapeForAppleScript('"')).toBe('\\"');
+        });
+        it("handles string with only whitespace", () => {
+            expect(escapeForAppleScript("   ")).toBe("   ");
+        });
+        it("handles multiple consecutive special characters", () => {
+            // Single quotes pass through, double quotes are escaped
+            const result = escapeForAppleScript("'''\"\"\"");
+            expect(result).toBe("'''\\\"\\\"\\\"");
+        });
+    });
+});
+// =============================================================================
+// HTML Content Escaping Tests (for already-HTML content)
+// =============================================================================
+describe("escapeHtmlForAppleScript", () => {
+    describe("basic escaping", () => {
+        it("returns empty string for null/undefined", () => {
+            expect(escapeHtmlForAppleScript("")).toBe("");
+            expect(escapeHtmlForAppleScript(null)).toBe("");
+            expect(escapeHtmlForAppleScript(undefined)).toBe("");
+        });
+        it("escapes double quotes for AppleScript", () => {
+            const result = escapeHtmlForAppleScript('<div>Hello "World"</div>');
+            expect(result).toBe('<div>Hello \\"World\\"</div>');
+        });
+        it("escapes backslashes for AppleScript", () => {
+            const result = escapeHtmlForAppleScript("<div>Path: C:\\Users\\test</div>");
+            expect(result).toBe("<div>Path: C:\\\\Users\\\\test</div>");
+        });
+        it("handles both backslashes and quotes", () => {
+            const result = escapeHtmlForAppleScript('<div>Path: "C:\\test"</div>');
+            expect(result).toBe('<div>Path: \\"C:\\\\test\\"</div>');
+        });
+    });
+    describe("preserves HTML content", () => {
+        it("does not re-encode existing HTML entities", () => {
+            const result = escapeHtmlForAppleScript("<div>&amp; &lt; &gt;</div>");
+            expect(result).toBe("<div>&amp; &lt; &gt;</div>");
+        });
+        it("preserves HTML tags", () => {
+            const result = escapeHtmlForAppleScript("<div><b>Bold</b><br><i>Italic</i></div>");
+            expect(result).toBe("<div><b>Bold</b><br><i>Italic</i></div>");
+        });
+        it("preserves numeric HTML entities", () => {
+            const result = escapeHtmlForAppleScript("<div>&#92; &#60; &#62;</div>");
+            expect(result).toBe("<div>&#92; &#60; &#62;</div>");
+        });
+    });
+});
+// =============================================================================
+// Date Parsing Tests
+// =============================================================================
+describe("parseAppleScriptDate", () => {
+    describe("standard format parsing", () => {
+        it("parses AppleScript date with 'date' prefix", () => {
+            const dateStr = "date Saturday, December 27, 2025 at 3:44:02 PM";
+            const result = parseAppleScriptDate(dateStr);
+            expect(result.getFullYear()).toBe(2025);
+            expect(result.getMonth()).toBe(11); // December is month 11 (0-indexed)
+            expect(result.getDate()).toBe(27);
+        });
+        it("parses date without 'date' prefix", () => {
+            const dateStr = "Saturday, December 27, 2025 at 3:44:02 PM";
+            const result = parseAppleScriptDate(dateStr);
+            expect(result.getFullYear()).toBe(2025);
+            expect(result.getMonth()).toBe(11);
+        });
+        it("correctly handles AM/PM times", () => {
+            const morningDate = "date Monday, January 1, 2025 at 9:30:00 AM";
+            const eveningDate = "date Monday, January 1, 2025 at 9:30:00 PM";
+            const morning = parseAppleScriptDate(morningDate);
+            const evening = parseAppleScriptDate(eveningDate);
+            expect(morning.getHours()).toBe(9);
+            expect(evening.getHours()).toBe(21);
+        });
+    });
+    describe("locale-independent numeric format (#25)", () => {
+        it("parses the Y-M-D-H-m-s form emitted by our producers", () => {
+            const result = parseAppleScriptDate("2025-12-27-15-44-2");
+            expect(result.getFullYear()).toBe(2025);
+            expect(result.getMonth()).toBe(11);
+            expect(result.getDate()).toBe(27);
+            expect(result.getHours()).toBe(15);
+            expect(result.getMinutes()).toBe(44);
+            expect(result.getSeconds()).toBe(2);
+        });
+        it("handles single-digit components and midnight", () => {
+            const result = parseAppleScriptDate("2025-1-5-0-0-0");
+            expect(result.getMonth()).toBe(0);
+            expect(result.getDate()).toBe(5);
+            expect(result.getHours()).toBe(0);
+        });
+    });
+    describe("fallback behavior", () => {
+        it("returns current date for invalid input", () => {
+            const before = new Date();
+            const result = parseAppleScriptDate("not a valid date");
+            const after = new Date();
+            // Result should be between before and after (i.e., "now")
+            expect(result.getTime()).toBeGreaterThanOrEqual(before.getTime());
+            expect(result.getTime()).toBeLessThanOrEqual(after.getTime());
+        });
+        it("returns current date for empty string", () => {
+            const before = new Date();
+            const result = parseAppleScriptDate("");
+            const after = new Date();
+            expect(result.getTime()).toBeGreaterThanOrEqual(before.getTime());
+            expect(result.getTime()).toBeLessThanOrEqual(after.getTime());
+        });
+    });
+});
+// =============================================================================
+// buildFolderReference Tests
+// =============================================================================
+describe("splitFolderPath", () => {
+    it("splits simple path on /", () => {
+        expect(splitFolderPath("Work/Clients")).toEqual(["Work", "Clients"]);
+    });
+    it("returns single segment for a name without /", () => {
+        expect(splitFolderPath("Work")).toEqual(["Work"]);
+    });
+    it("preserves escaped slashes in folder names", () => {
+        expect(splitFolderPath("Travel/Spain\\/Portugal 2023")).toEqual([
+            "Travel",
+            "Spain/Portugal 2023",
+        ]);
+    });
+    it("handles multiple escaped slashes", () => {
+        expect(splitFolderPath("A\\/B/C\\/D")).toEqual(["A/B", "C/D"]);
+    });
+});
+describe("buildFolderReference", () => {
+    it("returns simple folder reference for a single name", () => {
+        expect(buildFolderReference("Work")).toBe('folder "Work"');
+    });
+    it("returns nested folder reference for a path", () => {
+        expect(buildFolderReference("Work/Clients")).toBe('folder "Clients" of folder "Work"');
+    });
+    it("handles deeply nested paths", () => {
+        expect(buildFolderReference("Work/Clients/Omnia")).toBe('folder "Omnia" of folder "Clients" of folder "Work"');
+    });
+    it("handles special characters in folder names", () => {
+        const result = buildFolderReference("Food & Drink/🥘 Recipes");
+        expect(result).toContain('folder "🥘 Recipes"');
+        expect(result).toContain('folder "Food & Drink"');
+    });
+    it("handles escaped slashes in folder names", () => {
+        const result = buildFolderReference("Travel/Spain\\/Portugal 2023");
+        expect(result).toBe('folder "Spain/Portugal 2023" of folder "Travel"');
+    });
+});
+// =============================================================================
+// buildAppleScriptDateVar Tests
+// =============================================================================
+describe("buildAppleScriptDateVar", () => {
+    it("generates locale-safe AppleScript date setup code", () => {
+        const date = new Date(2025, 5, 15, 14, 30, 0); // June 15, 2025 2:30 PM
+        const result = buildAppleScriptDateVar(date);
+        expect(result).toContain("set thresholdDate to current date");
+        expect(result).toContain("set year of thresholdDate to 2025");
+        expect(result).toContain("set month of thresholdDate to 6");
+        expect(result).toContain("set day of thresholdDate to 15");
+        // 14*3600 + 30*60 = 52200
+        expect(result).toContain("set time of thresholdDate to 52200");
+    });
+    it("handles midnight (time = 0)", () => {
+        const date = new Date(2025, 0, 1, 0, 0, 0); // Jan 1, 2025 midnight
+        const result = buildAppleScriptDateVar(date);
+        expect(result).toContain("set month of thresholdDate to 1");
+        expect(result).toContain("set day of thresholdDate to 1");
+        expect(result).toContain("set time of thresholdDate to 0");
+    });
+    it("uses custom variable name", () => {
+        const date = new Date(2025, 0, 1, 0, 0, 0);
+        const result = buildAppleScriptDateVar(date, "myDate");
+        expect(result).toContain("set myDate to current date");
+        expect(result).toContain("set year of myDate to 2025");
+        expect(result).toContain("set month of myDate to 1");
+    });
+    it("calculates time in seconds correctly", () => {
+        const date = new Date(2025, 11, 25, 9, 5, 3); // 9:05:03 AM
+        const result = buildAppleScriptDateVar(date);
+        // 9*3600 + 5*60 + 3 = 32703
+        expect(result).toContain("set time of thresholdDate to 32703");
+    });
+});
+// =============================================================================
+// AppleNotesManager Tests
+// =============================================================================
+describe("AppleNotesManager", () => {
+    let manager;
+    beforeEach(() => {
+        manager = new AppleNotesManager();
+        vi.clearAllMocks();
+    });
+    describe("listAttachments — security", () => {
+        it("escapes the account name so it cannot break out of the AppleScript literal (injection regression)", () => {
+            mockExecuteAppleScript.mockReturnValue({ success: true, output: "" });
+            manager.listAttachments("My Note", 'evil" injected');
+            const script = String(mockExecuteAppleScript.mock.calls.at(-1)?.[0]);
+            // The account's double-quote must be escaped (\\") — a raw quote would
+            // terminate the tell-account string literal and allow `do shell script` injection.
+            expect(script).toContain('tell account "evil\\" injected"');
+            expect(script).not.toContain('tell account "evil" injected"');
+        });
+    });
+    // ---------------------------------------------------------------------------
+    // Note Creation
+    // ---------------------------------------------------------------------------
+    describe("createNote", () => {
+        it("returns Note object on successful creation", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "note id x-coredata://12345/ICNote/p100",
+            });
+            const result = manager.createNote("Shopping List", "Eggs, Milk, Bread");
+            expect(result).not.toBeNull();
+            expect(result?.title).toBe("Shopping List");
+            expect(result?.content).toBe("Eggs, Milk, Bread");
+            expect(result?.account).toBe("iCloud"); // Default account
+        });
+        it("strips the 'note id ' prefix from the returned id (#create-note-id)", () => {
+            // AppleScript's `id of newNote` yields an object specifier with a literal
+            // "note id " prefix. The returned id must be the bare x-coredata:// URL so
+            // downstream tools (get-note-content, update-note) accept it.
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "note id x-coredata://ABC-DEF/ICNote/p42",
+            });
+            const result = manager.createNote("Prefixed", "Body");
+            expect(result?.id).toBe("x-coredata://ABC-DEF/ICNote/p42");
+            expect(result?.id).not.toMatch(/^note id /);
+        });
+        it("returned id round-trips through get-note-content and update-note (#create-note-id)", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "note id x-coredata://ABC-DEF/ICNote/p99",
+            });
+            const created = manager.createNote("Roundtrip", "Body");
+            const id = created?.id;
+            expect(id).toBe("x-coredata://ABC-DEF/ICNote/p99");
+            // Reading back by the returned id must not throw "Invalid note ID format".
+            mockExecuteAppleScript.mockReturnValue({ success: true, output: "Body text" });
+            expect(() => manager.getNoteContentById(id)).not.toThrow();
+            // Updating by the returned id must not throw either.
+            mockExecuteAppleScript.mockReturnValue({ success: true, output: "" });
+            expect(() => manager.updateNoteById(id, undefined, "New body")).not.toThrow();
+        });
+        it("returns null when AppleScript fails", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: false,
+                output: "",
+                error: "Notes.app not responding",
+            });
+            const result = manager.createNote("Test", "Content");
+            expect(result).toBeNull();
+        });
+        it("uses specified account instead of default", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "note id x-coredata://...",
+            });
+            const result = manager.createNote("Draft", "Email content", [], undefined, "Gmail");
+            expect(result?.account).toBe("Gmail");
+            expect(mockExecuteAppleScript).toHaveBeenCalledWith(expect.stringContaining('tell account "Gmail"'));
+        });
+        it("creates note in specified folder", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "note id x-coredata://...",
+            });
+            manager.createNote("Work Note", "Content", [], "Work Projects");
+            expect(mockExecuteAppleScript).toHaveBeenCalledWith(expect.stringContaining('at folder "Work Projects"'));
+        });
+        it("stores tags in returned Note object", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "note id x-coredata://...",
+            });
+            const result = manager.createNote("Tagged Note", "Content", ["work", "urgent"]);
+            expect(result?.tags).toEqual(["work", "urgent"]);
+        });
+        it("uses escapeHtmlForAppleScript when format is html", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "note id x-coredata://12345/ICNote/p200",
+            });
+            const htmlContent = "<h2>Heading</h2><div>Body text</div>";
+            const result = manager.createNote("HTML Note", htmlContent, [], undefined, undefined, "html");
+            expect(result).not.toBeNull();
+            // HTML tags should NOT be entity-encoded — they should pass through to AppleScript
+            // escapeHtmlForAppleScript only escapes \ and ", not HTML tags
+            expect(mockExecuteAppleScript).toHaveBeenCalledWith(expect.stringContaining("<h2>Heading</h2><div>Body text</div>"));
+        });
+        it("uses escapeForAppleScript when format is plaintext (default)", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "note id x-coredata://12345/ICNote/p201",
+            });
+            const result = manager.createNote("Plain Note", "Simple text with\nnewline");
+            expect(result).not.toBeNull();
+            // Default plaintext: newlines become <br>
+            expect(mockExecuteAppleScript).toHaveBeenCalledWith(expect.stringContaining("Simple text with<br>newline"));
+        });
+        it("escapes double quotes in html format for AppleScript safety", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "note id x-coredata://12345/ICNote/p202",
+            });
+            manager.createNote("Quote Test", '<div class="test">Content</div>', [], undefined, undefined, "html");
+            // Double quotes must be escaped for AppleScript string embedding
+            expect(mockExecuteAppleScript).toHaveBeenCalledWith(expect.stringContaining('<div class=\\"test\\">Content</div>'));
+        });
+        it("sets title as h1 in body, not as name property", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "note id x-coredata://12345/ICNote/p203",
+            });
+            manager.createNote("My Title", "Body content");
+            const script = mockExecuteAppleScript.mock.calls[0][0];
+            // Title must appear as h1 in body
+            expect(script).toContain("<h1>My Title</h1>");
+            // name property must NOT be set (causes title duplication in Notes.app)
+            expect(script).not.toContain('name:"My Title"');
+        });
+        it("HTML-encodes special chars in title for h1 tag", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "note id x-coredata://12345/ICNote/p204",
+            });
+            manager.createNote("Q&A: <Hello> World", "Content");
+            expect(mockExecuteAppleScript).toHaveBeenCalledWith(expect.stringContaining("<h1>Q&amp;A: &lt;Hello&gt; World</h1>"));
+        });
+        it("HTML-encodes special chars in plaintext content", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "note id x-coredata://12345/ICNote/p205",
+            });
+            manager.createNote("Title", "Price: <10 & >5\nNext line");
+            const script = mockExecuteAppleScript.mock.calls[0][0];
+            expect(script).toContain("Price: &lt;10 &amp; &gt;5<br>Next line");
+        });
+        it("prepends h1 title before html content", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "note id x-coredata://12345/ICNote/p206",
+            });
+            manager.createNote("Report", "<h2>Section</h2><div>Details</div>", [], undefined, undefined, "html");
+            const script = mockExecuteAppleScript.mock.calls[0][0];
+            expect(script).toContain("<h1>Report</h1><h2>Section</h2><div>Details</div>");
+        });
+        it("encodes backslashes as HTML entities in plaintext content", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "note id x-coredata://12345/ICNote/p207",
+            });
+            manager.createNote("Title", "path\\to\\file");
+            const script = mockExecuteAppleScript.mock.calls[0][0];
+            expect(script).toContain("path&#92;to&#92;file");
+        });
+        it("converts tabs to br in plaintext content", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "note id x-coredata://12345/ICNote/p208",
+            });
+            manager.createNote("Title", "col1\tcol2\tcol3");
+            const script = mockExecuteAppleScript.mock.calls[0][0];
+            expect(script).toContain("col1<br>col2<br>col3");
+        });
+    });
+    // ---------------------------------------------------------------------------
+    // Note Search
+    // ---------------------------------------------------------------------------
+    describe("searchNotes", () => {
+        it("returns array of matching notes with folder info", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: [
+                    ["Meeting Notes", "x-coredata://ABC/ICNote/p1", "Work"].join(F),
+                    ["Project Plan", "x-coredata://ABC/ICNote/p2", "Notes"].join(F),
+                    ["Weekly Review", "x-coredata://ABC/ICNote/p3", "Archive"].join(F),
+                ].join(R),
+            });
+            const results = manager.searchNotes("notes");
+            expect(results).toHaveLength(3);
+            expect(results[0].title).toBe("Meeting Notes");
+            expect(results[0].id).toBe("x-coredata://ABC/ICNote/p1");
+            expect(results[0].folder).toBe("Work");
+            expect(results[1].title).toBe("Project Plan");
+            expect(results[1].id).toBe("x-coredata://ABC/ICNote/p2");
+            expect(results[1].folder).toBe("Notes");
+            expect(results[2].title).toBe("Weekly Review");
+            expect(results[2].id).toBe("x-coredata://ABC/ICNote/p3");
+            expect(results[2].folder).toBe("Archive");
+        });
+        it("returns empty array when no matches found", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "",
+            });
+            const results = manager.searchNotes("nonexistent");
+            expect(results).toHaveLength(0);
+        });
+        it("throws on AppleScript error rather than returning empty (#19)", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: false,
+                output: "",
+                error: "Search failed",
+            });
+            expect(() => manager.searchNotes("test")).toThrow(/Search failed/);
+        });
+        it("searches content when searchContent is true", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: ["Note with keyword", "x-coredata://ABC/ICNote/p1", "Notes"].join(F),
+            });
+            manager.searchNotes("project alpha", true);
+            expect(mockExecuteAppleScript).toHaveBeenCalledWith(expect.stringContaining('body contains "project alpha"'));
+        });
+        it("searches titles when searchContent is false", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: ["Project Alpha Notes", "x-coredata://ABC/ICNote/p1", "Notes"].join(F),
+            });
+            manager.searchNotes("Project Alpha", false);
+            expect(mockExecuteAppleScript).toHaveBeenCalledWith(expect.stringContaining('name contains "Project Alpha"'));
+        });
+        it("identifies notes in Recently Deleted folder", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: [
+                    ["Old Note", "x-coredata://ABC/ICNote/p1", "Recently Deleted"].join(F),
+                    ["Active Note", "x-coredata://ABC/ICNote/p2", "Notes"].join(F),
+                ].join(R),
+            });
+            const results = manager.searchNotes("note");
+            expect(results).toHaveLength(2);
+            expect(results[0].title).toBe("Old Note");
+            expect(results[0].id).toBe("x-coredata://ABC/ICNote/p1");
+            expect(results[0].folder).toBe("Recently Deleted");
+            expect(results[1].title).toBe("Active Note");
+            expect(results[1].id).toBe("x-coredata://ABC/ICNote/p2");
+            expect(results[1].folder).toBe("Notes");
+        });
+        it("deduplicates duplicate note IDs returned by Notes.app", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: [
+                    ["Not uploaded", "x-coredata://ABC/ICNote/p1", "Notes"].join(F),
+                    ["Not uploaded", "x-coredata://ABC/ICNote/p1", "Notes"].join(F),
+                ].join(R),
+            });
+            const results = manager.searchNotes("Not uploaded");
+            expect(results).toHaveLength(1);
+            expect(results[0].title).toBe("Not uploaded");
+            expect(results[0].id).toBe("x-coredata://ABC/ICNote/p1");
+        });
+        it("scopes search to specified account", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "",
+            });
+            manager.searchNotes("work", false, "Exchange");
+            expect(mockExecuteAppleScript).toHaveBeenCalledWith(expect.stringContaining('tell account "Exchange"'));
+        });
+        it("limits search to specified folder", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: ["Work Note", "x-coredata://ABC/ICNote/p1", "Work"].join(F),
+            });
+            manager.searchNotes("note", false, undefined, "Work");
+            expect(mockExecuteAppleScript).toHaveBeenCalledWith(expect.stringContaining('notes of folder "Work"'));
+        });
+        it("combines folder and account filters", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "",
+            });
+            manager.searchNotes("task", false, "Exchange", "Projects");
+            const script = mockExecuteAppleScript.mock.calls[0][0];
+            expect(script).toContain('tell account "Exchange"');
+            expect(script).toContain('notes of folder "Projects"');
+        });
+        it("adds date filter when modifiedSince is provided", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: ["Recent Note", "x-coredata://ABC/ICNote/p1", "Notes"].join(F),
+            });
+            manager.searchNotes("note", false, undefined, undefined, "2025-06-15T00:00:00");
+            const script = mockExecuteAppleScript.mock.calls[0][0];
+            // Locale-safe: uses variable setup instead of date "string"
+            expect(script).toContain("set thresholdDate to current date");
+            expect(script).toContain("set year of thresholdDate to 2025");
+            expect(script).toContain("set month of thresholdDate to 6");
+            expect(script).toContain("set day of thresholdDate to 15");
+            expect(script).toContain("modification date >= thresholdDate");
+            expect(script).toContain('name contains "note"');
+        });
+        it("combines date filter with content search", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: ["Note", "x-coredata://ABC/ICNote/p1", "Notes"].join(F),
+            });
+            manager.searchNotes("keyword", true, undefined, undefined, "2025-01-01");
+            const script = mockExecuteAppleScript.mock.calls[0][0];
+            expect(script).toContain('body contains "keyword"');
+            expect(script).toContain("set thresholdDate to current date");
+            expect(script).toContain("modification date >= thresholdDate");
+        });
+        it("ignores invalid modifiedSince date", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: ["Note", "x-coredata://ABC/ICNote/p1", "Notes"].join(F),
+            });
+            manager.searchNotes("note", false, undefined, undefined, "not-a-date");
+            const script = mockExecuteAppleScript.mock.calls[0][0];
+            expect(script).not.toContain("modification date");
+        });
+        it("applies limit to search results", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: ["Note 1", "x-coredata://ABC/ICNote/p1", "Notes"].join(F),
+            });
+            manager.searchNotes("note", false, undefined, undefined, undefined, 5);
+            const script = mockExecuteAppleScript.mock.calls[0][0];
+            expect(script).toContain("(count of resultList) >= 5");
+            expect(script).toContain("exit repeat");
+        });
+        it("combines modifiedSince, limit, folder, and content search", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: ["Note", "x-coredata://ABC/ICNote/p1", "Work"].join(F),
+            });
+            manager.searchNotes("project", true, "iCloud", "Work", "2025-03-01", 10);
+            const script = mockExecuteAppleScript.mock.calls[0][0];
+            expect(script).toContain('body contains "project"');
+            expect(script).toContain("set thresholdDate to current date");
+            expect(script).toContain("modification date >= thresholdDate");
+            expect(script).toContain('notes of folder "Work"');
+            expect(script).toContain("(count of resultList) >= 10");
+            expect(script).toContain('tell account "iCloud"');
+        });
+    });
+    // ---------------------------------------------------------------------------
+    // Note Content Retrieval
+    // ---------------------------------------------------------------------------
+    describe("getNoteContent", () => {
+        it("returns HTML content of note", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "<div>Shopping List</div><div>- Eggs<br>- Milk</div>",
+            });
+            const content = manager.getNoteContent("Shopping List");
+            expect(content).toBe("<div>Shopping List</div><div>- Eggs<br>- Milk</div>");
+        });
+        it("returns empty string when note not found", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: false,
+                output: "",
+                error: 'Can\'t get note "Missing"',
+            });
+            const content = manager.getNoteContent("Missing Note");
+            expect(content).toBe("");
+        });
+        it("looks up titles containing & literally, not HTML-escaped (regression)", () => {
+            // Bug found in live testing: titles with "&" were HTML-escaped to "&amp;"
+            // in the `note "..."` lookup, so the note could never be found.
+            mockExecuteAppleScript.mockReturnValue({ success: true, output: "<div>x</div>" });
+            manager.getNoteContent("Tom & Jerry", "iCloud");
+            const script = mockExecuteAppleScript.mock.calls[0][0];
+            expect(script).toContain("Tom & Jerry");
+            expect(script).not.toContain("Tom &amp; Jerry");
+        });
+        it("uses specified account", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "<div>Content</div>",
+            });
+            manager.getNoteContent("My Note", "Gmail");
+            expect(mockExecuteAppleScript).toHaveBeenCalledWith(expect.stringContaining('tell account "Gmail"'));
+        });
+    });
+    describe("getNotePlaintext", () => {
+        it("reads the note's plaintext property by title", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "Shopping List\n- Eggs\n- Milk",
+            });
+            const text = manager.getNotePlaintext("Shopping List");
+            expect(text).toBe("Shopping List\n- Eggs\n- Milk");
+            expect(mockExecuteAppleScript).toHaveBeenCalledWith(expect.stringContaining('get plaintext of note "Shopping List"'));
+        });
+        it("returns empty string when the note is not found", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: false,
+                output: "",
+                error: 'Can\'t get note "Missing"',
+            });
+            expect(manager.getNotePlaintext("Missing Note")).toBe("");
+        });
+        it("uses the specified account", () => {
+            mockExecuteAppleScript.mockReturnValue({ success: true, output: "Content" });
+            manager.getNotePlaintext("My Note", "Gmail");
+            expect(mockExecuteAppleScript).toHaveBeenCalledWith(expect.stringContaining('tell account "Gmail"'));
+        });
+    });
+    describe("getNotePlaintextById", () => {
+        it("reads the note's plaintext property by id at the application level", () => {
+            mockExecuteAppleScript.mockReturnValue({ success: true, output: "Just the text" });
+            const text = manager.getNotePlaintextById("x-coredata://ABC/ICNote/p1");
+            expect(text).toBe("Just the text");
+            expect(mockExecuteAppleScript).toHaveBeenCalledWith(expect.stringContaining('get plaintext of note id "x-coredata://ABC/ICNote/p1"'));
+        });
+        it("returns empty string when Notes.app rejects the read", () => {
+            mockExecuteAppleScript.mockReturnValue({ success: false, output: "", error: "no such note" });
+            expect(manager.getNotePlaintextById("x-coredata://ABC/ICNote/p1")).toBe("");
+        });
+        it("rejects malformed IDs", () => {
+            expect(() => manager.getNotePlaintextById("arbitrary string")).toThrow();
+        });
+    });
+    // ---------------------------------------------------------------------------
+    // Password Protection Helpers
+    // ---------------------------------------------------------------------------
+    describe("isNotePasswordProtected", () => {
+        it("returns true when note is password-protected", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: [
+                    "Locked Note",
+                    "x-coredata://ABC/ICNote/p1",
+                    "Monday, January 1, 2024 at 12:00:00 PM",
+                    "Monday, January 1, 2024 at 12:00:00 PM",
+                    "false",
+                    "true",
+                ].join(F),
+            });
+            const result = manager.isNotePasswordProtected("Locked Note");
+            expect(result).toBe(true);
+        });
+        it("returns false when note is not password-protected", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: [
+                    "Open Note",
+                    "x-coredata://ABC/ICNote/p2",
+                    "Monday, January 1, 2024 at 12:00:00 PM",
+                    "Monday, January 1, 2024 at 12:00:00 PM",
+                    "false",
+                    "false",
+                ].join(F),
+            });
+            const result = manager.isNotePasswordProtected("Open Note");
+            expect(result).toBe(false);
+        });
+        it("returns false when note is not found", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: false,
+                output: "",
+                error: "Note not found",
+            });
+            const result = manager.isNotePasswordProtected("Missing Note");
+            expect(result).toBe(false);
+        });
+    });
+    describe("isNotePasswordProtectedById", () => {
+        it("returns true when note is password-protected", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: [
+                    "Locked Note",
+                    "x-coredata://ABC/ICNote/p1",
+                    "Monday, January 1, 2024 at 12:00:00 PM",
+                    "Monday, January 1, 2024 at 12:00:00 PM",
+                    "false",
+                    "true",
+                ].join(F),
+            });
+            const result = manager.isNotePasswordProtectedById("x-coredata://ABC/ICNote/p1");
+            expect(result).toBe(true);
+        });
+        it("returns false when note is not password-protected", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: [
+                    "Open Note",
+                    "x-coredata://ABC/ICNote/p2",
+                    "Monday, January 1, 2024 at 12:00:00 PM",
+                    "Monday, January 1, 2024 at 12:00:00 PM",
+                    "false",
+                    "false",
+                ].join(F),
+            });
+            const result = manager.isNotePasswordProtectedById("x-coredata://ABC/ICNote/p2");
+            expect(result).toBe(false);
+        });
+        it("returns false when note is not found", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: false,
+                output: "",
+                error: "Note not found",
+            });
+            const result = manager.isNotePasswordProtectedById("x-coredata://00000000-0000-0000-0000-000000000000/ICNote/p999");
+            expect(result).toBe(false);
+        });
+    });
+    // ---------------------------------------------------------------------------
+    // Get Note By ID
+    // ---------------------------------------------------------------------------
+    describe("getNoteById", () => {
+        it("returns Note object with metadata for valid ID", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: [
+                    "My Note",
+                    "x-coredata://ABC123/ICNote/p100",
+                    "Saturday, December 27, 2025 at 3:00:00 PM",
+                    "Saturday, December 27, 2025 at 4:00:00 PM",
+                    "false",
+                    "false",
+                ].join(F),
+            });
+            const result = manager.getNoteById("x-coredata://ABC123/ICNote/p100");
+            expect(result).not.toBeNull();
+            expect(result?.title).toBe("My Note");
+            expect(result?.id).toBe("x-coredata://ABC123/ICNote/p100");
+            expect(result?.shared).toBe(false);
+            expect(result?.passwordProtected).toBe(false);
+        });
+        it("returns null when note ID not found", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: false,
+                output: "",
+                error: "Can't get note id",
+            });
+            const result = manager.getNoteById("x-coredata://00000000-0000-0000-0000-000000000000/ICNote/p999");
+            expect(result).toBeNull();
+        });
+        it("returns null when response format is unexpected (no commas)", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "incomplete data with no commas",
+            });
+            const result = manager.getNoteById("x-coredata://ABC123/ICNote/p100");
+            expect(result).toBeNull();
+        });
+        it("returns null when response format is missing second comma", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "title only, no more data",
+            });
+            const result = manager.getNoteById("x-coredata://ABC123/ICNote/p100");
+            // The new parsing requires at least title and ID separated by commas
+            expect(result).toBeNull();
+        });
+        it("correctly parses shared and passwordProtected as true", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: [
+                    "Shared Note",
+                    "x-coredata://ABC/ICNote/p1",
+                    "Monday, January 1, 2025 at 12:00:00 PM",
+                    "Monday, January 1, 2025 at 12:00:00 PM",
+                    "true",
+                    "true",
+                ].join(F),
+            });
+            const result = manager.getNoteById("x-coredata://ABC/ICNote/p1");
+            expect(result?.shared).toBe(true);
+            expect(result?.passwordProtected).toBe(true);
+        });
+    });
+    // ---------------------------------------------------------------------------
+    // Get Note Details
+    // ---------------------------------------------------------------------------
+    describe("getNoteDetails", () => {
+        it("returns Note object with full metadata", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: [
+                    "Project Notes",
+                    "x-coredata://ABC123/ICNote/p200",
+                    "Friday, December 20, 2025 at 10:00:00 AM",
+                    "Saturday, December 27, 2025 at 2:30:00 PM",
+                    "false",
+                    "false",
+                ].join(F),
+            });
+            const result = manager.getNoteDetails("Project Notes");
+            expect(result).not.toBeNull();
+            expect(result?.title).toBe("Project Notes");
+            expect(result?.id).toBe("x-coredata://ABC123/ICNote/p200");
+            expect(result?.account).toBe("iCloud");
+        });
+        it("returns null when note not found", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: false,
+                output: "",
+                error: "Can't get note",
+            });
+            const result = manager.getNoteDetails("Nonexistent");
+            expect(result).toBeNull();
+        });
+        it("uses specified account", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: [
+                    "Note",
+                    "id123",
+                    "Monday, January 1, 2025 at 12:00:00 PM",
+                    "Monday, January 1, 2025 at 12:00:00 PM",
+                    "false",
+                    "false",
+                ].join(F),
+            });
+            const result = manager.getNoteDetails("My Note", "Exchange");
+            expect(result?.account).toBe("Exchange");
+            expect(mockExecuteAppleScript).toHaveBeenCalledWith(expect.stringContaining('tell account "Exchange"'));
+        });
+        it("handles shared notes correctly", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: [
+                    "Shared Doc",
+                    "id456",
+                    "Monday, January 1, 2025 at 12:00:00 PM",
+                    "Monday, January 1, 2025 at 12:00:00 PM",
+                    "true",
+                    "false",
+                ].join(F),
+            });
+            const result = manager.getNoteDetails("Shared Doc");
+            expect(result?.shared).toBe(true);
+        });
+    });
+    // ---------------------------------------------------------------------------
+    // Note Deletion
+    // ---------------------------------------------------------------------------
+    describe("deleteNote", () => {
+        it("returns true on successful deletion", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "",
+            });
+            const result = manager.deleteNote("Old Note");
+            expect(result).toBe(true);
+        });
+        it("returns false when deletion fails", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: false,
+                output: "",
+                error: "Cannot delete protected note",
+            });
+            const result = manager.deleteNote("Protected Note");
+            expect(result).toBe(false);
+        });
+        it("uses specified account", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "",
+            });
+            manager.deleteNote("Draft", "Gmail");
+            expect(mockExecuteAppleScript).toHaveBeenCalledWith(expect.stringContaining('tell account "Gmail"'));
+        });
+    });
+    // ---------------------------------------------------------------------------
+    // Note Updates
+    // ---------------------------------------------------------------------------
+    describe("updateNote", () => {
+        it("returns true on successful update", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "",
+            });
+            const result = manager.updateNote("Old Title", "New Title", "Updated content");
+            expect(result).toBe(true);
+        });
+        it("returns false when update fails", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: false,
+                output: "",
+                error: "Note not found",
+            });
+            const result = manager.updateNote("Missing", "New Title", "Content");
+            expect(result).toBe(false);
+        });
+        it("preserves original title when newTitle is undefined", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "",
+            });
+            manager.updateNote("Keep This Title", undefined, "New content only");
+            // The generated body should use the original title
+            expect(mockExecuteAppleScript).toHaveBeenCalledWith(expect.stringContaining("<div>Keep This Title</div>"));
+        });
+        it("uses new title when provided", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "",
+            });
+            manager.updateNote("Old Title", "Brand New Title", "Content");
+            expect(mockExecuteAppleScript).toHaveBeenCalledWith(expect.stringContaining("<div>Brand New Title</div>"));
+        });
+        it("uses HTML content directly when format is html", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "",
+            });
+            // Use content with &amp; — if escapeForAppleScript were accidentally used,
+            // the & in &amp; would become &amp;amp;, causing this assertion to fail.
+            const htmlContent = "<h1>Title</h1><div>A &amp; B</div>";
+            const result = manager.updateNote("Old Title", undefined, htmlContent, undefined, "html");
+            expect(result).toBe(true);
+            // In HTML mode: content is used as-is, no <div> wrapper added
+            expect(mockExecuteAppleScript).toHaveBeenCalledWith(expect.stringContaining(`to "${htmlContent}"`));
+        });
+        it("does not wrap HTML content in div tags when format is html", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "",
+            });
+            manager.updateNote("Old Title", undefined, "<h1>My Title</h1><div>Content</div>", undefined, "html");
+            // Should NOT contain the <div>Old Title</div> wrapper
+            expect(mockExecuteAppleScript).not.toHaveBeenCalledWith(expect.stringContaining("<div>Old Title</div>"));
+        });
+        it("still wraps in div tags when format is plaintext (default)", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "",
+            });
+            manager.updateNote("My Title", undefined, "Plain content");
+            // Default behavior: should have <div> wrapper
+            expect(mockExecuteAppleScript).toHaveBeenCalledWith(expect.stringContaining("<div>My Title</div><div>Plain content</div>"));
+        });
+    });
+    // ---------------------------------------------------------------------------
+    // Note Update by ID
+    // ---------------------------------------------------------------------------
+    describe("updateNoteById", () => {
+        it("uses HTML content directly without div wrapping in HTML mode", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "",
+            });
+            const htmlContent = "<h1>My Title</h1><div>A &amp; B</div>";
+            const result = manager.updateNoteById("x-coredata://ABC00000-0000-0000-0000-000000000001/ICNote/p123", undefined, htmlContent, "html");
+            expect(result).toBe(true);
+            // HTML mode: content passed directly, no <div> wrapper
+            expect(mockExecuteAppleScript).toHaveBeenCalledWith(expect.stringContaining(`to "${htmlContent}"`));
+            // Should NOT contain the div-wrapped title pattern
+            expect(mockExecuteAppleScript).not.toHaveBeenCalledWith(expect.stringContaining("<div>My Title</div>"));
+        });
+        it("does not call getNoteById in HTML mode (skips lookup optimization)", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "",
+            });
+            const htmlContent = "<h1>Title</h1><div>Body</div>";
+            manager.updateNoteById("x-coredata://ABC00000-0000-0000-0000-000000000002/ICNote/p456", undefined, htmlContent, "html");
+            // In HTML mode, getNoteById should NOT be called (it would trigger
+            // an additional executeAppleScript call). Only one call should happen:
+            // the update itself.
+            expect(mockExecuteAppleScript).toHaveBeenCalledTimes(1);
+        });
+    });
+    // ---------------------------------------------------------------------------
+    // Note Listing
+    // ---------------------------------------------------------------------------
+    describe("listNotes", () => {
+        it("returns array of note titles", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: [
+                    ["Note A", "x-coredata://ABC/ICNote/p1"].join(F),
+                    ["Note B", "x-coredata://ABC/ICNote/p2"].join(F),
+                    ["Note C", "x-coredata://ABC/ICNote/p3"].join(F),
+                ].join(R),
+            });
+            const titles = manager.listNotes();
+            expect(titles).toEqual(["Note A", "Note B", "Note C"]);
+        });
+        it("filters out empty entries", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: [
+                    ["Note A", "x-coredata://ABC/ICNote/p1"].join(F),
+                    "",
+                    ["Note B", "x-coredata://ABC/ICNote/p2"].join(F),
+                    "",
+                    "",
+                ].join(R),
+            });
+            const titles = manager.listNotes();
+            expect(titles).toEqual(["Note A", "Note B"]);
+        });
+        it("deduplicates duplicate note IDs while preserving separate notes with the same title", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: [
+                    ["Same Title", "x-coredata://ABC/ICNote/p1"].join(F),
+                    ["Same Title", "x-coredata://ABC/ICNote/p1"].join(F),
+                    ["Same Title", "x-coredata://ABC/ICNote/p2"].join(F),
+                ].join(R),
+            });
+            const titles = manager.listNotes();
+            expect(titles).toEqual(["Same Title", "Same Title"]);
+        });
+        it("throws on failure rather than returning empty (#19)", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: false,
+                output: "",
+                error: "Account not found",
+            });
+            expect(() => manager.listNotes()).toThrow(/Account not found/);
+        });
+        it("filters by folder when specified", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: [
+                    ["Work Note 1", "x-coredata://ABC/ICNote/p1"].join(F),
+                    ["Work Note 2", "x-coredata://ABC/ICNote/p2"].join(F),
+                ].join(R),
+            });
+            manager.listNotes("iCloud", "Work");
+            expect(mockExecuteAppleScript).toHaveBeenCalledWith(expect.stringContaining('notes of folder "Work"'));
+        });
+        it("uses whose clause when modifiedSince is provided", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: [
+                    ["Recent Note 1", "x-coredata://ABC/ICNote/p1"].join(F),
+                    ["Recent Note 2", "x-coredata://ABC/ICNote/p2"].join(F),
+                ].join(R),
+            });
+            const results = manager.listNotes(undefined, undefined, "2025-06-15T00:00:00");
+            const script = mockExecuteAppleScript.mock.calls[0][0];
+            // Locale-safe: uses variable setup + whose clause (no sort order assumption)
+            expect(script).toContain("set thresholdDate to current date");
+            expect(script).toContain("set year of thresholdDate to 2025");
+            expect(script).toContain("set month of thresholdDate to 6");
+            expect(script).toContain("set day of thresholdDate to 15");
+            expect(script).toContain("whose modification date >= thresholdDate");
+            expect(results).toEqual(["Recent Note 1", "Recent Note 2"]);
+        });
+        it("uses repeat loop when limit is provided", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: [
+                    ["Note 1", "x-coredata://ABC/ICNote/p1"].join(F),
+                    ["Note 2", "x-coredata://ABC/ICNote/p2"].join(F),
+                    ["Note 3", "x-coredata://ABC/ICNote/p3"].join(F),
+                ].join(R),
+            });
+            const results = manager.listNotes(undefined, undefined, undefined, 3);
+            const script = mockExecuteAppleScript.mock.calls[0][0];
+            expect(script).toContain("(count of resultList) >= 3");
+            expect(results).toEqual(["Note 1", "Note 2", "Note 3"]);
+        });
+        it("combines folder, modifiedSince, and limit", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: [
+                    ["Work Note", "x-coredata://ABC/ICNote/p1"].join(F),
+                    ["Another Work Note", "x-coredata://ABC/ICNote/p2"].join(F),
+                ].join(R),
+            });
+            manager.listNotes("iCloud", "Work", "2025-01-01", 10);
+            const script = mockExecuteAppleScript.mock.calls[0][0];
+            expect(script).toContain("whose modification date >= thresholdDate");
+            expect(script).toContain('notes of folder "Work"');
+            expect(script).toContain("(count of resultList) >= 10");
+        });
+        it("returns empty array when modifiedSince yields no results", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "",
+            });
+            const results = manager.listNotes(undefined, undefined, "2099-01-01");
+            expect(results).toEqual([]);
+        });
+        it("ignores invalid modifiedSince date and falls back to limit-only", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: [
+                    ["Note 1", "x-coredata://ABC/ICNote/p1"].join(F),
+                    ["Note 2", "x-coredata://ABC/ICNote/p2"].join(F),
+                ].join(R),
+            });
+            const results = manager.listNotes(undefined, undefined, "not-a-date", 5);
+            const script = mockExecuteAppleScript.mock.calls[0][0];
+            expect(script).not.toContain("thresholdDate");
+            expect(script).toContain("(count of resultList) >= 5");
+            expect(results).toEqual(["Note 1", "Note 2"]);
+        });
+    });
+    // ---------------------------------------------------------------------------
+    // Folder Operations
+    // ---------------------------------------------------------------------------
+    describe("listFolders", () => {
+        it("returns array of Folder objects with paths", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: [
+                    ["id1", "Notes", "", "false"].join(F),
+                    ["id2", "Archive", "", "false"].join(F),
+                    ["id3", "Work", "", "true"].join(F),
+                ].join(R),
+            });
+            const folders = manager.listFolders();
+            expect(folders).toHaveLength(3);
+            expect(folders[0].name).toBe("Notes");
+            expect(folders[1].name).toBe("Archive");
+            expect(folders[2].name).toBe("Work");
+            expect(folders[0].id).toBe("id1");
+            expect(folders[2].shared).toBe(true);
+        });
+        it("includes parent folder in path", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: [
+                    ["id1", "Dev", "", "false"].join(F),
+                    ["id2", "Accessibility", "id1", "false"].join(F),
+                    ["id3", "Work", "", "false"].join(F),
+                    ["id4", "Clients", "id3", "false"].join(F),
+                ].join(R),
+            });
+            const folders = manager.listFolders();
+            expect(folders).toHaveLength(4);
+            expect(folders[0].name).toBe("Dev");
+            expect(folders[1].name).toBe("Dev/Accessibility");
+            expect(folders[2].name).toBe("Work");
+            expect(folders[3].name).toBe("Work/Clients");
+        });
+        it("disambiguates duplicate folder names using IDs", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: [
+                    ["id1", "Finance", "", "false"].join(F),
+                    ["id2", "Archive", "id1", "false"].join(F),
+                    ["id3", "Travel", "", "false"].join(F),
+                    ["id4", "Trips", "id3", "false"].join(F),
+                    ["id5", "Archive", "id4", "false"].join(F),
+                ].join(R),
+            });
+            const folders = manager.listFolders();
+            expect(folders).toHaveLength(5);
+            expect(folders[1].name).toBe("Finance/Archive");
+            expect(folders[4].name).toBe("Travel/Trips/Archive");
+        });
+        it("escapes slashes in folder names", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: [
+                    ["id1", "Travel", "", "false"].join(F),
+                    ["id2", "Spain/Portugal 2023", "id1", "false"].join(F),
+                ].join(R),
+            });
+            const folders = manager.listFolders();
+            expect(folders).toHaveLength(2);
+            expect(folders[0].name).toBe("Travel");
+            expect(folders[1].name).toBe("Travel/Spain\\/Portugal 2023");
+        });
+        it("parses legacy tab/newline output (backward compat)", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "id1\tNotes\nid2\tArchive\tid1",
+            });
+            const folders = manager.listFolders();
+            expect(folders).toHaveLength(2);
+            expect(folders[0].name).toBe("Notes");
+            expect(folders[1].name).toBe("Notes/Archive");
+            expect(folders[1].shared).toBe(false);
+        });
+        it("includes account in Folder objects", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: ["id1", "Notes", "", "false"].join(F),
+            });
+            const folders = manager.listFolders("Gmail");
+            expect(folders[0].account).toBe("Gmail");
+        });
+    });
+    describe("createFolder", () => {
+        it("returns Folder object on success", () => {
+            mockExecuteAppleScript
+                // Check existence — folder doesn't exist
+                .mockReturnValueOnce({ success: false, output: "", error: "Can't get folder" })
+                // Create the folder
+                .mockReturnValueOnce({
+                success: true,
+                output: "folder id x-coredata://ABC123/ICFolder/p456",
+            })
+                // Get ID of created folder
+                .mockReturnValueOnce({
+                success: true,
+                output: "folder id x-coredata://ABC123/ICFolder/p456",
+            });
+            const result = manager.createFolder("New Project");
+            expect(result).not.toBeNull();
+            expect(result?.name).toBe("New Project");
+            expect(result?.id).toBe("x-coredata://ABC123/ICFolder/p456");
+        });
+        it("returns existing folder without creating duplicate", () => {
+            mockExecuteAppleScript
+                // Check existence — folder already exists
+                .mockReturnValueOnce({
+                success: true,
+                output: "x-coredata://ABC123/ICFolder/p789",
+            })
+                // Get ID of existing folder
+                .mockReturnValueOnce({
+                success: true,
+                output: "folder id x-coredata://ABC123/ICFolder/p789",
+            });
+            const result = manager.createFolder("Existing Folder");
+            expect(result).not.toBeNull();
+            expect(result?.name).toBe("Existing Folder");
+            expect(result?.id).toBe("x-coredata://ABC123/ICFolder/p789");
+            // Should only have 2 calls (check + get ID), no create call
+            expect(mockExecuteAppleScript).toHaveBeenCalledTimes(2);
+        });
+        it("returns null on genuine failure", () => {
+            mockExecuteAppleScript
+                // Check existence — doesn't exist
+                .mockReturnValueOnce({ success: false, output: "", error: "Can't get folder" })
+                // Create fails
+                .mockReturnValueOnce({
+                success: false,
+                output: "",
+                error: "Permission denied",
+            });
+            const result = manager.createFolder("Restricted Folder");
+            expect(result).toBeNull();
+        });
+        it("creates nested folder path", () => {
+            mockExecuteAppleScript
+                // Check "Retro Tech" — doesn't exist
+                .mockReturnValueOnce({ success: false, output: "", error: "Can't get folder" })
+                // Create "Retro Tech"
+                .mockReturnValueOnce({ success: true, output: "folder id x-coredata://A/ICFolder/p1" })
+                // Check "Retro Tech/PC" — doesn't exist
+                .mockReturnValueOnce({ success: false, output: "", error: "Can't get folder" })
+                // Create "PC" inside "Retro Tech"
+                .mockReturnValueOnce({ success: true, output: "folder id x-coredata://A/ICFolder/p2" })
+                // Check "Retro Tech/PC/CPUs" — doesn't exist
+                .mockReturnValueOnce({ success: false, output: "", error: "Can't get folder" })
+                // Create "CPUs" inside "Retro Tech/PC"
+                .mockReturnValueOnce({ success: true, output: "folder id x-coredata://A/ICFolder/p3" })
+                // Get ID of final folder
+                .mockReturnValueOnce({ success: true, output: "folder id x-coredata://A/ICFolder/p3" });
+            const result = manager.createFolder("Retro Tech/PC/CPUs");
+            expect(result).not.toBeNull();
+            expect(result?.name).toBe("Retro Tech/PC/CPUs");
+            expect(result?.id).toBe("x-coredata://A/ICFolder/p3");
+            // Verify the create commands (calls at index 1, 3, 5)
+            const calls = mockExecuteAppleScript.mock.calls;
+            expect(calls[1][0]).toContain('make new folder with properties {name:"Retro Tech"}');
+            expect(calls[3][0]).toContain('make new folder at folder "Retro Tech" with properties {name:"PC"}');
+            expect(calls[5][0]).toContain('make new folder at folder "PC" of folder "Retro Tech" with properties {name:"CPUs"}');
+        });
+        it("skips existing intermediate folders in nested path", () => {
+            mockExecuteAppleScript
+                // Check "Retro Tech" — exists
+                .mockReturnValueOnce({ success: true, output: "x-coredata://A/ICFolder/p1" })
+                // Check "Retro Tech/PC" — doesn't exist
+                .mockReturnValueOnce({ success: false, output: "", error: "Can't get folder" })
+                // Create "PC" inside "Retro Tech"
+                .mockReturnValueOnce({ success: true, output: "folder id x-coredata://A/ICFolder/p2" })
+                // Get ID of final folder
+                .mockReturnValueOnce({ success: true, output: "folder id x-coredata://A/ICFolder/p2" });
+            const result = manager.createFolder("Retro Tech/PC");
+            expect(result).not.toBeNull();
+            expect(result?.name).toBe("Retro Tech/PC");
+            // No create call for "Retro Tech" — only for "PC"
+            const createCalls = mockExecuteAppleScript.mock.calls.filter((c) => c[0].includes("make new folder"));
+            expect(createCalls).toHaveLength(1);
+            expect(createCalls[0][0]).toContain('name:"PC"');
+        });
+    });
+    describe("deleteFolder", () => {
+        it("returns true on successful deletion", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "",
+            });
+            const result = manager.deleteFolder("Empty Folder");
+            expect(result).toBe(true);
+        });
+        it("returns false when deletion fails", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: false,
+                output: "",
+                error: "Folder contains notes",
+            });
+            const result = manager.deleteFolder("Non-Empty Folder");
+            expect(result).toBe(false);
+        });
+    });
+    // ---------------------------------------------------------------------------
+    // Note Moving
+    // ---------------------------------------------------------------------------
+    describe("moveNote", () => {
+        // The note-details lookup output reused by the title-based move tests.
+        const detailsOutput = [
+            "My Note",
+            "x-coredata://ABC/ICNote/p123",
+            "Monday, January 1, 2024 at 12:00:00 PM",
+            "Monday, January 1, 2024 at 12:00:00 PM",
+            "false",
+            "false",
+        ].join(F);
+        it("returns true when the native move completes successfully", () => {
+            // Mock sequence: getNoteDetails (resolve id) -> native move
+            mockExecuteAppleScript
+                .mockReturnValueOnce({ success: true, output: detailsOutput })
+                .mockReturnValueOnce({ success: true, output: "" });
+            const result = manager.moveNote("My Note", "Archive");
+            expect(result).toBe(true);
+            // No copy-then-delete: just the details lookup + a single native `move`.
+            expect(mockExecuteAppleScript).toHaveBeenCalledTimes(2);
+        });
+        it("uses the native AppleScript `move` command (preserves attachments/identity)", () => {
+            mockExecuteAppleScript
+                .mockReturnValueOnce({ success: true, output: detailsOutput })
+                .mockReturnValueOnce({ success: true, output: "" });
+            manager.moveNote("My Note", "Archive");
+            // The second call is the move; assert it issues a native `move ... to` and
+            // does NOT rebuild the note via `make new note` (the old lossy path).
+            const moveScript = mockExecuteAppleScript.mock.calls[1][0];
+            expect(moveScript).toContain("move noteRef to destFolder");
+            expect(moveScript).not.toContain("make new note");
+        });
+        it("returns false when source note cannot be found", () => {
+            mockExecuteAppleScript.mockReturnValueOnce({
+                success: false,
+                output: "",
+                error: "Note not found",
+            });
+            const result = manager.moveNote("Missing Note", "Archive");
+            expect(result).toBe(false);
+            expect(mockExecuteAppleScript).toHaveBeenCalledTimes(1); // Only tried to get details
+        });
+        it("returns false when the move fails (e.g. destination folder missing)", () => {
+            mockExecuteAppleScript
+                .mockReturnValueOnce({ success: true, output: detailsOutput })
+                .mockReturnValueOnce({
+                success: false,
+                output: "",
+                error: "Folder not found",
+            });
+            const result = manager.moveNote("My Note", "Nonexistent Folder");
+            expect(result).toBe(false);
+            expect(mockExecuteAppleScript).toHaveBeenCalledTimes(2); // Details + failed move
+        });
+    });
+    describe("moveNoteById", () => {
+        it("returns true when the native move succeeds", () => {
+            mockExecuteAppleScript.mockReturnValueOnce({ success: true, output: "" });
+            const result = manager.moveNoteById("x-coredata://ABC/ICNote/p123", "Archive");
+            expect(result).toBe(true);
+            // Single native `move` — no getNoteContentById/create/delete fan-out.
+            expect(mockExecuteAppleScript).toHaveBeenCalledTimes(1);
+            const moveScript = mockExecuteAppleScript.mock.calls[0][0];
+            expect(moveScript).toContain("move noteRef to destFolder");
+            expect(moveScript).not.toContain("make new note");
+        });
+        it("returns false when the move fails", () => {
+            mockExecuteAppleScript.mockReturnValueOnce({
+                success: false,
+                output: "",
+                error: "Folder not found",
+            });
+            const result = manager.moveNoteById("x-coredata://ABC/ICNote/p123", "Nonexistent");
+            expect(result).toBe(false);
+            expect(mockExecuteAppleScript).toHaveBeenCalledTimes(1);
+        });
+    });
+    // ---------------------------------------------------------------------------
+    // Account Operations
+    // ---------------------------------------------------------------------------
+    describe("listAccounts", () => {
+        it("returns array of Account objects", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: [
+                    ["acc1", "iCloud", "true", "folder1", "Notes"].join(F),
+                    ["acc2", "Gmail", "false", "folder2", "Inbox"].join(F),
+                    ["acc3", "Exchange", "false", "", ""].join(F),
+                ].join(R),
+            });
+            const accounts = manager.listAccounts();
+            expect(accounts).toHaveLength(3);
+            expect(accounts[0].name).toBe("iCloud");
+            expect(accounts[1].name).toBe("Gmail");
+            expect(accounts[2].name).toBe("Exchange");
+            expect(accounts[0].id).toBe("acc1");
+            expect(accounts[0].upgraded).toBe(true);
+            expect(accounts[0].defaultFolder).toBe("Notes");
+        });
+        it("parses legacy plain-name output (backward compat)", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: ["iCloud", "Gmail"].join(R),
+            });
+            const accounts = manager.listAccounts();
+            expect(accounts).toHaveLength(2);
+            expect(accounts[0]).toEqual({ name: "iCloud" });
+            expect(accounts[1]).toEqual({ name: "Gmail" });
+        });
+        it("handles account records with empty fields", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: ["", "", "", "", ""].join(F),
+            });
+            const accounts = manager.listAccounts();
+            expect(accounts).toHaveLength(1);
+            expect(accounts[0].name).toBe("");
+            expect(accounts[0].upgraded).toBe(false);
+            expect(accounts[0].defaultFolderId).toBeUndefined();
+        });
+        it("throws on failure rather than returning empty (#19)", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: false,
+                output: "",
+                error: "Notes.app not available",
+            });
+            expect(() => manager.listAccounts()).toThrow(/Notes.app not available/);
+        });
+    });
+    describe("getDefaultLocation", () => {
+        it("returns default account and folder metadata", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: ["acc1", "iCloud", "true", "folder1", "Notes", "false"].join(F),
+            });
+            const location = manager.getDefaultLocation();
+            expect(location.account).toMatchObject({
+                id: "acc1",
+                name: "iCloud",
+                upgraded: true,
+                defaultFolderId: "folder1",
+                defaultFolder: "Notes",
+            });
+            expect(location.folder).toMatchObject({
+                id: "folder1",
+                name: "Notes",
+                account: "iCloud",
+                shared: false,
+            });
+        });
+        it("throws when default location output cannot be parsed", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "bad-output",
+            });
+            expect(() => manager.getDefaultLocation()).toThrow(/parse default Notes location/);
+        });
+        it("throws when AppleScript fails", () => {
+            mockExecuteAppleScript.mockReturnValue({ success: false, output: "", error: "boom" });
+            expect(() => manager.getDefaultLocation()).toThrow(/Failed to get default Notes location/);
+        });
+        it("handles empty fields in default location output", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: ["", "", "", "", "", ""].join(F),
+            });
+            const location = manager.getDefaultLocation();
+            expect(location.account.name).toBe("");
+            expect(location.account.upgraded).toBe(false);
+            expect(location.folder.id).toBe("");
+            expect(location.folder.shared).toBe(false);
+        });
+    });
+    describe("getSelectedNotes", () => {
+        it("returns selected note metadata", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: [
+                    [
+                        "x-coredata://ABC/ICNote/p1",
+                        "Selected Note",
+                        "2026-6-22-14-30-0",
+                        "2026-6-22-14-35-0",
+                        "false",
+                        "false",
+                        "Notes",
+                        "iCloud",
+                    ].join(F),
+                ].join(R),
+            });
+            const notes = manager.getSelectedNotes();
+            expect(notes).toHaveLength(1);
+            expect(notes[0]).toMatchObject({
+                id: "x-coredata://ABC/ICNote/p1",
+                title: "Selected Note",
+                shared: false,
+                passwordProtected: false,
+                folder: "Notes",
+                account: "iCloud",
+            });
+            expect(notes[0].created.getFullYear()).toBe(2026);
+        });
+        it("returns an empty array when no note is selected", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "",
+            });
+            expect(manager.getSelectedNotes()).toEqual([]);
+        });
+        it("throws when AppleScript fails", () => {
+            mockExecuteAppleScript.mockReturnValue({ success: false, output: "", error: "boom" });
+            expect(() => manager.getSelectedNotes()).toThrow(/Failed to get selected notes/);
+        });
+        it("handles selected notes with empty optional fields", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: ["", "", "", "", "", "", "", ""].join(F),
+            });
+            const notes = manager.getSelectedNotes();
+            expect(notes).toHaveLength(1);
+            expect(notes[0].id).toBe("");
+            expect(notes[0].shared).toBe(false);
+            expect(notes[0].passwordProtected).toBe(false);
+            expect(notes[0].folder).toBeUndefined();
+            expect(notes[0].account).toBeUndefined();
+        });
+    });
+    describe("showNoteById", () => {
+        it("shows a note by id", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "",
+            });
+            expect(manager.showNoteById("x-coredata://ABC/ICNote/p1")).toBe(true);
+            expect(mockExecuteAppleScript).toHaveBeenCalledWith(expect.stringContaining('show note id "x-coredata://ABC/ICNote/p1"'));
+        });
+        it("can request a separate window", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: "",
+            });
+            manager.showNoteById("x-coredata://ABC/ICNote/p1", true);
+            expect(mockExecuteAppleScript).toHaveBeenCalledWith(expect.stringContaining("separately true"));
+        });
+        it("returns false when Notes.app rejects the show command", () => {
+            mockExecuteAppleScript.mockReturnValue({ success: false, output: "", error: "no such note" });
+            expect(manager.showNoteById("x-coredata://ABC/ICNote/p1")).toBe(false);
+        });
+    });
+    describe("showFolderById", () => {
+        it("shows a folder by id", () => {
+            mockExecuteAppleScript.mockReturnValue({ success: true, output: "" });
+            expect(manager.showFolderById("x-coredata://ABC/ICFolder/p1")).toBe(true);
+            expect(mockExecuteAppleScript).toHaveBeenCalledWith(expect.stringContaining('show folder id "x-coredata://ABC/ICFolder/p1"'));
+        });
+        it("can request a separate window", () => {
+            mockExecuteAppleScript.mockReturnValue({ success: true, output: "" });
+            manager.showFolderById("x-coredata://ABC/ICFolder/p1", true);
+            expect(mockExecuteAppleScript).toHaveBeenCalledWith(expect.stringContaining("separately true"));
+        });
+        it("returns false when Notes.app rejects the show command", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: false,
+                output: "",
+                error: "no such folder",
+            });
+            expect(manager.showFolderById("x-coredata://ABC/ICFolder/p1")).toBe(false);
+        });
+    });
+    describe("showAccountById", () => {
+        it("shows an account by id", () => {
+            mockExecuteAppleScript.mockReturnValue({ success: true, output: "" });
+            expect(manager.showAccountById("x-coredata://ABC/ICAccount/p1")).toBe(true);
+            expect(mockExecuteAppleScript).toHaveBeenCalledWith(expect.stringContaining('show account id "x-coredata://ABC/ICAccount/p1"'));
+        });
+        it("can request a separate window", () => {
+            mockExecuteAppleScript.mockReturnValue({ success: true, output: "" });
+            manager.showAccountById("x-coredata://ABC/ICAccount/p1", true);
+            expect(mockExecuteAppleScript).toHaveBeenCalledWith(expect.stringContaining("separately true"));
+        });
+        it("returns false when Notes.app rejects the show command", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: false,
+                output: "",
+                error: "no such account",
+            });
+            expect(manager.showAccountById("x-coredata://ABC/ICAccount/p1")).toBe(false);
+        });
+    });
+    describe("showAttachmentById", () => {
+        it("resolves the attachment within its note and shows it", () => {
+            mockExecuteAppleScript.mockReturnValue({ success: true, output: "OK" });
+            expect(manager.showAttachmentById("x-coredata://ABC/ICNote/p1", "att-123")).toBe(true);
+            const script = mockExecuteAppleScript.mock.calls[0][0];
+            expect(script).toContain('set theNote to note id "x-coredata://ABC/ICNote/p1"');
+            expect(script).toContain('is "att-123"');
+            expect(script).toContain("show theAttachment");
+        });
+        it("can request a separate window", () => {
+            mockExecuteAppleScript.mockReturnValue({ success: true, output: "OK" });
+            manager.showAttachmentById("x-coredata://ABC/ICNote/p1", "att-123", true);
+            expect(mockExecuteAppleScript).toHaveBeenCalledWith(expect.stringContaining("separately true"));
+        });
+        it("returns false when the attachment is not found on the note", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: true,
+                output: `ERR${F}attachment not found`,
+            });
+            expect(manager.showAttachmentById("x-coredata://ABC/ICNote/p1", "missing")).toBe(false);
+        });
+        it("returns false when Notes.app rejects the show command", () => {
+            mockExecuteAppleScript.mockReturnValue({
+                success: false,
+                output: "",
+                error: "no such note",
+            });
+            expect(manager.showAttachmentById("x-coredata://ABC/ICNote/p1", "att-123")).toBe(false);
+        });
+    });
+    // ---------------------------------------------------------------------------
+    // Health Check
+    // ---------------------------------------------------------------------------
+    describe("healthCheck", () => {
+        it("returns healthy when all checks pass", () => {
+            mockExecuteAppleScript
+                // Check 1: Notes.app accessible
+                .mockReturnValueOnce({ success: true, output: "ok" })
+                // Check 2: Permissions (get account name)
+                .mockReturnValueOnce({ success: true, output: "iCloud" })
+                // Check 3: listAccounts
+                .mockReturnValueOnce({ success: true, output: "iCloud" })
+                // Check 4: listNotes
+                .mockReturnValueOnce({
+                success: true,
+                output: [
+                    ["Note 1", "x-coredata://ABC/ICNote/p1"].join(F),
+                    ["Note 2", "x-coredata://ABC/ICNote/p2"].join(F),
+                ].join(R),
+            });
+            const result = manager.healthCheck();
+            expect(result.healthy).toBe(true);
+            expect(result.checks).toHaveLength(4);
+            expect(result.checks.every((c) => c.passed)).toBe(true);
+        });
+        it("returns unhealthy when Notes.app is not accessible", () => {
+            mockExecuteAppleScript.mockReturnValueOnce({
+                success: false,
+                output: "",
+                error: "Application not found",
+            });
+            const result = manager.healthCheck();
+            expect(result.healthy).toBe(false);
+            expect(result.checks).toHaveLength(1);
+            expect(result.checks[0].name).toBe("notes_app");
+            expect(result.checks[0].passed).toBe(false);
+        });
+        it("returns unhealthy with permission hint when not authorized", () => {
+            mockExecuteAppleScript.mockReturnValueOnce({
+                success: false,
+                output: "",
+                error: "not authorized to send Apple events",
+            });
+            const result = manager.healthCheck();
+            expect(result.healthy).toBe(false);
+            expect(result.checks[0].message).toContain("Automation permissions");
+        });
+        it("returns unhealthy when no accounts found", () => {
+            mockExecuteAppleScript
+                .mockReturnValueOnce({ success: true, output: "ok" })
+                .mockReturnValueOnce({ success: true, output: "iCloud" })
+                .mockReturnValueOnce({ success: true, output: "" }); // No accounts
+            const result = manager.healthCheck();
+            expect(result.healthy).toBe(false);
+            expect(result.checks.find((c) => c.name === "accounts")?.passed).toBe(false);
+        });
+        it("includes account names in successful account check", () => {
+            mockExecuteAppleScript
+                .mockReturnValueOnce({ success: true, output: "ok" })
+                .mockReturnValueOnce({ success: true, output: "iCloud" })
+                .mockReturnValueOnce({ success: true, output: ["iCloud", "Gmail"].join(R) })
+                .mockReturnValueOnce({ success: true, output: "" });
+            const result = manager.healthCheck();
+            const accountCheck = result.checks.find((c) => c.name === "accounts");
+            expect(accountCheck?.message).toContain("iCloud");
+            expect(accountCheck?.message).toContain("Gmail");
+        });
+    });
+    // ---------------------------------------------------------------------------
+    // Statistics
+    // ---------------------------------------------------------------------------
+    describe("getNotesStats", () => {
+        it("returns statistics for all accounts and folders", () => {
+            mockExecuteAppleScript
+                // listAccounts
+                .mockReturnValueOnce({ success: true, output: "iCloud" })
+                // per-account folder counts: name<F>count, records joined by R
+                .mockReturnValueOnce({
+                success: true,
+                output: ["Notes", "3"].join(F) + R + ["Work", "2"].join(F) + R,
+            })
+                // getRecentlyModifiedCounts: c1<F>c7<F>c30
+                .mockReturnValueOnce({ success: true, output: ["0", "0", "0"].join(F) });
+            const stats = manager.getNotesStats();
+            expect(stats.totalNotes).toBe(5);
+            expect(stats.accounts).toHaveLength(1);
+            expect(stats.accounts[0].name).toBe("iCloud");
+            expect(stats.accounts[0].totalNotes).toBe(5);
+            expect(stats.accounts[0].folderCount).toBe(2);
+            expect(stats.accounts[0].folders).toHaveLength(2);
+        });
+        it("returns zero counts when no notes exist", () => {
+            mockExecuteAppleScript
+                .mockReturnValueOnce({ success: true, output: "iCloud" })
+                .mockReturnValueOnce({ success: true, output: ["Notes", "0"].join(F) + R })
+                .mockReturnValueOnce({ success: true, output: ["0", "0", "0"].join(F) });
+            const stats = manager.getNotesStats();
+            expect(stats.totalNotes).toBe(0);
+            expect(stats.recentlyModified.last24h).toBe(0);
+            expect(stats.recentlyModified.last7d).toBe(0);
+            expect(stats.recentlyModified.last30d).toBe(0);
+        });
+        it("handles multiple accounts", () => {
+            mockExecuteAppleScript
+                // listAccounts
+                .mockReturnValueOnce({ success: true, output: ["iCloud", "Gmail"].join(R) })
+                // iCloud folder counts
+                .mockReturnValueOnce({ success: true, output: ["Notes", "1"].join(F) + R })
+                // Gmail folder counts
+                .mockReturnValueOnce({ success: true, output: ["Notes", "1"].join(F) + R })
+                // getRecentlyModifiedCounts
+                .mockReturnValueOnce({ success: true, output: ["0", "0", "0"].join(F) });
+            const stats = manager.getNotesStats();
+            expect(stats.totalNotes).toBe(2);
+            expect(stats.accounts).toHaveLength(2);
+            expect(stats.accounts[0].name).toBe("iCloud");
+            expect(stats.accounts[1].name).toBe("Gmail");
+        });
+        it("reports complete coverage when every scope succeeds (#19)", () => {
+            mockExecuteAppleScript
+                .mockReturnValueOnce({ success: true, output: "iCloud" })
+                .mockReturnValueOnce({ success: true, output: ["Notes", "3"].join(F) + R })
+                .mockReturnValueOnce({ success: true, output: ["1", "2", "3"].join(F) });
+            const stats = manager.getNotesStats();
+            expect(stats.coverage.complete).toBe(true);
+            expect(stats.coverage.warnings).toEqual([]);
+            expect(stats.coverage.covered).toBe(stats.coverage.scanned);
+        });
+        it("degrades gracefully when one account fails, with a coverage warning (#19)", () => {
+            mockExecuteAppleScript
+                // listAccounts
+                .mockReturnValueOnce({ success: true, output: ["iCloud", "Gmail"].join(R) })
+                // iCloud folder counts succeed
+                .mockReturnValueOnce({ success: true, output: ["Notes", "4"].join(F) + R })
+                // Gmail folder counts FAIL
+                .mockReturnValueOnce({ success: false, output: "", error: "Gmail account is locked" })
+                // getRecentlyModifiedCounts succeed
+                .mockReturnValueOnce({ success: true, output: ["0", "0", "0"].join(F) });
+            const stats = manager.getNotesStats();
+            // Healthy account's data is preserved, not discarded
+            expect(stats.totalNotes).toBe(4);
+            expect(stats.accounts).toHaveLength(1);
+            expect(stats.accounts[0].name).toBe("iCloud");
+            // Failure surfaced as a coverage warning
+            expect(stats.coverage.complete).toBe(false);
+            expect(stats.coverage.warnings).toHaveLength(1);
+            expect(stats.coverage.warnings[0].scope).toBe("Gmail");
+            expect(stats.coverage.warnings[0].reason).toContain("locked");
+        });
+        it("flags recent-activity failure as a coverage warning, not fake zeros (#19)", () => {
+            mockExecuteAppleScript
+                .mockReturnValueOnce({ success: true, output: "iCloud" })
+                .mockReturnValueOnce({ success: true, output: ["Notes", "5"].join(F) + R })
+                // getRecentlyModifiedCounts FAILS
+                .mockReturnValueOnce({ success: false, output: "", error: "timed out" });
+            const stats = manager.getNotesStats();
+            expect(stats.totalNotes).toBe(5);
+            expect(stats.recentlyModified.last24h).toBe(0);
+            expect(stats.coverage.complete).toBe(false);
+            expect(stats.coverage.warnings.some((w) => w.scope === "recent-activity")).toBe(true);
+        });
+        it("throws when no account can be read at all (#19)", () => {
+            mockExecuteAppleScript
+                .mockReturnValueOnce({ success: true, output: ["iCloud", "Gmail"].join(R) })
+                .mockReturnValueOnce({ success: false, output: "", error: "iCloud unreachable" })
+                .mockReturnValueOnce({ success: false, output: "", error: "Gmail unreachable" });
+            expect(() => manager.getNotesStats()).toThrow(/Failed to read folder stats for any/);
+        });
+    });
+    // ---------------------------------------------------------------------------
+    // Attachment Listing
+    // ---------------------------------------------------------------------------
+    describe("listAttachmentsById", () => {
+        it("returns attachments for a note", () => {
+            mockExecuteAppleScript.mockReturnValueOnce({
+                success: true,
+                output: [
+                    ["x-coredata://ABC/ICAttachment/p1", "photo.jpg", "public.jpeg"].join(F),
+                    ["x-coredata://ABC/ICAttachment/p2", "document.pdf", "com.adobe.pdf"].join(F),
+                ].join(R),
+            });
+            const attachments = manager.listAttachmentsById("x-coredata://ABC/ICNote/p123");
+            expect(attachments).toHaveLength(2);
+            expect(attachments[0]).toMatchObject({
+                id: "x-coredata://ABC/ICAttachment/p1",
+                name: "photo.jpg",
+                contentType: "public.jpeg",
+                contentId: "public.jpeg",
+            });
+            expect(attachments[1]).toMatchObject({
+                id: "x-coredata://ABC/ICAttachment/p2",
+                name: "document.pdf",
+                contentType: "com.adobe.pdf",
+                contentId: "com.adobe.pdf",
+            });
+        });
+        it("parses richer attachment metadata when present", () => {
+            mockExecuteAppleScript.mockReturnValueOnce({
+                success: true,
+                output: [
+                    [
+                        "x-coredata://ABC/ICAttachment/p1",
+                        "site.webloc",
+                        "cid:123",
+                        "https://example.com",
+                        "2026-6-22-10-0-0",
+                        "2026-6-22-11-0-0",
+                        "true",
+                    ].join(F),
+                ].join(R),
+            });
+            const attachments = manager.listAttachmentsById("x-coredata://ABC/ICNote/p123");
+            expect(attachments[0]).toMatchObject({
+                id: "x-coredata://ABC/ICAttachment/p1",
+                name: "site.webloc",
+                contentType: "cid:123",
+                contentId: "cid:123",
+                url: "https://example.com",
+                shared: true,
+            });
+            expect(attachments[0].created?.getFullYear()).toBe(2026);
+            expect(attachments[0].modified?.getHours()).toBe(11);
+        });
+        it("returns empty array when note has no attachments", () => {
+            mockExecuteAppleScript.mockReturnValueOnce({ success: true, output: "" });
+            const attachments = manager.listAttachmentsById("x-coredata://ABC/ICNote/p123");
+            expect(attachments).toEqual([]);
+        });
+        it("returns empty array on error", () => {
+            mockExecuteAppleScript.mockReturnValueOnce({
+                success: false,
+                output: "",
+                error: "Note not found",
+            });
+            const attachments = manager.listAttachmentsById("x-coredata://ABC/ICNote/p999");
+            expect(attachments).toEqual([]);
+        });
+        it("generates correct AppleScript for ID lookup", () => {
+            mockExecuteAppleScript.mockReturnValueOnce({ success: true, output: "" });
+            manager.listAttachmentsById("x-coredata://ABC/ICNote/p123");
+            expect(mockExecuteAppleScript).toHaveBeenCalledWith(expect.stringContaining('note id "x-coredata://ABC/ICNote/p123"'));
+        });
+    });
+    describe("listAttachments", () => {
+        it("returns attachments for a note by title", () => {
+            mockExecuteAppleScript.mockReturnValueOnce({
+                success: true,
+                output: ["attach-id", "image.png", "public.png"].join(F),
+            });
+            const attachments = manager.listAttachments("My Note");
+            expect(attachments).toHaveLength(1);
+            expect(attachments[0]).toMatchObject({
+                id: "attach-id",
+                name: "image.png",
+                contentType: "public.png",
+                contentId: "public.png",
+            });
+        });
+        it("uses specified account", () => {
+            mockExecuteAppleScript.mockReturnValueOnce({ success: true, output: "" });
+            manager.listAttachments("My Note", "Gmail");
+            expect(mockExecuteAppleScript).toHaveBeenCalledWith(expect.stringContaining('account "Gmail"'));
+        });
+        it("defaults to iCloud account", () => {
+            mockExecuteAppleScript.mockReturnValueOnce({ success: true, output: "" });
+            manager.listAttachments("My Note");
+            expect(mockExecuteAppleScript).toHaveBeenCalledWith(expect.stringContaining('account "iCloud"'));
+        });
+        it("returns empty array when note has no attachments", () => {
+            mockExecuteAppleScript.mockReturnValueOnce({ success: true, output: "" });
+            const attachments = manager.listAttachments("Empty Note");
+            expect(attachments).toEqual([]);
+        });
+    });
+    // ---------------------------------------------------------------------------
+    // Batch Operations
+    // ---------------------------------------------------------------------------
+    describe("batchDeleteNotes", () => {
+        const ID1 = "x-coredata://ABC00000-0000-0000-0000-000000000011/ICNote/p1";
+        const ID2 = "x-coredata://ABC00000-0000-0000-0000-000000000012/ICNote/p2";
+        it("deletes the whole batch in a single osascript spawn (#26)", () => {
+            // One script handles all ids; per-id status tokens joined by RECORD_SEP.
+            mockExecuteAppleScript.mockReturnValueOnce({
+                success: true,
+                output: ["ok", "ok"].join(R) + R,
+            });
+            const results = manager.batchDeleteNotes([ID1, ID2]);
+            // Exactly one spawn for N notes, not 3N.
+            expect(mockExecuteAppleScript).toHaveBeenCalledTimes(1);
+            expect(results).toHaveLength(2);
+            expect(results[0]).toEqual({ id: ID1, success: true });
+            expect(results[1]).toEqual({ id: ID2, success: true });
+        });
+        it("returns error for non-existent note", () => {
+            mockExecuteAppleScript.mockReturnValueOnce({ success: true, output: "missing" + R });
+            const results = manager.batchDeleteNotes([
+                "x-coredata://ABC00000-0000-0000-0000-000000000099/ICNote/p404",
+            ]);
+            expect(results[0]).toEqual({
+                id: "x-coredata://ABC00000-0000-0000-0000-000000000099/ICNote/p404",
+                success: false,
+                error: "Note not found",
+            });
+        });
+        it("returns error for password-protected note", () => {
+            mockExecuteAppleScript.mockReturnValueOnce({ success: true, output: "pw" + R });
+            const results = manager.batchDeleteNotes([ID1]);
+            expect(results[0]).toEqual({ id: ID1, success: false, error: "Note is password-protected" });
+        });
+        it("handles mixed success and failure, preserving order", () => {
+            mockExecuteAppleScript.mockReturnValueOnce({
+                success: true,
+                output: ["ok", "missing"].join(R) + R,
+            });
+            const results = manager.batchDeleteNotes([ID1, ID2]);
+            expect(results[0]).toEqual({ id: ID1, success: true });
+            expect(results[1]).toEqual({ id: ID2, success: false, error: "Note not found" });
+        });
+        it("fails an invalid id without spawning, isolating it from valid ids", () => {
+            mockExecuteAppleScript.mockReturnValueOnce({ success: true, output: "ok" + R });
+            const results = manager.batchDeleteNotes(["not-a-valid-id", ID1]);
+            expect(results[0].success).toBe(false);
+            expect(results[0].error).toMatch(/Invalid note ID/);
+            expect(results[1]).toEqual({ id: ID1, success: true });
+        });
+        it("fails the whole batch when the single script errors", () => {
+            mockExecuteAppleScript.mockReturnValueOnce({
+                success: false,
+                output: "",
+                error: "Notes.app not responding",
+            });
+            const results = manager.batchDeleteNotes([ID1, ID2]);
+            expect(results.every((r) => r.success === false)).toBe(true);
+            expect(results[0].error).toContain("Notes.app not responding");
+        });
+        it("returns [] for an empty batch without spawning", () => {
+            const results = manager.batchDeleteNotes([]);
+            expect(results).toEqual([]);
+            expect(mockExecuteAppleScript).not.toHaveBeenCalled();
+        });
+    });
+    describe("batchMoveNotes", () => {
+        const ID1 = "x-coredata://ABC00000-0000-0000-0000-000000000011/ICNote/p1";
+        const ID2 = "x-coredata://ABC00000-0000-0000-0000-000000000012/ICNote/p2";
+        it("moves the whole batch in a single osascript spawn (#26)", () => {
+            mockExecuteAppleScript.mockReturnValueOnce({
+                success: true,
+                output: ["ok", "ok"].join(R) + R,
+            });
+            const results = manager.batchMoveNotes([ID1, ID2], "Archive");
+            expect(mockExecuteAppleScript).toHaveBeenCalledTimes(1);
+            expect(results).toHaveLength(2);
+            expect(results[0]).toEqual({ id: ID1, success: true });
+            expect(results[1]).toEqual({ id: ID2, success: true });
+        });
+        it("returns error for non-existent note", () => {
+            mockExecuteAppleScript.mockReturnValueOnce({ success: true, output: "missing" + R });
+            const results = manager.batchMoveNotes(["x-coredata://ABC00000-0000-0000-0000-000000000099/ICNote/p404"], "Archive");
+            expect(results[0]).toEqual({
+                id: "x-coredata://ABC00000-0000-0000-0000-000000000099/ICNote/p404",
+                success: false,
+                error: "Note not found",
+            });
+        });
+        it("returns error for password-protected note", () => {
+            mockExecuteAppleScript.mockReturnValueOnce({ success: true, output: "pw" + R });
+            const results = manager.batchMoveNotes([ID1], "Archive");
+            expect(results[0]).toEqual({ id: ID1, success: false, error: "Note is password-protected" });
+        });
+        it("maps a per-item move failure to 'Move failed'", () => {
+            mockExecuteAppleScript.mockReturnValueOnce({
+                success: true,
+                output: ["ok", "fail"].join(R) + R,
+            });
+            const results = manager.batchMoveNotes([ID1, ID2], "Archive");
+            expect(results[0]).toEqual({ id: ID1, success: true });
+            expect(results[1]).toEqual({ id: ID2, success: false, error: "Move failed" });
+        });
+    });
+    // ---------------------------------------------------------------------------
+    // Export Operations
+    // ---------------------------------------------------------------------------
+    describe("exportNotesAsJson", () => {
+        // Note details output helper - format: title, id, date, date, shared, passwordProtected
+        const noteDetailsOutput = (title, passwordProtected = false) => [
+            title,
+            "x-coredata://ABC/ICNote/p1",
+            "Sunday, January 1, 2025 at 1:00:00 PM",
+            "Sunday, January 1, 2025 at 1:00:00 PM",
+            "false",
+            String(passwordProtected),
+        ].join(F);
+        it("exports notes with metadata and content", () => {
+            mockExecuteAppleScript
+                // listAccounts
+                .mockReturnValueOnce({ success: true, output: "iCloud" })
+                // listFolders for iCloud
+                .mockReturnValueOnce({ success: true, output: "id1\tNotes" })
+                // listNotes for Notes folder
+                .mockReturnValueOnce({
+                success: true,
+                output: ["Test Note", "x-coredata://ABC/ICNote/p1"].join(F),
+            })
+                // getNoteDetails
+                .mockReturnValueOnce({ success: true, output: noteDetailsOutput("Test Note", false) })
+                // getNoteContent
+                .mockReturnValueOnce({
+                success: true,
+                output: "<div>Test Note</div><div>Content here</div>",
+            });
+            const result = manager.exportNotesAsJson();
+            expect(result.version).toBe("1.0");
+            expect(result.exportDate).toBeDefined();
+            expect(result.summary.totalNotes).toBe(1);
+            expect(result.summary.totalFolders).toBe(1);
+            expect(result.summary.totalAccounts).toBe(1);
+            expect(result.accounts[0].name).toBe("iCloud");
+            expect(result.accounts[0].folders[0].name).toBe("Notes");
+            expect(result.accounts[0].folders[0].notes).toHaveLength(1);
+        });
+        it("skips content for password-protected notes", () => {
+            mockExecuteAppleScript
+                // listAccounts
+                .mockReturnValueOnce({ success: true, output: "iCloud" })
+                // listFolders for iCloud
+                .mockReturnValueOnce({ success: true, output: "id1\tNotes" })
+                // listNotes for Notes folder
+                .mockReturnValueOnce({
+                success: true,
+                output: ["Locked Note", "x-coredata://ABC/ICNote/p1"].join(F),
+            })
+                // getNoteDetails (passwordProtected = true)
+                .mockReturnValueOnce({ success: true, output: noteDetailsOutput("Locked Note", true) });
+            // No getNoteContent call because note is password-protected
+            const result = manager.exportNotesAsJson();
+            const note = result.accounts[0].folders[0].notes[0];
+            expect(note.passwordProtected).toBe(true);
+            expect(note.content).toBe("");
+        });
+        it("handles empty accounts", () => {
+            mockExecuteAppleScript
+                // listAccounts
+                .mockReturnValueOnce({ success: true, output: "iCloud" })
+                // listFolders for iCloud
+                .mockReturnValueOnce({ success: true, output: "id1\tNotes" })
+                // listNotes returns empty
+                .mockReturnValueOnce({ success: true, output: "" });
+            const result = manager.exportNotesAsJson();
+            expect(result.summary.totalNotes).toBe(0);
+        });
+    });
+    // ---------------------------------------------------------------------------
+    // Markdown Conversion
+    // ---------------------------------------------------------------------------
+    describe("getNoteMarkdown", () => {
+        it("converts HTML to Markdown", () => {
+            mockExecuteAppleScript.mockReturnValueOnce({
+                success: true,
+                output: "<div>My Title</div><div>This is a paragraph.</div><div><b>Bold text</b></div>",
+            });
+            const markdown = manager.getNoteMarkdown("My Note");
+            expect(markdown).toContain("My Title");
+            expect(markdown).toContain("This is a paragraph.");
+            expect(markdown).toContain("**Bold text**");
+        });
+        it("returns empty string when note not found", () => {
+            mockExecuteAppleScript.mockReturnValueOnce({
+                success: false,
+                output: "",
+                error: "Note not found",
+            });
+            const markdown = manager.getNoteMarkdown("Missing Note");
+            expect(markdown).toBe("");
+        });
+        it("handles lists correctly", () => {
+            mockExecuteAppleScript.mockReturnValueOnce({
+                success: true,
+                output: "<ul><li>Item 1</li><li>Item 2</li></ul>",
+            });
+            const markdown = manager.getNoteMarkdown("List Note");
+            // Turndown may add extra whitespace after the bullet
+            expect(markdown).toMatch(/-\s+Item 1/);
+            expect(markdown).toMatch(/-\s+Item 2/);
+        });
+    });
+    describe("getNoteMarkdownById", () => {
+        it("converts HTML to Markdown using ID", () => {
+            mockExecuteAppleScript.mockReturnValueOnce({
+                success: true,
+                output: "<div>Note Title</div><div>Content here</div>",
+            });
+            const markdown = manager.getNoteMarkdownById("x-coredata://ABC/ICNote/p123");
+            expect(markdown).toContain("Note Title");
+            expect(markdown).toContain("Content here");
+        });
+        it("returns empty string when note ID not found", () => {
+            mockExecuteAppleScript.mockReturnValueOnce({
+                success: false,
+                output: "",
+                error: "Note not found",
+            });
+            const markdown = manager.getNoteMarkdownById("x-coredata://00000000-0000-0000-0000-000000000000/ICNote/p999");
+            expect(markdown).toBe("");
+        });
+        it("enriches markdown with checklist state when available", () => {
+            mockExecuteAppleScript.mockReturnValueOnce({
+                success: true,
+                output: "<ul><li>Buy milk</li><li>Walk dog</li><li>Send email</li></ul>",
+            });
+            mockGetChecklistItems.mockReturnValueOnce({
+                items: [
+                    { text: "Buy milk", done: true },
+                    { text: "Walk dog", done: false },
+                    { text: "Send email", done: true },
+                ],
+            });
+            const markdown = manager.getNoteMarkdownById("x-coredata://ABC/ICNote/p123");
+            expect(markdown).toMatch(/-\s+\[x\] Buy milk/);
+            expect(markdown).toMatch(/-\s+\[ \] Walk dog/);
+            expect(markdown).toMatch(/-\s+\[x\] Send email/);
+        });
+        it("returns plain markdown when checklist state is unavailable", () => {
+            mockExecuteAppleScript.mockReturnValueOnce({
+                success: true,
+                output: "<ul><li>Item 1</li><li>Item 2</li></ul>",
+            });
+            mockGetChecklistItems.mockReturnValueOnce({
+                items: null,
+                error: "no_fda",
+                message: "Full Disk Access required",
+            });
+            const markdown = manager.getNoteMarkdownById("x-coredata://ABC/ICNote/p456");
+            expect(markdown).toMatch(/-\s+Item 1/);
+            expect(markdown).toMatch(/-\s+Item 2/);
+            expect(markdown).not.toContain("[x]");
+            expect(markdown).not.toContain("[ ]");
+        });
+    });
+    // ===========================================================================
+    // Security Tests
+    // ===========================================================================
+    describe("sanitizeId", () => {
+        it("accepts valid CoreData IDs", () => {
+            const id = "x-coredata://12345ABC-DEF0-1234-5678-9ABCDEF01234/ICNote/p100";
+            expect(sanitizeId(id)).toBe(id);
+        });
+        it("accepts temp IDs from generateFallbackId", () => {
+            expect(sanitizeId("temp-1704067200000-0")).toBe("temp-1704067200000-0");
+            expect(sanitizeId("temp-1704067200000-42")).toBe("temp-1704067200000-42");
+        });
+        it("rejects IDs with AppleScript injection", () => {
+            expect(() => sanitizeId('x-coredata://test" & do shell script "rm -rf ~" & "')).toThrow("Invalid note ID format");
+        });
+        it("rejects IDs with double-quote breakout", () => {
+            expect(() => sanitizeId('x-coredata://test"; delete note id "dummy" & "')).toThrow("Invalid note ID format");
+        });
+        it("rejects arbitrary strings", () => {
+            expect(() => sanitizeId("not-a-valid-id")).toThrow("Invalid note ID format");
+        });
+        it("rejects empty string", () => {
+            expect(() => sanitizeId("")).toThrow("Invalid note ID format");
+        });
+        it("accepts various ICEntity types", () => {
+            expect(sanitizeId("x-coredata://ABC123/ICFolder/p50")).toBe("x-coredata://ABC123/ICFolder/p50");
+            expect(sanitizeId("x-coredata://ABC123/ICAttachment/p1")).toBe("x-coredata://ABC123/ICAttachment/p1");
+        });
+    });
+    describe("escapeForAppleScript - injection prevention", () => {
+        it("escapes double quotes to prevent AppleScript string breakout", () => {
+            const malicious = 'Hello "World" end tell';
+            const escaped = escapeForAppleScript(malicious);
+            expect(escaped).toContain('\\"');
+            expect(escaped).not.toContain('"World"');
+        });
+        it("escapes backslashes to prevent escape sequence injection", () => {
+            const malicious = "path\\to\\file";
+            const escaped = escapeForAppleScript(malicious);
+            // Backslashes should be encoded as HTML entities (&#92;)
+            expect(escaped).toContain("&#92;");
+        });
+        it("handles combined injection payload", () => {
+            const payload = '" & do shell script "echo pwned" & "';
+            const escaped = escapeForAppleScript(payload);
+            // All double quotes must be escaped with backslash
+            // Count unescaped double quotes — there should be none
+            const unescapedQuotes = escaped.replace(/\\"/g, "").match(/"/g);
+            expect(unescapedQuotes).toBeNull();
+        });
+    });
+    describe("buildFolderReference - input validation", () => {
+        it("rejects empty folder paths", () => {
+            expect(() => buildFolderReference("")).toThrow("Folder path is empty");
+        });
+        it("rejects paths that are only slashes", () => {
+            expect(() => buildFolderReference("///")).toThrow("Folder path is empty");
+        });
+        it("rejects excessively deep folder nesting", () => {
+            const deepPath = Array(25).fill("folder").join("/");
+            expect(() => buildFolderReference(deepPath)).toThrow("maximum nesting depth");
+        });
+        it("rejects excessively long folder paths", () => {
+            const longPath = "a".repeat(1001);
+            expect(() => buildFolderReference(longPath)).toThrow("maximum length");
+        });
+        it("escapes folder names with double quotes", () => {
+            const result = buildFolderReference('My "Special" Folder');
+            expect(result).toContain('\\"');
+            expect(result).not.toContain('"Special"');
+        });
+        it("handles folder names with emoji", () => {
+            const result = buildFolderReference("Food & Drink/\uD83C\uDF72 Recipes");
+            expect(result).toContain("folder");
+            expect(result).toContain("of");
+        });
+    });
+    describe("ID-based operations sanitize input", () => {
+        it("getNoteById rejects malformed IDs", () => {
+            expect(() => {
+                manager.getNoteById('malicious" & do shell script "echo pwned');
+            }).toThrow("Invalid note ID format");
+        });
+        it("deleteNoteById rejects malformed IDs", () => {
+            expect(() => {
+                manager.deleteNoteById('x-coredata://test"; delete note 1 & "');
+            }).toThrow("Invalid note ID format");
+        });
+        it("getNoteContentById rejects malformed IDs", () => {
+            expect(() => {
+                manager.getNoteContentById("arbitrary string");
+            }).toThrow("Invalid note ID format");
+        });
+        it("updateNoteById rejects malformed IDs", () => {
+            expect(() => {
+                manager.updateNoteById("not-valid", undefined, "content");
+            }).toThrow("Invalid note ID format");
+        });
+    });
+});
+describe("htmlToPlaintext (export helper)", () => {
+    // htmlToPlaintext is a private, pure string transform used by exportNote; it
+    // touches no AppleScript, so we exercise it directly through a cast.
+    const toPlaintext = (html) => new AppleNotesManager().htmlToPlaintext(html);
+    it("decodes the basic HTML entities", () => {
+        expect(toPlaintext("a &amp; b")).toBe("a & b");
+        expect(toPlaintext("&lt;tag&gt;")).toBe("<tag>");
+        expect(toPlaintext("say &quot;hi&quot;")).toBe('say "hi"');
+        expect(toPlaintext("path&#92;file")).toBe("path\\file");
+        expect(toPlaintext("a&nbsp;b")).toBe("a b");
+    });
+    it("decodes &amp; last so encoded entities round-trip (no double-unescape)", () => {
+        // The literal text "&lt;" is stored in HTML as "&amp;lt;" and must decode
+        // back to "&lt;", NOT be double-unescaped to "<".
+        expect(toPlaintext("&amp;lt;")).toBe("&lt;");
+        expect(toPlaintext("&amp;gt;")).toBe("&gt;");
+        expect(toPlaintext("&amp;amp;")).toBe("&amp;");
+        expect(toPlaintext("&amp;nbsp;")).toBe("&nbsp;");
+    });
+    it("converts block/line tags to newlines and strips other tags", () => {
+        expect(toPlaintext("one<br>two")).toBe("one\ntwo");
+        expect(toPlaintext("<div>a</div><div>b</div>")).toBe("a\nb");
+        expect(toPlaintext("<p>x</p><p>y</p>")).toBe("x\ny");
+        expect(toPlaintext("<b>bold</b>")).toBe("bold");
+    });
+    it("collapses 3+ newlines and trims surrounding whitespace", () => {
+        expect(toPlaintext("a<br><br><br><br>b")).toBe("a\n\nb");
+        expect(toPlaintext("  <div>x</div>  ")).toBe("x");
+    });
+    it("strips nested/overlapping tags without leaving a tag (iterated strip)", () => {
+        // A single pass can leave residue when removing one tag re-forms another;
+        // the loop keeps stripping until no <...> remains.
+        expect(toPlaintext("a<<i>>b")).not.toMatch(/<[^>]*>/);
+        expect(toPlaintext("<x<y>z>")).not.toMatch(/<[^>]*>/);
+        expect(toPlaintext("plain <b>text</b> here")).toBe("plain text here");
+    });
+});

--- a/build/services/attachmentSave.test.js
+++ b/build/services/attachmentSave.test.js
@@ -1,0 +1,85 @@
+/**
+ * Tests for save-attachment / fetch-attachment manager methods (#27).
+ * AppleScript is mocked; the filesystem side runs for real in a temp dir, with
+ * the mock writing the file the way Notes.app's `save` would.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { writeFileSync, mkdtempSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+vi.mock("@/utils/applescript.js", () => ({ executeAppleScript: vi.fn() }));
+vi.mock("@/utils/checklistParser.js", () => ({
+    getChecklistItems: vi.fn().mockReturnValue({ items: null }),
+}));
+import { AppleNotesManager } from "../services/appleNotesManager.js";
+import { executeAppleScript } from "../utils/applescript.js";
+const mockExec = vi.mocked(executeAppleScript);
+const F = "\x1f";
+let manager;
+const tmpDirs = [];
+beforeEach(() => {
+    vi.clearAllMocks();
+    manager = new AppleNotesManager();
+});
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+describe("saveAttachmentById (#27)", () => {
+    it("saves to an allowed path and returns metadata", () => {
+        const dir = mkdtempSync(join(tmpdir(), "anatt-"));
+        tmpDirs.push(dir);
+        const dest = join(dir, "photo.png");
+        mockExec.mockImplementation((script) => {
+            const m = script.match(/POSIX file "([^"]+)"/);
+            if (m)
+                writeFileSync(m[1], Buffer.from("PNGDATA"));
+            return { success: true, output: ["OK", "photo.png", "public.png"].join(F) };
+        });
+        const r = manager.saveAttachmentById("x-coredata://A/ICNote/p1", "att-1", dest);
+        expect(r.success).toBe(true);
+        expect(r.savedPath).toBe(dest);
+        expect(r.name).toBe("photo.png");
+        expect(r.contentType).toBe("public.png");
+    });
+    it("rejects an unsafe destination before running AppleScript", () => {
+        const r = manager.saveAttachmentById("x-coredata://A/ICNote/p1", "att-1", "/etc/evil.png");
+        expect(r.success).toBe(false);
+        expect(r.error).toMatch(/outside allowed/);
+        expect(mockExec).not.toHaveBeenCalled();
+    });
+    it("surfaces 'attachment not found' from AppleScript", () => {
+        const dest = join(tmpdir(), "nope.png");
+        mockExec.mockReturnValue({ success: true, output: ["ERR", "attachment not found"].join(F) });
+        const r = manager.saveAttachmentById("x-coredata://A/ICNote/p1", "missing", dest);
+        expect(r.success).toBe(false);
+        expect(r.error).toMatch(/not found/);
+    });
+    it("fails when Notes reports OK but no file was written", () => {
+        const dest = join(tmpdir(), "ghost-" + Date.now() + ".png");
+        mockExec.mockReturnValue({ success: true, output: ["OK", "x.png", "public.png"].join(F) });
+        const r = manager.saveAttachmentById("x-coredata://A/ICNote/p1", "att-1", dest);
+        expect(r.success).toBe(false);
+        expect(r.error).toMatch(/no file was written/);
+    });
+});
+describe("getAttachmentBase64ById (#27)", () => {
+    it("exports to a temp file and returns base64, cleaning up", () => {
+        mockExec.mockImplementation((script) => {
+            const m = script.match(/POSIX file "([^"]+)"/);
+            if (m)
+                writeFileSync(m[1], Buffer.from("hello-bytes"));
+            return { success: true, output: ["OK", "doc.pdf", "com.adobe.pdf"].join(F) };
+        });
+        const r = manager.getAttachmentBase64ById("x-coredata://A/ICNote/p1", "att-1");
+        expect(r.success).toBe(true);
+        expect(r.name).toBe("doc.pdf");
+        expect(r.bytes).toBe("hello-bytes".length);
+        expect(Buffer.from(r.base64 ?? "", "base64").toString()).toBe("hello-bytes");
+    });
+    it("returns the error when the save step fails", () => {
+        mockExec.mockReturnValue({ success: false, output: "", error: "Notes not running" });
+        const r = manager.getAttachmentBase64ById("x-coredata://A/ICNote/p1", "att-1");
+        expect(r.success).toBe(false);
+        expect(r.error).toMatch(/Notes not running/);
+    });
+});

--- a/build/services/fileConfig.js
+++ b/build/services/fileConfig.js
@@ -1,0 +1,51 @@
+/**
+ * File-based configuration loader (#24).
+ *
+ * Some host apps (e.g. Claude Desktop) spawn the MCP server with a scrubbed
+ * environment and ignore the `env` block in their server config, so there's no
+ * way to pass `APPLE_NOTES_MCP_*` settings in. This loads them from a JSON file
+ * the host doesn't manage, merging into `process.env` WITHOUT overriding
+ * anything already set (so an explicit env still wins).
+ *
+ * Only non-secret config belongs here (e.g. APPLE_NOTES_MCP_MAX_BUFFER, DEBUG).
+ *
+ * Path: `APPLE_NOTES_MCP_CONFIG_FILE`, else
+ * `~/Library/Application Support/apple-notes-mcp/config.json`.
+ *
+ * @module services/fileConfig
+ */
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+export function fileConfigPath(env = process.env) {
+    const override = env.APPLE_NOTES_MCP_CONFIG_FILE;
+    if (override && override.trim())
+        return override.trim();
+    return join(homedir(), "Library", "Application Support", "apple-notes-mcp", "config.json");
+}
+/**
+ * Merge a JSON config file's string values into `env` for keys not already set.
+ * Returns the keys applied. Tolerates a missing/corrupt file.
+ */
+export function loadFileConfig(env = process.env, path = fileConfigPath(env)) {
+    const applied = [];
+    try {
+        if (!existsSync(path))
+            return applied;
+        const parsed = JSON.parse(readFileSync(path, "utf8"));
+        if (!parsed || typeof parsed !== "object")
+            return applied;
+        for (const [k, v] of Object.entries(parsed)) {
+            if (typeof v !== "string")
+                continue;
+            if (env[k] === undefined || env[k] === "") {
+                env[k] = v;
+                applied.push(k);
+            }
+        }
+    }
+    catch (e) {
+        console.error(`Failed to load apple-notes-mcp config file ${path}: ${String(e)}`);
+    }
+    return applied;
+}

--- a/build/services/fileConfig.test.js
+++ b/build/services/fileConfig.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { loadFileConfig, fileConfigPath } from "../services/fileConfig.js";
+let dir;
+let file;
+beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "anmcp-cfg-"));
+    file = join(dir, "config.json");
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+describe("loadFileConfig (#24)", () => {
+    it("applies file values for keys not already in env", () => {
+        writeFileSync(file, JSON.stringify({ APPLE_NOTES_MCP_MAX_BUFFER: "1048576", DEBUG: "1" }));
+        const env = {};
+        const applied = loadFileConfig(env, file);
+        expect(env.APPLE_NOTES_MCP_MAX_BUFFER).toBe("1048576");
+        expect(env.DEBUG).toBe("1");
+        expect(applied.sort()).toEqual(["APPLE_NOTES_MCP_MAX_BUFFER", "DEBUG"]);
+    });
+    it("never overrides a value already set in the environment", () => {
+        writeFileSync(file, JSON.stringify({ APPLE_NOTES_MCP_MAX_BUFFER: "1" }));
+        const env = { APPLE_NOTES_MCP_MAX_BUFFER: "999" };
+        loadFileConfig(env, file);
+        expect(env.APPLE_NOTES_MCP_MAX_BUFFER).toBe("999");
+    });
+    it("treats empty-string env as unset and fills it", () => {
+        writeFileSync(file, JSON.stringify({ DEBUG: "1" }));
+        const env = { DEBUG: "" };
+        loadFileConfig(env, file);
+        expect(env.DEBUG).toBe("1");
+    });
+    it("ignores non-string values", () => {
+        writeFileSync(file, JSON.stringify({ A: "ok", B: 5, C: true }));
+        const env = {};
+        expect(loadFileConfig(env, file)).toEqual(["A"]);
+    });
+    it("tolerates a missing file and a corrupt file", () => {
+        expect(loadFileConfig({}, join(dir, "nope.json"))).toEqual([]);
+        writeFileSync(file, "{ not json");
+        expect(loadFileConfig({}, file)).toEqual([]);
+    });
+    it("defaults the path to the app-support dir, honoring the override", () => {
+        expect(fileConfigPath({})).toMatch(/apple-notes-mcp\/config\.json$/);
+        expect(fileConfigPath({ APPLE_NOTES_MCP_CONFIG_FILE: "/tmp/x.json" })).toBe("/tmp/x.json");
+    });
+});

--- a/build/services/notesHtmlMarkdown.test.js
+++ b/build/services/notesHtmlMarkdown.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NOTES_NORMALIZED_HTML_FIXTURES } from "../services/__fixtures__/notesNormalizedHtml.js";
+// Mock the same seams the main manager test does: AppleScript execution and the
+// SQLite-backed checklist reader (no Full Disk Access in unit tests).
+vi.mock("@/utils/applescript.js", () => ({
+    executeAppleScript: vi.fn(),
+}));
+vi.mock("@/utils/checklistParser.js", () => ({
+    getChecklistItems: vi.fn().mockReturnValue({ items: null }),
+}));
+import { executeAppleScript } from "../utils/applescript.js";
+import { AppleNotesManager } from "../services/appleNotesManager.js";
+const mockExecuteAppleScript = vi.mocked(executeAppleScript);
+const NOTE_ID = "x-coredata://ABC/ICNote/p1";
+/**
+ * Regression coverage for Notes-normalized HTML -> Markdown conversion.
+ *
+ * The fixtures encode the HTML shape Apple Notes returns and the Markdown the
+ * server currently emits. Routing through getNoteMarkdownById exercises the real
+ * Turndown pipeline (including the notesDivs rule) with AppleScript mocked to
+ * return the fixture body.
+ */
+describe("Notes-normalized HTML to Markdown", () => {
+    let manager;
+    beforeEach(() => {
+        vi.clearAllMocks();
+        manager = new AppleNotesManager();
+    });
+    for (const fixture of NOTES_NORMALIZED_HTML_FIXTURES) {
+        it(`converts ${fixture.name} (${fixture.description})`, () => {
+            mockExecuteAppleScript.mockReturnValue({ success: true, output: fixture.html });
+            const markdown = manager.getNoteMarkdownById(NOTE_ID);
+            expect(markdown).toBe(fixture.expectedMarkdown);
+        });
+    }
+    it("documents that a <div><br></div> spacer leaves a two-space line", () => {
+        mockExecuteAppleScript.mockReturnValue({
+            success: true,
+            output: "<div>A</div><div><br></div><div>B</div>",
+        });
+        const markdown = manager.getNoteMarkdownById(NOTE_ID);
+        // The spacer survives as a stray "  " line — the Markdown-side fingerprint of
+        // the whitespace-accumulation behavior CLAUDE.md warns about.
+        expect(markdown).toBe("A\n  \n\nB");
+    });
+    it("documents that <tt> is dropped, keeping only its text", () => {
+        mockExecuteAppleScript.mockReturnValue({
+            success: true,
+            output: "<div>Run <tt>npm install</tt> first.</div>",
+        });
+        const markdown = manager.getNoteMarkdownById(NOTE_ID);
+        expect(markdown).toBe("Run npm install first.");
+        expect(markdown).not.toContain("`");
+    });
+});

--- a/build/tools/doctor.js
+++ b/build/tools/doctor.js
@@ -1,0 +1,50 @@
+import { hasFullDiskAccess } from "../utils/checklistParser.js";
+export function runDoctor(manager) {
+    const checks = [];
+    // 1. Notes.app reachability + Automation permission (existing health checks).
+    const hc = manager.healthCheck();
+    for (const c of hc.checks) {
+        checks.push({
+            name: `Notes.app: ${c.name}`,
+            status: c.passed ? "ok" : "fail",
+            detail: c.message,
+        });
+    }
+    // 2. Accounts.
+    try {
+        const accounts = manager.listAccounts();
+        checks.push({
+            name: "Accounts",
+            status: accounts.length > 0 ? "ok" : "warn",
+            detail: accounts.length > 0
+                ? `${accounts.length} account(s): ${accounts.map((a) => a.name).join(", ")}`
+                : "no Notes accounts found",
+        });
+    }
+    catch (e) {
+        checks.push({
+            name: "Accounts",
+            status: "fail",
+            detail: `could not list accounts: ${String(e)}`,
+        });
+    }
+    // 3. Full Disk Access — required for checklist state + checklist annotations.
+    const fda = hasFullDiskAccess();
+    checks.push({
+        name: "Full Disk Access",
+        status: fda ? "ok" : "warn",
+        detail: fda
+            ? "granted — checklist features available"
+            : "not granted — get-checklist-state and checklist annotations in get-note-markdown won't work. Grant in System Settings > Privacy & Security > Full Disk Access.",
+    });
+    const healthy = !checks.some((c) => c.status === "fail");
+    return { healthy, checks };
+}
+/** Render a DoctorReport as readable text. */
+export function formatDoctorReport(r) {
+    const icon = (s) => (s === "ok" ? "✅" : s === "warn" ? "⚠️ " : "❌");
+    const lines = [`🩺 apple-notes-mcp doctor — ${r.healthy ? "healthy" : "ISSUES FOUND"}`, ""];
+    for (const c of r.checks)
+        lines.push(`${icon(c.status)} ${c.name}: ${c.detail}`);
+    return lines.join("\n");
+}

--- a/build/tools/doctor.test.js
+++ b/build/tools/doctor.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from "vitest";
+vi.mock("@/utils/checklistParser.js", () => ({ hasFullDiskAccess: vi.fn(() => true) }));
+import { runDoctor, formatDoctorReport } from "../tools/doctor.js";
+import { hasFullDiskAccess } from "../utils/checklistParser.js";
+function fakeMgr(over = {}) {
+    return {
+        healthCheck: () => ({
+            healthy: true,
+            checks: [{ name: "reachable", passed: true, message: "Notes.app responded" }],
+        }),
+        listAccounts: () => [{ name: "iCloud" }, { name: "Gmail" }],
+        ...over,
+    };
+}
+describe("runDoctor (#22)", () => {
+    it("reports accounts + Full Disk Access and stays healthy on warnings", () => {
+        const r = runDoctor(fakeMgr());
+        expect(r.healthy).toBe(true);
+        expect(r.checks.find((c) => c.name === "Accounts")?.status).toBe("ok");
+        expect(r.checks.find((c) => c.name === "Accounts")?.detail).toMatch(/iCloud, Gmail/);
+        expect(r.checks.find((c) => c.name === "Full Disk Access")?.status).toBe("ok");
+    });
+    it("warns (not fails) when Full Disk Access is not granted", () => {
+        vi.mocked(hasFullDiskAccess).mockReturnValueOnce(false);
+        const r = runDoctor(fakeMgr());
+        const fda = r.checks.find((c) => c.name === "Full Disk Access");
+        expect(fda?.status).toBe("warn");
+        expect(fda?.detail).toMatch(/Full Disk Access/);
+        expect(r.healthy).toBe(true);
+    });
+    it("is unhealthy when a Notes.app check fails", () => {
+        const r = runDoctor(fakeMgr({
+            healthCheck: () => ({
+                healthy: false,
+                checks: [{ name: "permission", passed: false, message: "not authorized" }],
+            }),
+        }));
+        expect(r.healthy).toBe(false);
+        expect(formatDoctorReport(r)).toMatch(/ISSUES FOUND/);
+        expect(formatDoctorReport(r)).toMatch(/❌ Notes\.app: permission/);
+    });
+});

--- a/build/tools/resourcesAndPrompts.js
+++ b/build/tools/resourcesAndPrompts.js
@@ -1,0 +1,70 @@
+/**
+ * MCP resources & prompts for apple-notes (#23).
+ *
+ * Resources expose read-only views agents can attach as context without a tool
+ * round-trip (accounts, folders, stats, and a note-by-id template). Prompts are
+ * reusable starting points for common Notes workflows.
+ *
+ * @module tools/resourcesAndPrompts
+ */
+import { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+const json = (uri, data) => ({
+    contents: [{ uri: uri.href, mimeType: "application/json", text: JSON.stringify(data, null, 2) }],
+});
+export function registerResourcesAndPrompts(server, manager) {
+    // --- Resources ---
+    server.resource("accounts", "notes://accounts", (uri) => json(uri, { accounts: manager.listAccounts() }));
+    server.resource("folders", "notes://folders", (uri) => {
+        const data = manager
+            .listAccounts()
+            .map((a) => ({ account: a.name, folders: manager.listFolders(a.name) }));
+        return json(uri, { accounts: data });
+    });
+    server.resource("stats", "notes://stats", (uri) => json(uri, manager.getNotesStats()));
+    server.resource("note", new ResourceTemplate("notes://note/{id}", { list: undefined }), (uri, variables) => {
+        const id = decodeURIComponent(String(variables.id));
+        const markdown = manager.getNoteMarkdownById(id);
+        return {
+            contents: [{ uri: uri.href, mimeType: "text/markdown", text: markdown || "(not found)" }],
+        };
+    });
+    // --- Prompts ---
+    server.prompt("find-note", "Search Apple Notes for a topic and summarize the best match", { topic: z.string().describe("What to search for") }, ({ topic }) => ({
+        messages: [
+            {
+                role: "user",
+                content: {
+                    type: "text",
+                    text: `Search my Apple Notes for "${topic}" with the search-notes tool (set searchContent: true). Open the most relevant result with get-note-content and give me a concise summary plus its note id.`,
+                },
+            },
+        ],
+    }));
+    server.prompt("weekly-review", "Review notes changed recently and surface follow-ups", () => ({
+        messages: [
+            {
+                role: "user",
+                content: {
+                    type: "text",
+                    text: "Use get-notes-stats to see how many notes changed in the last 7 days, then search-notes (searchContent: true, modifiedSince: the date 7 days ago) to list them. Summarize the themes and call out any open action items or checklists I should follow up on.",
+                },
+            },
+        ],
+    }));
+    server.prompt("new-meeting-note", "Draft and create a structured meeting note", {
+        subject: z.string().describe("Meeting subject"),
+        attendees: z.string().optional().describe("Comma-separated attendees"),
+        folder: z.string().optional().describe("Target folder"),
+    }, ({ subject, attendees, folder }) => ({
+        messages: [
+            {
+                role: "user",
+                content: {
+                    type: "text",
+                    text: `Create an Apple Note titled "${subject}" ${folder ? `in folder "${folder}" ` : ""}using create-note (format: html). Include sections for Attendees${attendees ? ` (${attendees})` : ""}, Agenda, Discussion, and Action Items. Render Action Items as a plain bulleted list and remind me I can convert it to a checklist in Notes with ⇧⌘L.`,
+                },
+            },
+        ],
+    }));
+}

--- a/build/tools/resourcesAndPrompts.test.js
+++ b/build/tools/resourcesAndPrompts.test.js
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from "vitest";
+import { registerResourcesAndPrompts } from "../tools/resourcesAndPrompts.js";
+class FakeServer {
+    resources = new Map();
+    prompts = new Map();
+    resource(name, uriOrTemplate, cb) {
+        this.resources.set(name, { uriOrTemplate, cb });
+    }
+    prompt(name, ...rest) {
+        this.prompts.set(name, rest[rest.length - 1]);
+    }
+}
+function fakeMgr() {
+    return {
+        listAccounts: () => [{ name: "iCloud" }],
+        listFolders: vi.fn(() => [{ name: "Notes" }]),
+        getNotesStats: () => ({
+            totalNotes: 1,
+            accounts: [],
+            recentlyModified: { last24h: 0, last7d: 0, last30d: 0 },
+        }),
+        getNoteMarkdownById: vi.fn(() => "# Hello"),
+    };
+}
+describe("registerResourcesAndPrompts (#23)", () => {
+    it("registers the expected resources and prompts", () => {
+        const s = new FakeServer();
+        registerResourcesAndPrompts(s, fakeMgr());
+        expect([...s.resources.keys()].sort()).toEqual(["accounts", "folders", "note", "stats"]);
+        expect([...s.prompts.keys()].sort()).toEqual([
+            "find-note",
+            "new-meeting-note",
+            "weekly-review",
+        ]);
+    });
+    it("accounts/folders/stats resources return JSON", () => {
+        const s = new FakeServer();
+        registerResourcesAndPrompts(s, fakeMgr());
+        const acc = s.resources.get("accounts").cb(new URL("notes://accounts"), {});
+        expect(JSON.parse(acc.contents[0].text)).toEqual({ accounts: [{ name: "iCloud" }] });
+        const fol = s.resources.get("folders").cb(new URL("notes://folders"), {});
+        expect(JSON.parse(fol.contents[0].text).accounts[0].account).toBe("iCloud");
+        const st = s.resources.get("stats").cb(new URL("notes://stats"), {});
+        expect(JSON.parse(st.contents[0].text).totalNotes).toBe(1);
+    });
+    it("note template resolves the id and returns markdown", () => {
+        const s = new FakeServer();
+        const mgr = fakeMgr();
+        registerResourcesAndPrompts(s, mgr);
+        const out = s.resources.get("note").cb(new URL("notes://note/abc%20def"), { id: "abc%20def" });
+        expect(mgr.getNoteMarkdownById).toHaveBeenCalledWith("abc def");
+        expect(out.contents[0].text).toBe("# Hello");
+    });
+    it("prompts produce user messages including their args", () => {
+        const s = new FakeServer();
+        registerResourcesAndPrompts(s, fakeMgr());
+        expect(s.prompts.get("find-note")({ topic: "taxes" }).messages[0].content.text).toMatch(/taxes/);
+        expect(s.prompts.get("weekly-review")({}).messages[0].content.text).toMatch(/last 7 days/);
+        const mtg = s.prompts.get("new-meeting-note")({ subject: "Q3 Plan", attendees: "Rob, Sam" });
+        expect(mtg.messages[0].content.text).toMatch(/Q3 Plan/);
+        expect(mtg.messages[0].content.text).toMatch(/Rob, Sam/);
+    });
+});

--- a/build/types.js
+++ b/build/types.js
@@ -1,0 +1,13 @@
+/**
+ * Type Definitions for Apple Notes MCP Server
+ *
+ * This module contains all TypeScript interfaces and types used throughout
+ * the Apple Notes MCP server. These types model:
+ *
+ * - Apple Notes data structures (notes, folders, accounts)
+ * - AppleScript execution results
+ * - MCP tool parameters
+ *
+ * @module types
+ */
+export {};

--- a/build/utils/applescript.js
+++ b/build/utils/applescript.js
@@ -1,0 +1,421 @@
+/**
+ * AppleScript Execution Utilities
+ *
+ * This module provides a safe interface for executing AppleScript commands
+ * on macOS. It handles script execution, error capture, and result parsing.
+ *
+ * @module utils/applescript
+ */
+import { execSync, spawnSync } from "child_process";
+/**
+ * Default execution timeout for AppleScript commands in milliseconds.
+ * 30 seconds is sufficient for most operations, including complex
+ * searches on large note collections. Can be overridden per-call.
+ */
+const DEFAULT_TIMEOUT_MS = 30000;
+/**
+ * Output cap for osascript. Node's execSync defaults to 1 MB, which a large
+ * Notes library (export-notes-json, full-library stat scans, long-note content)
+ * can blow past — execSync then throws ENOBUFS and the failure surfaces as an
+ * empty result. 64 MB headroom, overridable via APPLE_NOTES_MCP_MAX_BUFFER. (#16)
+ */
+const DEFAULT_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
+function getMaxBuffer() {
+    const raw = process.env.APPLE_NOTES_MCP_MAX_BUFFER;
+    if (raw !== undefined) {
+        const n = Number(raw);
+        if (Number.isFinite(n) && n > 0)
+            return n;
+    }
+    return DEFAULT_MAX_BUFFER_BYTES;
+}
+/**
+ * Headroom (ms) between the in-AppleScript `with timeout` and the outer
+ * osascript process timeout. The script-level timeout must fire first so
+ * Notes.app aborts from inside its own AppleScript dispatch — releasing the
+ * event queue — before Node SIGKILLs osascript. Killing osascript alone does
+ * not stop work already dispatched into Notes.app, which is what wedges it for
+ * subsequent calls. (#17)
+ */
+const SCRIPT_TIMEOUT_HEADROOM_MS = 5000;
+/**
+ * Wrap a script body in an AppleScript `with timeout` block so an Apple Event
+ * that honors timeouts aborts cleanly rather than holding Notes.app's
+ * single-threaded dispatch open. Set below the process timeout so the in-app
+ * abort wins the race against the outer SIGKILL. (#17)
+ */
+function wrapWithTimeout(script, processTimeoutMs) {
+    const seconds = Math.max(1, Math.ceil((processTimeoutMs - SCRIPT_TIMEOUT_HEADROOM_MS) / 1000));
+    return `with timeout of ${seconds} seconds\n${script}\nend timeout`;
+}
+/**
+ * Default retry configuration.
+ * - 1 attempt means no retries (default behavior)
+ * - Use maxRetries: 3 for exponential backoff with 1s/2s delays
+ */
+const DEFAULT_MAX_RETRIES = 1;
+const DEFAULT_RETRY_DELAY_MS = 1000;
+/**
+ * Check if debug/verbose logging is enabled.
+ * Set DEBUG=1 or DEBUG=true or VERBOSE=1 to enable.
+ */
+const isDebugEnabled = () => {
+    const debug = process.env.DEBUG;
+    const verbose = process.env.VERBOSE;
+    return debug === "1" || debug === "true" || verbose === "1" || verbose === "true";
+};
+/**
+ * Log a debug message if debug mode is enabled.
+ *
+ * @param message - The message to log
+ * @param data - Optional additional data to log
+ */
+function debugLog(message, data) {
+    if (!isDebugEnabled())
+        return;
+    const timestamp = new Date().toISOString();
+    if (data !== undefined) {
+        console.error(`[DEBUG ${timestamp}] ${message}`, data);
+    }
+    else {
+        console.error(`[DEBUG ${timestamp}] ${message}`);
+    }
+}
+/**
+ * Escapes a string for safe inclusion in a shell command.
+ *
+ * When passing AppleScript to osascript via shell, we need to handle
+ * the interaction between shell quoting and AppleScript string literals.
+ * This function escapes single quotes since we wrap the script in single quotes.
+ *
+ * @param script - The raw AppleScript code
+ * @returns Shell-safe version of the script
+ *
+ * @example
+ * // Input: tell app "Notes" to get note "Rob's Note"
+ * // Output: tell app "Notes" to get note "Rob'\''s Note"
+ */
+function escapeForShell(script) {
+    // Replace single quotes with: end quote, escaped quote, start quote
+    // This is the standard shell escaping pattern for single-quoted strings
+    return script.replace(/'/g, "'\\''");
+}
+/**
+ * Checks if an error is a timeout error from execSync.
+ *
+ * Node.js throws errors with specific properties when a child process
+ * is killed due to timeout.
+ *
+ * @param error - The caught error object
+ * @returns True if this was a timeout error
+ */
+function isTimeoutError(error) {
+    if (error instanceof Error) {
+        const execError = error;
+        // execSync kills the process with SIGTERM on timeout
+        return execError.killed === true || execError.signal === "SIGTERM";
+    }
+    return false;
+}
+/**
+ * Error patterns that indicate transient failures worth retrying.
+ * These typically occur when Notes.app is syncing or temporarily busy.
+ */
+const RETRYABLE_ERROR_PATTERNS = [
+    /timed? out/i,
+    /not responding/i,
+    /connection.*invalid/i,
+    /lost connection/i,
+    /busy/i,
+];
+/**
+ * Checks if an error message indicates a transient failure that should be retried.
+ *
+ * @param errorMessage - The error message to check
+ * @returns True if this error is worth retrying
+ */
+function isRetryableError(errorMessage) {
+    return RETRYABLE_ERROR_PATTERNS.some((pattern) => pattern.test(errorMessage));
+}
+/**
+ * Synchronous sleep using the system's sleep command.
+ * Used between retry attempts for exponential backoff.
+ *
+ * This is more efficient than a busy-wait loop as it doesn't
+ * consume CPU cycles during the delay.
+ *
+ * Uses spawnSync instead of execSync to avoid interference with
+ * execSync mocks in tests.
+ *
+ * @param ms - Milliseconds to sleep
+ */
+function sleep(ms) {
+    // Use system sleep command with fractional seconds support
+    // This avoids CPU-spinning busy wait while keeping the code synchronous
+    const seconds = ms / 1000;
+    const result = spawnSync("sleep", [seconds.toString()], { stdio: "ignore" });
+    if (result.error) {
+        // Fallback to busy-wait if sleep command fails (shouldn't happen on macOS)
+        const end = Date.now() + ms;
+        while (Date.now() < end) {
+            // Busy wait fallback
+        }
+    }
+}
+/**
+ * User-friendly error messages mapped from common AppleScript errors.
+ * Each entry maps a pattern (regex or string) to a user-friendly message.
+ */
+const ERROR_MAPPINGS = [
+    // Permission errors
+    {
+        pattern: /not authorized|not permitted|access.*denied/i,
+        message: "Permission denied. Grant automation access in System Preferences > Privacy & Security > Automation.",
+    },
+    // Application not running
+    {
+        pattern: /application isn't running|not running/i,
+        message: "Notes.app is not responding. Try opening Notes.app manually.",
+    },
+    // Connection errors
+    {
+        pattern: /connection is invalid|lost connection/i,
+        message: "Lost connection to Notes.app. The app may have crashed or been restarted.",
+    },
+    // Note not found (general)
+    {
+        pattern: /can't get note "([^"]+)"/i,
+        message: 'Note "$1" not found. Verify the title is exact (case-sensitive).',
+    },
+    // Note not found by ID
+    {
+        pattern: /can't get note id/i,
+        message: "Note not found. The note may have been deleted or the ID is invalid.",
+    },
+    // Folder not found
+    {
+        pattern: /can't get folder "([^"]+)"/i,
+        message: 'Folder "$1" not found. Use list-folders to see available folders.',
+    },
+    // Account not found
+    {
+        pattern: /can't get account "([^"]+)"/i,
+        message: 'Account "$1" not found. Use list-accounts to see available accounts.',
+    },
+    // Folder already exists
+    {
+        pattern: /folder.*already exists/i,
+        message: "A folder with that name already exists.",
+    },
+    // Cannot delete (various reasons)
+    {
+        pattern: /can't delete|cannot delete/i,
+        message: "Cannot delete. The item may be locked or in use.",
+    },
+    // Password protected notes
+    {
+        pattern: /password protected|locked note/i,
+        message: "Note is password-protected. Unlock it in Notes.app first.",
+    },
+    // Syntax/script errors (usually programming bugs)
+    {
+        pattern: /syntax error|expected/i,
+        message: "Internal error. Please report this issue.",
+    },
+];
+/**
+ * Parses error output from osascript to extract meaningful error messages.
+ *
+ * osascript errors typically include execution error numbers and descriptions.
+ * This function attempts to extract the human-readable portion and map it
+ * to a user-friendly message with helpful suggestions.
+ *
+ * @param errorOutput - Raw error string from execSync
+ * @returns User-friendly error message with suggested action
+ */
+function parseErrorMessage(errorOutput) {
+    // First, extract the core error message from AppleScript format
+    let coreError = errorOutput;
+    // Check for execution error format: "execution error: Message (-1234)"
+    const executionError = errorOutput.match(/execution error: (.+?)(?:\s*\(-?\d+\))?$/m);
+    if (executionError) {
+        coreError = executionError[1].trim();
+    }
+    // Try to match against known error patterns for user-friendly messages
+    for (const { pattern, message } of ERROR_MAPPINGS) {
+        const match = coreError.match(pattern);
+        if (match) {
+            // Replace $1, $2, etc. with captured groups
+            let result = message;
+            for (let i = 1; i < match.length; i++) {
+                result = result.replace(`$${i}`, match[i] || "");
+            }
+            return result;
+        }
+    }
+    // Fall back to basic "Can't get X" parsing
+    const notFoundError = coreError.match(/Can't get (.+?)\./);
+    if (notFoundError) {
+        return `Not found: ${notFoundError[1]}`;
+    }
+    // Return cleaned version of original error
+    return coreError.trim() || "Unknown AppleScript error";
+}
+/**
+ * Executes an AppleScript command and returns a structured result.
+ *
+ * This function serves as the bridge between TypeScript and macOS AppleScript.
+ * It handles the complexity of shell escaping, execution, and error handling
+ * so that calling code can work with clean TypeScript interfaces.
+ *
+ * The script is executed synchronously via the `osascript` command-line tool.
+ * Multi-line scripts are supported and preserved (important for AppleScript
+ * tell blocks and repeat loops).
+ *
+ * @param script - The AppleScript code to execute
+ * @param options - Optional execution settings (timeout, etc.)
+ * @returns A result object with success status and output or error message
+ *
+ * @example
+ * ```typescript
+ * // Basic usage with default timeout (30 seconds)
+ * const result = executeAppleScript(`
+ *   tell application "Notes"
+ *     get name of every note
+ *   end tell
+ * `);
+ *
+ * // With custom timeout for complex operations
+ * const result = executeAppleScript(complexScript, { timeoutMs: 60000 });
+ *
+ * if (result.success) {
+ *   console.log("Notes:", result.output);
+ * } else {
+ *   console.error("Failed:", result.error);
+ * }
+ * ```
+ */
+export function executeAppleScript(script, options = {}) {
+    const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
+    const retryDelayMs = options.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
+    // Validate input - empty scripts are likely programmer errors
+    if (!script || !script.trim()) {
+        return {
+            success: false,
+            output: "",
+            error: "Cannot execute empty AppleScript",
+        };
+    }
+    // Prepare the script:
+    // 1. Trim leading/trailing whitespace (cosmetic)
+    // 2. Wrap in `with timeout` so Notes.app aborts cleanly from inside its own
+    //    dispatch before the outer process SIGKILL (#17)
+    // 3. Preserve internal newlines (required for AppleScript syntax)
+    // 4. Escape for shell execution
+    const preparedScript = escapeForShell(wrapWithTimeout(script.trim(), timeoutMs));
+    // Build the osascript command
+    // We use single quotes to wrap the script, which is why we escape
+    // single quotes within the script itself
+    const command = `osascript -e '${preparedScript}'`;
+    // Debug: Log the script being executed
+    debugLog("Executing AppleScript", {
+        scriptPreview: script.trim().substring(0, 200) + (script.length > 200 ? "..." : ""),
+        timeout: timeoutMs,
+        maxRetries,
+    });
+    let lastError = null;
+    const startTime = Date.now();
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+        const attemptStart = Date.now();
+        try {
+            // Execute synchronously - MCP tools are inherently synchronous
+            // and Apple Notes operations are fast enough that async isn't needed
+            const output = execSync(command, {
+                encoding: "utf8",
+                timeout: timeoutMs,
+                // SIGKILL (not the default SIGTERM): a wedged osascript blocked on an
+                // unresponsive Notes.app can ignore SIGTERM and leak, piling up and
+                // worsening contention. SIGKILL guarantees reaping on timeout. (#17)
+                killSignal: "SIGKILL",
+                // Raise the output cap above Node's 1 MB default so large exports /
+                // long notes aren't truncated into an ENOBUFS failure. (#16)
+                maxBuffer: getMaxBuffer(),
+                // Capture stderr separately to get error details
+                stdio: ["pipe", "pipe", "pipe"],
+            });
+            const duration = Date.now() - attemptStart;
+            debugLog("AppleScript succeeded", {
+                attempt,
+                duration: `${duration}ms`,
+                outputLength: output.length,
+                outputPreview: output.substring(0, 100) + (output.length > 100 ? "..." : ""),
+            });
+            return {
+                success: true,
+                output: output.trim(),
+            };
+        }
+        catch (error) {
+            // execSync throws on non-zero exit codes
+            // The error object contains stderr output with AppleScript error details
+            const attemptDuration = Date.now() - attemptStart;
+            let errorMessage;
+            let isTimeout = false;
+            let rawError;
+            // Check for timeout first - provide specific message
+            if (isTimeoutError(error)) {
+                isTimeout = true;
+                const timeoutSecs = Math.round(timeoutMs / 1000);
+                errorMessage = `Operation timed out after ${timeoutSecs} seconds. Notes.app may be unresponsive or the operation involves too many notes.`;
+            }
+            else if (error instanceof Error) {
+                rawError = error.message;
+                // Node's ExecException includes stderr in the message
+                errorMessage = parseErrorMessage(error.message);
+            }
+            else if (typeof error === "string") {
+                rawError = error;
+                errorMessage = parseErrorMessage(error);
+            }
+            else {
+                errorMessage = "AppleScript execution failed with unknown error";
+            }
+            // Debug: Log error details
+            debugLog("AppleScript failed", {
+                attempt,
+                duration: `${attemptDuration}ms`,
+                totalElapsed: `${Date.now() - startTime}ms`,
+                isTimeout,
+                errorMessage,
+                rawError: rawError?.substring(0, 500),
+            });
+            lastError = {
+                success: false,
+                output: "",
+                error: errorMessage,
+            };
+            // Check if we should retry
+            const canRetry = isTimeout || isRetryableError(errorMessage);
+            const hasAttemptsLeft = attempt < maxRetries;
+            if (canRetry && hasAttemptsLeft) {
+                const delayMs = retryDelayMs * Math.pow(2, attempt - 1);
+                console.error(`AppleScript retry: Attempt ${attempt}/${maxRetries} failed with "${errorMessage}". Retrying in ${delayMs}ms...`);
+                sleep(delayMs);
+                // Continue to next attempt
+            }
+            else {
+                // Log final error and return
+                if (isTimeout) {
+                    console.error(`AppleScript timeout: ${errorMessage}`);
+                }
+                else {
+                    console.error(`AppleScript error: ${errorMessage}`);
+                }
+                return lastError;
+            }
+        }
+    }
+    // Return the last error (all retries exhausted - shouldn't reach here normally)
+    return lastError;
+}

--- a/build/utils/applescript.test.js
+++ b/build/utils/applescript.test.js
@@ -1,0 +1,342 @@
+/**
+ * Tests for AppleScript execution utilities
+ *
+ * These tests mock the child_process.execSync function to avoid
+ * requiring actual AppleScript execution during testing.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { execSync } from "child_process";
+import { executeAppleScript } from "./applescript.js";
+// Mock the child_process module
+vi.mock("child_process", () => ({
+    execSync: vi.fn(),
+    spawnSync: vi.fn(() => ({ error: null })), // Mock sleep to return immediately
+}));
+const mockExecSync = vi.mocked(execSync);
+describe("executeAppleScript", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+    describe("successful execution", () => {
+        it("returns success result with trimmed output", () => {
+            // Arrange: Mock a successful AppleScript execution
+            mockExecSync.mockReturnValue("  Note Title  \n");
+            // Act: Execute a simple script
+            const result = executeAppleScript('tell app "Notes" to get name of note 1');
+            // Assert: Output should be trimmed
+            expect(result.success).toBe(true);
+            expect(result.output).toBe("Note Title");
+            expect(result.error).toBeUndefined();
+        });
+        it("preserves newlines within the script for AppleScript syntax", () => {
+            mockExecSync.mockReturnValue("success");
+            // Multi-line AppleScript with tell blocks
+            const script = `
+        tell application "Notes"
+          tell account "iCloud"
+            get notes
+          end tell
+        end tell
+      `;
+            executeAppleScript(script);
+            // Verify the script was passed with newlines preserved
+            const calledCommand = mockExecSync.mock.calls[0][0];
+            expect(calledCommand).toContain("tell application");
+            expect(calledCommand).toContain("end tell");
+        });
+        it("escapes single quotes in the script for shell safety", () => {
+            mockExecSync.mockReturnValue("content");
+            // Script containing a single quote (e.g., in a note title)
+            executeAppleScript('get note "Rob\'s Notes"');
+            // Verify the quote was escaped for shell
+            const calledCommand = mockExecSync.mock.calls[0][0];
+            expect(calledCommand).toContain("Rob'\\''s");
+        });
+    });
+    describe("hardened executor (#16/#17)", () => {
+        afterEach(() => {
+            delete process.env.APPLE_NOTES_MCP_MAX_BUFFER;
+        });
+        it("wraps the script in `with timeout` so Notes.app aborts cleanly", () => {
+            mockExecSync.mockReturnValue("ok");
+            executeAppleScript("get name of notes", { timeoutMs: 30000 });
+            const cmd = mockExecSync.mock.calls[0][0];
+            expect(cmd).toContain("with timeout of");
+            expect(cmd).toContain("end timeout");
+            // 30s process timeout − 5s headroom = 25s script timeout
+            expect(cmd).toContain("with timeout of 25 seconds");
+        });
+        it("passes SIGKILL and a large maxBuffer to execSync", () => {
+            mockExecSync.mockReturnValue("ok");
+            executeAppleScript("get name of notes");
+            const opts = mockExecSync.mock.calls[0][1];
+            expect(opts.killSignal).toBe("SIGKILL");
+            expect(opts.maxBuffer).toBe(64 * 1024 * 1024);
+        });
+        it("honors APPLE_NOTES_MCP_MAX_BUFFER override", () => {
+            process.env.APPLE_NOTES_MCP_MAX_BUFFER = "1048576";
+            mockExecSync.mockReturnValue("ok");
+            executeAppleScript("get name of notes");
+            const opts = mockExecSync.mock.calls[0][1];
+            expect(opts.maxBuffer).toBe(1048576);
+        });
+    });
+    describe("error handling", () => {
+        it("returns error result when execution fails", () => {
+            // Arrange: Mock an AppleScript execution failure
+            mockExecSync.mockImplementation(() => {
+                throw new Error("execution error: Can't get note. (-1728)");
+            });
+            // Act: Try to execute a script that will fail
+            const result = executeAppleScript('get note "Nonexistent"');
+            // Assert: Should return structured error
+            expect(result.success).toBe(false);
+            expect(result.output).toBe("");
+            expect(result.error).toBeDefined();
+        });
+        it("parses execution error messages cleanly", () => {
+            mockExecSync.mockImplementation(() => {
+                throw new Error("execution error: Note not found (-1728)");
+            });
+            const result = executeAppleScript("get note 1");
+            // Should extract the meaningful part of the error
+            expect(result.error).toBe("Note not found");
+        });
+        it("handles 'not found' error patterns with user-friendly message", () => {
+            mockExecSync.mockImplementation(() => {
+                throw new Error('Can\'t get note "Missing".');
+            });
+            const result = executeAppleScript('get note "Missing"');
+            expect(result.error).toContain("not found");
+            expect(result.error).toContain("Missing");
+            expect(result.error).toContain("case-sensitive"); // Includes helpful hint
+        });
+        it("provides helpful message for permission errors", () => {
+            mockExecSync.mockImplementation(() => {
+                throw new Error("execution error: Not authorized to send Apple events (-1743)");
+            });
+            const result = executeAppleScript("test");
+            expect(result.error).toContain("Permission denied");
+            expect(result.error).toContain("System Preferences");
+        });
+        it("provides helpful message for folder not found", () => {
+            mockExecSync.mockImplementation(() => {
+                throw new Error('Can\'t get folder "Work".');
+            });
+            const result = executeAppleScript("test");
+            expect(result.error).toContain("Work");
+            expect(result.error).toContain("not found");
+            expect(result.error).toContain("list-folders");
+        });
+        it("provides helpful message for account not found", () => {
+            mockExecSync.mockImplementation(() => {
+                throw new Error('Can\'t get account "Gmail".');
+            });
+            const result = executeAppleScript("test");
+            expect(result.error).toContain("Gmail");
+            expect(result.error).toContain("not found");
+            expect(result.error).toContain("list-accounts");
+        });
+        it("handles non-Error exceptions gracefully", () => {
+            mockExecSync.mockImplementation(() => {
+                throw "string error"; // Some code throws strings
+            });
+            const result = executeAppleScript("some script");
+            expect(result.success).toBe(false);
+            expect(result.error).toBe("string error");
+        });
+        it("handles unknown error types", () => {
+            mockExecSync.mockImplementation(() => {
+                throw { weird: "object" }; // Unusual but possible
+            });
+            const result = executeAppleScript("some script");
+            expect(result.success).toBe(false);
+            expect(result.error).toBe("AppleScript execution failed with unknown error");
+        });
+    });
+    describe("input validation", () => {
+        it("returns error for empty script", () => {
+            const result = executeAppleScript("");
+            expect(result.success).toBe(false);
+            expect(result.error).toBe("Cannot execute empty AppleScript");
+            expect(mockExecSync).not.toHaveBeenCalled();
+        });
+        it("returns error for whitespace-only script", () => {
+            const result = executeAppleScript("   \n\t  ");
+            expect(result.success).toBe(false);
+            expect(result.error).toBe("Cannot execute empty AppleScript");
+            expect(mockExecSync).not.toHaveBeenCalled();
+        });
+    });
+    describe("execution options", () => {
+        it("uses default 30 second timeout", () => {
+            mockExecSync.mockReturnValue("ok");
+            executeAppleScript("test");
+            const options = mockExecSync.mock.calls[0][1];
+            expect(options.timeout).toBe(30000); // 30 second default timeout
+        });
+        it("allows custom timeout via options", () => {
+            mockExecSync.mockReturnValue("ok");
+            executeAppleScript("test", { timeoutMs: 60000 });
+            const options = mockExecSync.mock.calls[0][1];
+            expect(options.timeout).toBe(60000); // Custom timeout
+        });
+        it("uses UTF-8 encoding for output", () => {
+            mockExecSync.mockReturnValue("日本語テスト");
+            const result = executeAppleScript("test");
+            expect(result.output).toBe("日本語テスト");
+            const options = mockExecSync.mock.calls[0][1];
+            expect(options.encoding).toBe("utf8");
+        });
+    });
+    describe("timeout handling", () => {
+        it("returns specific error message on timeout", () => {
+            // Simulate a timeout error (Node.js sets killed=true and signal=SIGTERM)
+            const timeoutError = new Error("Command failed: SIGTERM");
+            timeoutError.killed = true;
+            timeoutError.signal = "SIGTERM";
+            mockExecSync.mockImplementation(() => {
+                throw timeoutError;
+            });
+            const result = executeAppleScript("test");
+            expect(result.success).toBe(false);
+            expect(result.error).toContain("timed out after 30 seconds");
+            expect(result.error).toContain("Notes.app may be unresponsive");
+        });
+        it("includes custom timeout value in error message", () => {
+            const timeoutError = new Error("Command failed: SIGTERM");
+            timeoutError.killed = true;
+            timeoutError.signal = "SIGTERM";
+            mockExecSync.mockImplementation(() => {
+                throw timeoutError;
+            });
+            const result = executeAppleScript("test", { timeoutMs: 60000 });
+            expect(result.error).toContain("timed out after 60 seconds");
+        });
+    });
+    describe("retry logic", () => {
+        it("does not retry by default (maxRetries=1)", () => {
+            mockExecSync.mockImplementation(() => {
+                throw new Error("Notes.app is not responding");
+            });
+            executeAppleScript("test");
+            // Only one attempt with default settings
+            expect(mockExecSync).toHaveBeenCalledTimes(1);
+        });
+        it("retries on transient errors when maxRetries > 1", () => {
+            let callCount = 0;
+            mockExecSync.mockImplementation(() => {
+                callCount++;
+                if (callCount < 3) {
+                    throw new Error("Notes.app is not responding");
+                }
+                return "success";
+            });
+            const result = executeAppleScript("test", { maxRetries: 3, retryDelayMs: 1 });
+            expect(result.success).toBe(true);
+            expect(result.output).toBe("success");
+            expect(mockExecSync).toHaveBeenCalledTimes(3);
+        });
+        it("does not retry on non-transient errors", () => {
+            mockExecSync.mockImplementation(() => {
+                throw new Error('Can\'t get note "Missing"');
+            });
+            executeAppleScript("test", { maxRetries: 3, retryDelayMs: 1 });
+            // Should not retry for "note not found" errors
+            expect(mockExecSync).toHaveBeenCalledTimes(1);
+        });
+        it("retries on timeout errors", () => {
+            let callCount = 0;
+            mockExecSync.mockImplementation(() => {
+                callCount++;
+                if (callCount < 2) {
+                    const timeoutError = new Error("SIGTERM");
+                    timeoutError.killed = true;
+                    timeoutError.signal = "SIGTERM";
+                    throw timeoutError;
+                }
+                return "success after retry";
+            });
+            const result = executeAppleScript("test", { maxRetries: 3, retryDelayMs: 1 });
+            expect(result.success).toBe(true);
+            expect(result.output).toBe("success after retry");
+            expect(mockExecSync).toHaveBeenCalledTimes(2);
+        });
+        it("retries on 'connection invalid' errors", () => {
+            let callCount = 0;
+            mockExecSync.mockImplementation(() => {
+                callCount++;
+                if (callCount < 2) {
+                    throw new Error("connection is invalid");
+                }
+                return "recovered";
+            });
+            const result = executeAppleScript("test", { maxRetries: 3, retryDelayMs: 1 });
+            expect(result.success).toBe(true);
+            expect(mockExecSync).toHaveBeenCalledTimes(2);
+        });
+        it("returns last error after all retries exhausted", () => {
+            mockExecSync.mockImplementation(() => {
+                throw new Error("Notes.app is not responding");
+            });
+            const result = executeAppleScript("test", { maxRetries: 3, retryDelayMs: 1 });
+            expect(result.success).toBe(false);
+            expect(result.error).toContain("not responding");
+            expect(mockExecSync).toHaveBeenCalledTimes(3);
+        });
+        it("retries on 'timed out' errors", () => {
+            let callCount = 0;
+            mockExecSync.mockImplementation(() => {
+                callCount++;
+                if (callCount < 2) {
+                    throw new Error("operation timed out");
+                }
+                return "recovered";
+            });
+            const result = executeAppleScript("test", { maxRetries: 3, retryDelayMs: 1 });
+            expect(result.success).toBe(true);
+            expect(mockExecSync).toHaveBeenCalledTimes(2);
+        });
+        it("retries on 'lost connection' errors", () => {
+            let callCount = 0;
+            mockExecSync.mockImplementation(() => {
+                callCount++;
+                if (callCount < 2) {
+                    throw new Error("lost connection to Notes.app");
+                }
+                return "recovered";
+            });
+            const result = executeAppleScript("test", { maxRetries: 3, retryDelayMs: 1 });
+            expect(result.success).toBe(true);
+            expect(mockExecSync).toHaveBeenCalledTimes(2);
+        });
+        it("retries on 'busy' errors", () => {
+            let callCount = 0;
+            mockExecSync.mockImplementation(() => {
+                callCount++;
+                if (callCount < 2) {
+                    throw new Error("Notes.app is busy");
+                }
+                return "recovered";
+            });
+            const result = executeAppleScript("test", { maxRetries: 3, retryDelayMs: 1 });
+            expect(result.success).toBe(true);
+            expect(mockExecSync).toHaveBeenCalledTimes(2);
+        });
+        it("uses exponential backoff between retries", () => {
+            let execCallCount = 0;
+            // Fails first 3 times, succeeds on 4th attempt
+            mockExecSync.mockImplementation(() => {
+                execCallCount++;
+                if (execCallCount <= 3) {
+                    throw new Error("Notes.app is not responding");
+                }
+                return "success";
+            });
+            // With retryDelayMs=100, delays should be: 100ms, 200ms, 400ms
+            const result = executeAppleScript("test", { maxRetries: 4, retryDelayMs: 100 });
+            expect(result.success).toBe(true);
+            expect(mockExecSync).toHaveBeenCalledTimes(4);
+        });
+    });
+});

--- a/build/utils/attachmentFs.js
+++ b/build/utils/attachmentFs.js
@@ -1,0 +1,97 @@
+/**
+ * Filesystem helpers for saving / fetching note attachments (#27).
+ *
+ * Notes.app exports an attachment to a path via AppleScript `save`. These helpers
+ * keep that safe (no writing outside sensible roots, no path traversal) and
+ * provide a base64 read for the fetch-attachment tool.
+ *
+ * @module utils/attachmentFs
+ */
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from "fs";
+import { isAbsolute, resolve, sep } from "path";
+import { homedir, tmpdir } from "os";
+/** Roots an attachment may be written to. */
+export function allowedSaveRoots() {
+    return [resolve(homedir()), resolve(tmpdir()), "/Volumes", "/private/var/folders", "/tmp"];
+}
+/**
+ * Validate a user-supplied destination path. Returns the resolved absolute path,
+ * or throws if it is relative or escapes the allowed roots.
+ */
+export function assertSafeSavePath(p, roots = allowedSaveRoots()) {
+    if (!p || !p.trim())
+        throw new Error("A destination path is required.");
+    if (!isAbsolute(p))
+        throw new Error(`Destination path must be absolute: "${p}"`);
+    const abs = resolve(p);
+    const ok = roots.some((r) => abs === r || abs.startsWith(r.endsWith(sep) ? r : r + sep));
+    if (!ok) {
+        throw new Error(`Refusing to write outside allowed locations (home, temp, /Volumes): "${abs}"`);
+    }
+    return abs;
+}
+/**
+ * Default upper bound on an attachment that `fetch-attachment` will base64-encode
+ * into a single MCP response. `readFileSync` loads the whole file into memory and
+ * base64 grows it ~33%, so an unbounded read of a multi-GB attachment (video,
+ * disk image) could exhaust memory. 25 MB is generous for the inline-fetch use
+ * case (docs, images, PDFs); larger attachments should be exported to disk with
+ * `save-attachment` instead. Overridable via APPLE_NOTES_MCP_MAX_ATTACHMENT_BYTES.
+ */
+const DEFAULT_MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024;
+/** Resolve the configured max attachment size (bytes) for inline base64 fetch. */
+export function maxAttachmentBytes(env = process.env) {
+    const raw = env.APPLE_NOTES_MCP_MAX_ATTACHMENT_BYTES;
+    if (raw !== undefined) {
+        const n = Number(raw);
+        if (Number.isFinite(n) && n > 0)
+            return n;
+    }
+    return DEFAULT_MAX_ATTACHMENT_BYTES;
+}
+/** Read a file as base64. */
+export function readFileBase64(p) {
+    return readFileSync(p).toString("base64");
+}
+/**
+ * Read a file as base64, refusing files larger than `maxBytes`.
+ *
+ * Guards `fetch-attachment` against unbounded in-memory reads: the size is
+ * checked from filesystem metadata BEFORE the file is read, so an oversized
+ * attachment is rejected with a clear error instead of loading it (and its
+ * ~33%-larger base64) into memory. (`APPLE_NOTES_MCP_MAX_BUFFER` does not apply
+ * to `readFileSync`.)
+ *
+ * @throws if the file exceeds `maxBytes`
+ */
+export function readFileBase64Capped(p, maxBytes = maxAttachmentBytes()) {
+    const size = fileSize(p);
+    if (size > maxBytes) {
+        throw new Error(`Attachment is ${size} bytes, exceeding the ${maxBytes}-byte fetch limit ` +
+            `(APPLE_NOTES_MCP_MAX_ATTACHMENT_BYTES). Use save-attachment to export it to disk instead.`);
+    }
+    return readFileBase64(p);
+}
+/** Byte size of a file (0 if missing). */
+export function fileSize(p) {
+    try {
+        return statSync(p).size;
+    }
+    catch {
+        return 0;
+    }
+}
+/** Make a private temp dir for a one-shot attachment export; caller cleans up. */
+export function makeTempDir() {
+    return mkdtempSync(resolve(tmpdir(), "apple-notes-att-"));
+}
+/** Remove a temp dir tree, ignoring errors. */
+export function cleanupTempDir(dir) {
+    try {
+        if (existsSync(dir))
+            rmSync(dir, { recursive: true, force: true });
+    }
+    catch {
+        /* best-effort */
+    }
+}

--- a/build/utils/attachmentFs.test.js
+++ b/build/utils/attachmentFs.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { writeFileSync, existsSync, mkdtempSync } from "fs";
+import { homedir, tmpdir } from "os";
+import { join } from "path";
+import { assertSafeSavePath, readFileBase64, readFileBase64Capped, maxAttachmentBytes, fileSize, makeTempDir, cleanupTempDir, allowedSaveRoots, } from "../utils/attachmentFs.js";
+const dirs = [];
+afterEach(() => dirs.splice(0).forEach(cleanupTempDir));
+describe("assertSafeSavePath (#27)", () => {
+    it("accepts absolute paths under the temp dir and home dir", () => {
+        const p = join(tmpdir(), "x.png");
+        expect(assertSafeSavePath(p)).toBe(p);
+        const h = join(homedir(), "Downloads", "x.png");
+        expect(assertSafeSavePath(h)).toBe(h);
+    });
+    it("rejects empty, relative, and out-of-root paths", () => {
+        expect(() => assertSafeSavePath("")).toThrow(/required/);
+        expect(() => assertSafeSavePath("relative/x.png")).toThrow(/absolute/);
+        expect(() => assertSafeSavePath("/etc/passwd")).toThrow(/outside allowed/);
+    });
+    it("blocks traversal that escapes an allowed root", () => {
+        expect(() => assertSafeSavePath(join(tmpdir(), "..", "..", "etc", "x"))).toThrow(/outside allowed/);
+    });
+    it("exposes the allowed roots", () => {
+        expect(allowedSaveRoots()).toEqual(expect.arrayContaining(["/Volumes"]));
+    });
+});
+describe("base64 / size / temp helpers (#27)", () => {
+    it("reads a file as base64 and reports its size", () => {
+        const dir = mkdtempSync(join(tmpdir(), "anatt-"));
+        dirs.push(dir);
+        const f = join(dir, "f.bin");
+        writeFileSync(f, Buffer.from("hello"));
+        expect(readFileBase64(f)).toBe(Buffer.from("hello").toString("base64"));
+        expect(fileSize(f)).toBe(5);
+    });
+    it("fileSize returns 0 for a missing file", () => {
+        expect(fileSize(join(tmpdir(), "definitely-missing-xyz.bin"))).toBe(0);
+    });
+    it("makeTempDir creates a dir and cleanupTempDir removes it (idempotent)", () => {
+        const dir = makeTempDir();
+        expect(existsSync(dir)).toBe(true);
+        cleanupTempDir(dir);
+        expect(existsSync(dir)).toBe(false);
+        expect(() => cleanupTempDir(dir)).not.toThrow();
+    });
+});
+describe("readFileBase64Capped / maxAttachmentBytes (size guard)", () => {
+    it("reads files at or under the cap", () => {
+        const dir = mkdtempSync(join(tmpdir(), "anatt-"));
+        dirs.push(dir);
+        const f = join(dir, "ok.bin");
+        writeFileSync(f, Buffer.from("hello"));
+        expect(readFileBase64Capped(f, 1024)).toBe(Buffer.from("hello").toString("base64"));
+    });
+    it("throws (without reading) when the file exceeds the cap", () => {
+        const dir = mkdtempSync(join(tmpdir(), "anatt-"));
+        dirs.push(dir);
+        const f = join(dir, "big.bin");
+        writeFileSync(f, Buffer.alloc(2048));
+        expect(() => readFileBase64Capped(f, 1024)).toThrow(/exceeding the 1024-byte fetch limit/);
+    });
+    it("maxAttachmentBytes honors APPLE_NOTES_MCP_MAX_ATTACHMENT_BYTES and falls back to a sane default", () => {
+        expect(maxAttachmentBytes({ APPLE_NOTES_MCP_MAX_ATTACHMENT_BYTES: "12345" })).toBe(12345);
+        // Invalid / non-positive values fall back to the default (25 MB).
+        expect(maxAttachmentBytes({ APPLE_NOTES_MCP_MAX_ATTACHMENT_BYTES: "0" })).toBe(25 * 1024 * 1024);
+        expect(maxAttachmentBytes({ APPLE_NOTES_MCP_MAX_ATTACHMENT_BYTES: "nope" })).toBe(25 * 1024 * 1024);
+        expect(maxAttachmentBytes({})).toBe(25 * 1024 * 1024);
+    });
+});

--- a/build/utils/checklistParser.js
+++ b/build/utils/checklistParser.js
@@ -1,0 +1,259 @@
+/**
+ * Apple Notes Checklist State Parser
+ *
+ * Reads checklist done/undone state by querying the NoteStore SQLite database
+ * and decoding the protobuf-encoded note content. This bypasses the AppleScript
+ * limitation where `body of note` strips checklist state information.
+ *
+ * Data flow:
+ * 1. Query NoteStore.sqlite for the gzipped protobuf blob (ZICNOTEDATA.ZDATA)
+ * 2. Decompress with gzip
+ * 3. Decode protobuf to extract text and attribute runs
+ * 4. Walk attribute runs to identify checklist items and their done state
+ *
+ * Protobuf field path:
+ *   Document (root) → field 2 (Note) → field 3 (Note body)
+ *     → field 2 (note_text: plain text)
+ *     → field 5 (attribute_run: repeated styling runs)
+ *       → field 1 (length)
+ *       → field 2 (paragraph_style)
+ *         → field 1 (style_type: 103 = checklist)
+ *         → field 5 (checklist)
+ *           → field 2 (done: 0 = unchecked, 1 = checked)
+ *
+ * @module utils/checklistParser
+ * @see https://github.com/sweetrb/apple-notes-mcp/issues/2
+ */
+import { execFileSync } from "child_process";
+import * as zlib from "zlib";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import { decodeMessage, getField, getFields, varintValue, stringValue, embeddedMessage, } from "../utils/protobuf.js";
+/** Style type value for checklist items in Apple Notes protobuf format. */
+const CHECKLIST_STYLE_TYPE = 103;
+const NOTES_DB_PATH = path.join(os.homedir(), "Library/Group Containers/group.com.apple.notes/NoteStore.sqlite");
+/**
+ * Checks whether the NoteStore database is accessible (Full Disk Access).
+ *
+ * @returns true if the database file exists and can be read
+ */
+export function hasFullDiskAccess() {
+    try {
+        if (!fs.existsSync(NOTES_DB_PATH))
+            return false;
+        // Try to open the database with a simple query
+        execFileSync("sqlite3", ["-readonly", NOTES_DB_PATH, "SELECT 1;"], {
+            encoding: "utf8",
+            timeout: 3000,
+            stdio: ["pipe", "pipe", "pipe"],
+        });
+        return true;
+    }
+    catch {
+        return false;
+    }
+}
+/**
+ * Queries the NoteStore SQLite database for a note's raw ZDATA blob.
+ *
+ * Uses the note's CoreData identifier to find the corresponding protobuf data.
+ * The identifier is extracted from the full CoreData URL format:
+ *   x-coredata://DEVICE-UUID/ICNote/pXXXX → pXXXX
+ *
+ * @param noteId - CoreData URL identifier (e.g., "x-coredata://ABC/ICNote/p123")
+ * @returns Object with hex data or error classification
+ */
+function queryNoteData(noteId) {
+    // Extract the primary key suffix (e.g., "p123" from "x-coredata://ABC/ICNote/p123")
+    const pkMatch = noteId.match(/\/p(\d+)$/);
+    if (!pkMatch) {
+        console.error(`Invalid note ID format: ${noteId}`);
+        return { hex: null, error: "invalid_id" };
+    }
+    const pk = pkMatch[1];
+    // Query for the gzipped protobuf data, output as hex for safe transport
+    const query = `SELECT hex(nd.ZDATA) FROM ZICNOTEDATA nd JOIN ZICCLOUDSYNCINGOBJECT n ON nd.ZNOTE = n.Z_PK WHERE n.Z_PK = ${pk};`;
+    try {
+        const result = execFileSync("sqlite3", ["-readonly", NOTES_DB_PATH, query], {
+            encoding: "utf8",
+            timeout: 5000,
+            stdio: ["pipe", "pipe", "pipe"],
+        });
+        const hex = result.trim();
+        if (!hex)
+            return { hex: null };
+        return { hex };
+    }
+    catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`Failed to query NoteStore database: ${message}`);
+        // Detect Full Disk Access denial
+        if (message.includes("authorization denied") || message.includes("unable to open database")) {
+            return { hex: null, error: "no_fda" };
+        }
+        return { hex: null };
+    }
+}
+/**
+ * Converts a hex string to a Uint8Array.
+ */
+function hexToBytes(hex) {
+    const bytes = new Uint8Array(hex.length / 2);
+    for (let i = 0; i < hex.length; i += 2) {
+        bytes[i / 2] = parseInt(hex.substring(i, i + 2), 16);
+    }
+    return bytes;
+}
+/**
+ * Extracts checklist items from a protobuf-encoded note.
+ *
+ * Navigates the protobuf structure:
+ *   Document → Note (field 2) → Note body (field 3)
+ *     → note_text (field 2): plain text with \n line separators
+ *     → attribute_run (field 5): repeated, sequential styling runs
+ *
+ * Walks attribute runs sequentially, tracking character position in the plain
+ * text. When a run has style_type == 103 (checklist), extracts the line text
+ * and done state.
+ *
+ * @param data - Decompressed protobuf bytes
+ * @returns Array of checklist items, or null if parsing fails
+ */
+function parseChecklistFromProtobuf(data) {
+    try {
+        // Document root
+        const docFields = decodeMessage(data);
+        // Field 2 = Note (Version/Document wrapper)
+        const noteWrapper = getField(docFields, 2);
+        const noteWrapperFields = embeddedMessage(noteWrapper);
+        if (!noteWrapperFields)
+            return null;
+        // Field 3 = Note body (the actual content)
+        const noteBody = getField(noteWrapperFields, 3);
+        const noteBodyFields = embeddedMessage(noteBody);
+        if (!noteBodyFields)
+            return null;
+        // Field 2 = note_text (plain text content)
+        const noteTextField = getField(noteBodyFields, 2);
+        const noteText = stringValue(noteTextField);
+        if (!noteText)
+            return null;
+        // Field 5 = attribute_run (repeated)
+        const attributeRuns = getFields(noteBodyFields, 5);
+        if (attributeRuns.length === 0)
+            return null;
+        // Split text into lines for mapping
+        const lines = noteText.split("\n");
+        // Walk attribute runs, tracking position in the text
+        const items = [];
+        let charPos = 0;
+        // Track which lines we've already added (multiple runs can cover the same line)
+        const seenLines = new Set();
+        for (const run of attributeRuns) {
+            const runFields = embeddedMessage(run);
+            if (!runFields)
+                continue;
+            // Field 1 = length (character count this run covers)
+            const lengthField = getField(runFields, 1);
+            const runLength = varintValue(lengthField) ?? 0;
+            // Field 2 = paragraph_style
+            const paragraphStyle = getField(runFields, 2);
+            const styleFields = embeddedMessage(paragraphStyle);
+            if (styleFields) {
+                // Field 1 = style_type
+                const styleType = varintValue(getField(styleFields, 1));
+                if (styleType === CHECKLIST_STYLE_TYPE) {
+                    // Field 5 = checklist info
+                    const checklistField = getField(styleFields, 5);
+                    const checklistFields = embeddedMessage(checklistField);
+                    // Field 2 = done (0 = unchecked, 1 = checked)
+                    const done = checklistFields ? (varintValue(getField(checklistFields, 2)) ?? 0) : 0;
+                    // Find which line this position corresponds to
+                    let lineStart = 0;
+                    for (let lineIdx = 0; lineIdx < lines.length; lineIdx++) {
+                        const lineEnd = lineStart + lines[lineIdx].length;
+                        if (charPos >= lineStart && charPos < lineEnd + 1 && !seenLines.has(lineIdx)) {
+                            seenLines.add(lineIdx);
+                            items.push({
+                                text: lines[lineIdx],
+                                done: done === 1,
+                            });
+                            break;
+                        }
+                        lineStart = lineEnd + 1; // +1 for the \n
+                    }
+                }
+            }
+            charPos += runLength;
+        }
+        return items;
+    }
+    catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`Failed to parse protobuf checklist data: ${message}`);
+        return null;
+    }
+}
+/**
+ * Gets the checklist state for a note by its CoreData ID.
+ *
+ * This reads directly from the NoteStore SQLite database, bypassing
+ * AppleScript's limitation of stripping checklist state from `body of note`.
+ *
+ * Requires Full Disk Access to read the Notes database.
+ *
+ * @param noteId - CoreData URL identifier (e.g., "x-coredata://ABC/ICNote/p123")
+ * @returns Structured result with items, error type, and message
+ */
+export function getChecklistItems(noteId) {
+    // Query the database for raw note data
+    const { hex: hexData, error: queryError } = queryNoteData(noteId);
+    if (queryError === "invalid_id") {
+        return {
+            items: null,
+            error: "invalid_id",
+            message: `Invalid note ID format: "${noteId}". Expected format: x-coredata://UUID/ICNote/pNNN`,
+        };
+    }
+    if (queryError === "no_fda") {
+        return {
+            items: null,
+            error: "no_fda",
+            message: "Full Disk Access is required to read checklist state. " +
+                "Grant access in System Settings > Privacy & Security > Full Disk Access, " +
+                "then add and restart this application.",
+        };
+    }
+    if (!hexData) {
+        return {
+            items: null,
+            error: "no_checklists",
+            message: "No data found for this note in the database.",
+        };
+    }
+    // Convert hex to bytes and decompress
+    const compressedData = hexToBytes(hexData);
+    let decompressed;
+    try {
+        decompressed = zlib.gunzipSync(compressedData);
+    }
+    catch {
+        console.error("Failed to decompress note data — may not be gzip format");
+        return {
+            items: null,
+            error: "parse_error",
+            message: "Failed to decompress note data.",
+        };
+    }
+    // Parse protobuf and extract checklist items
+    const items = parseChecklistFromProtobuf(new Uint8Array(decompressed));
+    if (!items || items.length === 0) {
+        return {
+            items: null,
+            error: "no_checklists",
+            message: "This note does not contain any checklist items.",
+        };
+    }
+    return { items };
+}

--- a/build/utils/checklistParser.test.js
+++ b/build/utils/checklistParser.test.js
@@ -1,0 +1,230 @@
+/**
+ * Tests for the Apple Notes checklist state parser.
+ *
+ * These tests mock the SQLite database access and test the protobuf
+ * parsing logic with realistic test fixtures.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as zlib from "zlib";
+import { getChecklistItems, hasFullDiskAccess } from "./checklistParser.js";
+// Mock child_process to avoid actual database access
+vi.mock("child_process", () => ({
+    execFileSync: vi.fn(),
+    spawnSync: vi.fn(() => ({ error: null })),
+}));
+// Mock fs for database existence checks
+vi.mock("fs", () => ({
+    existsSync: vi.fn(() => true),
+    statSync: vi.fn(() => ({ mtimeMs: Date.now() })),
+}));
+import { execFileSync } from "child_process";
+import { existsSync } from "fs";
+const mockExecSync = vi.mocked(execFileSync);
+const mockExistsSync = vi.mocked(existsSync);
+/**
+ * Builds a minimal Apple Notes protobuf structure with checklist items.
+ *
+ * Structure:
+ *   Document (root)
+ *     field 2 (Note wrapper)
+ *       field 3 (Note body)
+ *         field 2 (note_text: plain text)
+ *         field 5 (attribute_run) - repeated
+ */
+function buildChecklistProtobuf(items) {
+    // Helper to encode a varint
+    function encodeVarint(value) {
+        const bytes = [];
+        while (value > 0x7f) {
+            bytes.push((value & 0x7f) | 0x80);
+            value >>>= 7;
+        }
+        bytes.push(value & 0x7f);
+        return bytes;
+    }
+    // Helper to encode a tag
+    function encodeTag(fieldNumber, wireType) {
+        return encodeVarint((fieldNumber << 3) | wireType);
+    }
+    // Helper to wrap bytes as a length-delimited field
+    function lengthDelimited(fieldNumber, data) {
+        const bytes = data instanceof Uint8Array ? Array.from(data) : data;
+        return [...encodeTag(fieldNumber, 2), ...encodeVarint(bytes.length), ...bytes];
+    }
+    // Helper to encode a varint field
+    function varintField(fieldNumber, value) {
+        return [...encodeTag(fieldNumber, 0), ...encodeVarint(value)];
+    }
+    // Build the plain text: "Title\nitem1\nitem2\n..."
+    const textLines = ["Checklist Note", ...items.map((i) => i.text)];
+    const noteText = textLines.join("\n");
+    const encoder = new TextEncoder();
+    // Build attribute runs
+    // First run: title line (not a checklist)
+    const titleLength = textLines[0].length + 1; // +1 for \n
+    const titleRun = lengthDelimited(5, [
+        ...varintField(1, titleLength), // length
+        // No paragraph_style with checklist — just a regular paragraph
+    ]);
+    // Checklist runs
+    const checklistRuns = [];
+    for (const item of items) {
+        const runLength = item.text.length + 1; // +1 for \n (or end of text)
+        // Build checklist info: field 2 = done
+        const checklistInfo = lengthDelimited(5, varintField(2, item.done ? 1 : 0));
+        // Build paragraph_style: field 1 = 103 (checklist), field 5 = checklist info
+        const paragraphStyle = lengthDelimited(2, [...varintField(1, 103), ...checklistInfo]);
+        // Build attribute run: field 1 = length, field 2 = paragraph_style
+        const run = lengthDelimited(5, [...varintField(1, runLength), ...paragraphStyle]);
+        checklistRuns.push(...run);
+    }
+    // Build note body (field 3):
+    //   field 2 = note_text, field 5 = attribute_runs (already encoded above)
+    const noteTextField = lengthDelimited(2, encoder.encode(noteText));
+    const noteBody = lengthDelimited(3, [...noteTextField, ...titleRun, ...checklistRuns]);
+    // Build note wrapper (field 2 of document)
+    const noteWrapper = lengthDelimited(2, noteBody);
+    return new Uint8Array(noteWrapper);
+}
+describe("hasFullDiskAccess", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+    it("returns true when database is accessible", () => {
+        mockExistsSync.mockReturnValue(true);
+        mockExecSync.mockReturnValue("1\n");
+        expect(hasFullDiskAccess()).toBe(true);
+    });
+    it("returns false when database file does not exist", () => {
+        mockExistsSync.mockReturnValue(false);
+        expect(hasFullDiskAccess()).toBe(false);
+    });
+    it("returns false when sqlite3 query fails", () => {
+        mockExistsSync.mockReturnValue(true);
+        mockExecSync.mockImplementation(() => {
+            throw new Error("authorization denied");
+        });
+        expect(hasFullDiskAccess()).toBe(false);
+    });
+});
+describe("getChecklistItems", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+    it("returns error for invalid note ID format", () => {
+        const result = getChecklistItems("invalid-id");
+        expect(result.items).toBeNull();
+        expect(result.error).toBe("invalid_id");
+    });
+    it("returns no_checklists when database query returns empty", () => {
+        mockExecSync.mockReturnValue("");
+        const result = getChecklistItems("x-coredata://ABC/ICNote/p123");
+        expect(result.items).toBeNull();
+        expect(result.error).toBe("no_checklists");
+    });
+    it("parses checklist with mixed done/undone items", () => {
+        const items = [
+            { text: "Buy milk", done: true },
+            { text: "Walk dog", done: false },
+            { text: "Send email", done: true },
+        ];
+        const protobuf = buildChecklistProtobuf(items);
+        const compressed = zlib.gzipSync(Buffer.from(protobuf));
+        const hex = Buffer.from(compressed).toString("hex").toUpperCase();
+        mockExecSync.mockReturnValue((hex + "\n"));
+        const result = getChecklistItems("x-coredata://ABC/ICNote/p123");
+        expect(result.items).not.toBeNull();
+        expect(result.items).toHaveLength(3);
+        expect(result.items[0]).toEqual({ text: "Buy milk", done: true });
+        expect(result.items[1]).toEqual({ text: "Walk dog", done: false });
+        expect(result.items[2]).toEqual({ text: "Send email", done: true });
+        expect(result.error).toBeUndefined();
+    });
+    it("parses checklist with all items unchecked", () => {
+        const items = [
+            { text: "Task A", done: false },
+            { text: "Task B", done: false },
+        ];
+        const protobuf = buildChecklistProtobuf(items);
+        const compressed = zlib.gzipSync(Buffer.from(protobuf));
+        const hex = Buffer.from(compressed).toString("hex").toUpperCase();
+        mockExecSync.mockReturnValue((hex + "\n"));
+        const result = getChecklistItems("x-coredata://ABC/ICNote/p456");
+        expect(result.items).not.toBeNull();
+        expect(result.items).toHaveLength(2);
+        expect(result.items.every((i) => !i.done)).toBe(true);
+    });
+    it("parses checklist with all items checked", () => {
+        const items = [
+            { text: "Done 1", done: true },
+            { text: "Done 2", done: true },
+        ];
+        const protobuf = buildChecklistProtobuf(items);
+        const compressed = zlib.gzipSync(Buffer.from(protobuf));
+        const hex = Buffer.from(compressed).toString("hex").toUpperCase();
+        mockExecSync.mockReturnValue((hex + "\n"));
+        const result = getChecklistItems("x-coredata://ABC/ICNote/p789");
+        expect(result.items).not.toBeNull();
+        expect(result.items).toHaveLength(2);
+        expect(result.items.every((i) => i.done)).toBe(true);
+    });
+    it("returns null when note has no checklist items", () => {
+        // Build a protobuf with no checklist style_type
+        const encoder = new TextEncoder();
+        // Minimal note with just text, no checklist runs
+        // Field 2 (note text) = "Just a regular note"
+        const noteText = encoder.encode("Just a regular note");
+        const noteTextField = [0x12, noteText.length, ...noteText]; // field 2, length-delimited
+        // A non-checklist attribute run (style_type = 0, regular paragraph)
+        const regularRun = [
+            0x2a, // field 5, length-delimited (attribute_run)
+            0x04, // length 4
+            0x08,
+            0x13, // field 1 (length) = 19
+            0x12,
+            0x00, // field 2 (paragraph_style) = empty
+        ];
+        const noteBody = [
+            0x1a, // field 3, length-delimited
+            noteTextField.length + regularRun.length,
+            ...noteTextField,
+            ...regularRun,
+        ];
+        const noteWrapper = [0x12, noteBody.length, ...noteBody]; // field 2
+        const compressed = zlib.gzipSync(Buffer.from(new Uint8Array(noteWrapper)));
+        const hex = Buffer.from(compressed).toString("hex").toUpperCase();
+        mockExecSync.mockReturnValue((hex + "\n"));
+        const result = getChecklistItems("x-coredata://ABC/ICNote/p100");
+        expect(result.items).toBeNull();
+        expect(result.error).toBe("no_checklists");
+    });
+    it("returns null when sqlite3 command fails", () => {
+        mockExecSync.mockImplementation(() => {
+            throw new Error("database is locked");
+        });
+        const result = getChecklistItems("x-coredata://ABC/ICNote/p123");
+        expect(result.items).toBeNull();
+    });
+    it("returns no_fda error when authorization is denied", () => {
+        mockExecSync.mockImplementation(() => {
+            throw new Error("unable to open database: authorization denied");
+        });
+        const result = getChecklistItems("x-coredata://ABC/ICNote/p123");
+        expect(result.items).toBeNull();
+        expect(result.error).toBe("no_fda");
+        expect(result.message).toContain("Full Disk Access");
+        expect(result.message).toContain("System Settings");
+    });
+    it("returns parse_error for non-gzip data", () => {
+        // Return valid hex that isn't gzip
+        mockExecSync.mockReturnValue("DEADBEEF\n");
+        const result = getChecklistItems("x-coredata://ABC/ICNote/p123");
+        expect(result.items).toBeNull();
+        expect(result.error).toBe("parse_error");
+    });
+    it("extracts correct primary key from note ID", () => {
+        mockExecSync.mockReturnValue("");
+        getChecklistItems("x-coredata://12345-ABCDE/ICNote/p42");
+        expect(mockExecSync).toHaveBeenCalledWith("sqlite3", expect.arrayContaining([expect.stringContaining("Z_PK = 42")]), expect.any(Object));
+    });
+});

--- a/build/utils/contentWarnings.js
+++ b/build/utils/contentWarnings.js
@@ -1,0 +1,44 @@
+/**
+ * Content Warnings for create-note / update-note
+ *
+ * Detects content patterns that look like the user is trying to do something
+ * Apple Notes via AppleScript cannot actually render — so the response can
+ * carry a clear warning instead of silently producing a broken note.
+ *
+ * @module utils/contentWarnings
+ */
+/**
+ * Detects checklist-like syntax in note content.
+ *
+ * Apple Notes checklists are a paragraph style stored in a protobuf blob in
+ * the NoteStore SQLite database. AppleScript's `body of note` setter does not
+ * expose paragraph styles: `<input type="checkbox">` is stripped, a
+ * `class="checklist"` on `<ul>` is dropped, and markdown `- [ ]` lines in
+ * `plaintext` mode arrive as literal text. There is no input that produces a
+ * real checklist.
+ *
+ * @param content - The user-supplied note body (HTML or plaintext)
+ * @returns A user-facing warning string, or null when no checklist-like
+ *   patterns are present
+ */
+export function detectChecklistAttempt(content) {
+    if (!content)
+        return null;
+    // HTML checkbox input — `<input type="checkbox" ...>` in either quoting style.
+    const htmlCheckbox = /<input\b[^>]*\btype\s*=\s*["']checkbox["']/i.test(content);
+    // Markdown-style checklist: lines starting with optional whitespace, then
+    // `-` or `*`, a space, and `[ ]` / `[x]` / `[X]`.
+    const markdownCheckbox = /^[ \t]*[-*]\s+\[[ xX]\]/m.test(content);
+    // CSS class hint — some clients try `<ul class="checklist">` or
+    // `<li class="todo">`. AppleScript drops these classes too.
+    const checklistClass = /class\s*=\s*["'][^"']*\b(?:checklist|todo)\b/i.test(content);
+    if (!htmlCheckbox && !markdownCheckbox && !checklistClass)
+        return null;
+    return ("\n\n⚠️ Your content looks like a checklist, but Apple Notes checklists " +
+        'cannot be created via AppleScript — `<input type="checkbox">` is ' +
+        "stripped, checklist CSS classes are dropped, and markdown `- [ ]` lines " +
+        "arrive as literal text. The note was created with the surrounding " +
+        "structure (list items or paragraphs) intact. To convert it to a real " +
+        "Apple Notes checklist, open the note, select the items, and press " +
+        "⇧⌘L (Format → Checklist).");
+}

--- a/build/utils/contentWarnings.test.js
+++ b/build/utils/contentWarnings.test.js
@@ -1,0 +1,52 @@
+/**
+ * Tests for the content-warning detectors.
+ */
+import { describe, it, expect } from "vitest";
+import { detectChecklistAttempt } from "./contentWarnings.js";
+describe("detectChecklistAttempt", () => {
+    it("returns null for plain text without checklist syntax", () => {
+        expect(detectChecklistAttempt("Just a regular note.")).toBeNull();
+    });
+    it("returns null for empty content", () => {
+        expect(detectChecklistAttempt("")).toBeNull();
+    });
+    it("returns null for HTML lists that are not checklists", () => {
+        expect(detectChecklistAttempt("<ul><li>Apple</li><li>Banana</li></ul>")).toBeNull();
+    });
+    it('warns on <input type="checkbox"> (double-quoted)', () => {
+        const w = detectChecklistAttempt('<input type="checkbox"> Buy milk');
+        expect(w).not.toBeNull();
+        expect(w).toContain("⚠️");
+        expect(w).toContain("⇧⌘L");
+    });
+    it("warns on <input type='checkbox'> (single-quoted)", () => {
+        expect(detectChecklistAttempt("<input type='checkbox'> Buy milk")).not.toBeNull();
+    });
+    it("warns on <input> with extra attributes before type", () => {
+        expect(detectChecklistAttempt('<input id="x" type="checkbox"> Item')).not.toBeNull();
+    });
+    it('warns on <INPUT TYPE="CHECKBOX"> (case-insensitive)', () => {
+        expect(detectChecklistAttempt('<INPUT TYPE="CHECKBOX"> Item')).not.toBeNull();
+    });
+    it("warns on markdown `- [ ]` syntax", () => {
+        expect(detectChecklistAttempt("- [ ] todo 1\n- [x] done 1")).not.toBeNull();
+    });
+    it("warns on markdown `* [ ]` syntax", () => {
+        expect(detectChecklistAttempt("* [ ] todo 1")).not.toBeNull();
+    });
+    it("warns on markdown checklist with leading whitespace", () => {
+        expect(detectChecklistAttempt("  - [ ] indented todo")).not.toBeNull();
+    });
+    it('warns on <ul class="checklist">', () => {
+        expect(detectChecklistAttempt('<ul class="checklist"><li>a</li></ul>')).not.toBeNull();
+    });
+    it('warns on <li class="todo">', () => {
+        expect(detectChecklistAttempt('<ul><li class="todo">a</li></ul>')).not.toBeNull();
+    });
+    it("does not warn on the word 'checklist' in prose", () => {
+        expect(detectChecklistAttempt("My checklist of things to do tomorrow.")).toBeNull();
+    });
+    it("does not warn on a literal `[ ]` not at start of a list line", () => {
+        expect(detectChecklistAttempt("The brackets [ ] are not a checklist.")).toBeNull();
+    });
+});

--- a/build/utils/hashtags.js
+++ b/build/utils/hashtags.js
@@ -1,0 +1,56 @@
+/**
+ * Inline hashtag extraction for Apple Notes.
+ *
+ * Apple Notes "tags" are not a first-class AppleScript property — they are
+ * inline `#hashtag` tokens typed into the note body. Notes stores the tag
+ * relationship in its private Core Data store, which AppleScript does not
+ * expose, so the only way to surface a note's tags is to parse them back out
+ * of the body text. This module does exactly that.
+ *
+ * See docs/APPLESCRIPT-LIMITATIONS.md and issue #29.
+ */
+/**
+ * Strip HTML tags from a Notes body and neutralise numeric character
+ * references so they can't masquerade as hashtags (e.g. `&#8217;`).
+ */
+function htmlToText(html) {
+    return html
+        .replace(/<[^>]*>/g, " ") // drop tags
+        .replace(/&#x?[0-9a-f]+;/gi, " ") // neutralise numeric entities (&#8217;)
+        .replace(/&[a-z]+;/gi, " "); // neutralise named entities (&amp; &nbsp;)
+}
+/**
+ * A hashtag token: `#` followed by a run of letters/digits/underscores that
+ * contains at least one letter. This matches Apple Notes' own rule — a purely
+ * numeric token like `#123` is NOT treated as a tag. The token must not be
+ * preceded by a word character, so `foo#bar` and URL fragments like
+ * `page.html#section` (preceded by a letter) are ignored.
+ */
+const HASHTAG_RE = /(?<![\p{L}\p{N}_])#([\p{L}\p{N}_]*\p{L}[\p{L}\p{N}_]*)/gu;
+/**
+ * Extract inline `#hashtag` tokens from a note body (HTML or plain text).
+ *
+ * - HTML is stripped first, so tags inside `<div>#work</div>` are found.
+ * - Pure-number tokens (`#123`) are ignored, matching Notes' behaviour.
+ * - Results are de-duplicated case-insensitively, preserving the first-seen
+ *   casing and document order. The leading `#` is not included.
+ *
+ * @param body - The note body, as HTML or plain text.
+ * @returns Ordered, de-duplicated tag names without the leading `#`.
+ */
+export function parseHashtags(body) {
+    if (!body)
+        return [];
+    const text = htmlToText(body);
+    const seen = new Set();
+    const result = [];
+    for (const match of text.matchAll(HASHTAG_RE)) {
+        const tag = match[1];
+        const key = tag.toLowerCase();
+        if (!seen.has(key)) {
+            seen.add(key);
+            result.push(tag);
+        }
+    }
+    return result;
+}

--- a/build/utils/hashtags.test.js
+++ b/build/utils/hashtags.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { parseHashtags } from "../utils/hashtags.js";
+describe("parseHashtags", () => {
+    it("returns [] for empty / nullish input", () => {
+        expect(parseHashtags("")).toEqual([]);
+        expect(parseHashtags(null)).toEqual([]);
+        expect(parseHashtags(undefined)).toEqual([]);
+        expect(parseHashtags("no tags here")).toEqual([]);
+    });
+    it("extracts a single tag", () => {
+        expect(parseHashtags("Buy milk #groceries")).toEqual(["groceries"]);
+    });
+    it("extracts multiple tags in document order", () => {
+        expect(parseHashtags("#work then #home then #travel")).toEqual(["work", "home", "travel"]);
+    });
+    it("strips the leading # and not the rest", () => {
+        expect(parseHashtags("#project_alpha")).toEqual(["project_alpha"]);
+    });
+    it("finds tags inside HTML bodies", () => {
+        expect(parseHashtags("<div>Plan <b>#q3</b> launch</div>")).toEqual(["q3"]);
+    });
+    it("de-duplicates case-insensitively, keeping first-seen casing", () => {
+        expect(parseHashtags("#Work and #work and #WORK")).toEqual(["Work"]);
+    });
+    it("ignores purely numeric tokens (matches Notes behaviour)", () => {
+        expect(parseHashtags("ticket #123 and #4you")).toEqual(["4you"]);
+    });
+    it("does not match mid-word or URL fragments", () => {
+        expect(parseHashtags("foo#bar")).toEqual([]);
+        expect(parseHashtags("see page.html#section for details")).toEqual([]);
+    });
+    it("does not treat numeric HTML entities as tags", () => {
+        // &#8217; is a right single quote entity, not a #8217 tag
+        expect(parseHashtags("It&#8217;s a #plan")).toEqual(["plan"]);
+    });
+    it("matches a tag at the very start of the body", () => {
+        expect(parseHashtags("#start of note")).toEqual(["start"]);
+    });
+    it("handles tags terminated by punctuation", () => {
+        expect(parseHashtags("done: #alpha, #beta; #gamma.")).toEqual(["alpha", "beta", "gamma"]);
+    });
+    it("supports unicode letters in tags", () => {
+        expect(parseHashtags("café trip #café")).toEqual(["café"]);
+    });
+});

--- a/build/utils/jxa.js
+++ b/build/utils/jxa.js
@@ -1,0 +1,139 @@
+/**
+ * JXA (JavaScript for Automation) Execution Utilities
+ *
+ * This module provides an alternative to AppleScript using JavaScript.
+ * JXA was introduced in OS X Yosemite and uses the same OSA infrastructure
+ * as AppleScript but with JavaScript syntax.
+ *
+ * Potential advantages over AppleScript:
+ * - Standard JavaScript string escaping (simpler than AppleScript)
+ * - Better Unicode handling
+ * - Familiar syntax for developers
+ * - Native JSON support
+ *
+ * @module utils/jxa
+ */
+import { execSync } from "child_process";
+/**
+ * Output cap for osascript (JXA). Mirrors the AppleScript executor — Node's 1 MB
+ * default truncates large JXA output into an ENOBUFS failure. 64 MB default,
+ * overridable via APPLE_NOTES_MCP_MAX_BUFFER. (#16)
+ */
+const DEFAULT_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
+function getMaxBuffer() {
+    const raw = process.env.APPLE_NOTES_MCP_MAX_BUFFER;
+    if (raw !== undefined) {
+        const n = Number(raw);
+        if (Number.isFinite(n) && n > 0)
+            return n;
+    }
+    return DEFAULT_MAX_BUFFER_BYTES;
+}
+const DEFAULT_TIMEOUT_MS = 30000;
+/**
+ * Escapes a string for safe inclusion in a JXA script.
+ *
+ * JXA uses standard JavaScript string escaping, which is simpler
+ * than AppleScript's escaping requirements.
+ *
+ * @param str - The string to escape
+ * @returns Escaped string safe for JXA embedding
+ */
+export function escapeForJXA(str) {
+    if (!str)
+        return "";
+    // Standard JavaScript string escaping
+    return str
+        .replace(/\\/g, "\\\\") // Backslashes first
+        .replace(/"/g, '\\"') // Double quotes
+        .replace(/\n/g, "\\n") // Newlines
+        .replace(/\r/g, "\\r") // Carriage returns
+        .replace(/\t/g, "\\t"); // Tabs
+}
+/**
+ * Checks if an error is a timeout error.
+ */
+function isTimeoutError(error) {
+    if (error instanceof Error) {
+        const execError = error;
+        return execError.killed === true || execError.signal === "SIGTERM";
+    }
+    return false;
+}
+/**
+ * Executes a JXA (JavaScript for Automation) script.
+ *
+ * JXA scripts are executed via `osascript -l JavaScript`.
+ *
+ * @param script - The JavaScript code to execute
+ * @param options - Execution options
+ * @returns Result with success status and output or error
+ *
+ * @example
+ * ```typescript
+ * const result = executeJXA(`
+ *   const Notes = Application("Notes");
+ *   Notes.accounts().map(a => a.name());
+ * `);
+ * ```
+ */
+export function executeJXA(script, options = {}) {
+    const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    if (!script || !script.trim()) {
+        return {
+            success: false,
+            output: "",
+            error: "Cannot execute empty JXA script",
+        };
+    }
+    // Escape the script for shell embedding
+    // We use single quotes to wrap, so escape single quotes within
+    const escapedScript = script.trim().replace(/'/g, "'\\''");
+    const command = `osascript -l JavaScript -e '${escapedScript}'`;
+    try {
+        const output = execSync(command, {
+            encoding: "utf8",
+            timeout: timeoutMs,
+            killSignal: "SIGKILL", // reap a wedged osascript reliably (#17)
+            maxBuffer: getMaxBuffer(), // avoid ENOBUFS truncation on large output (#16)
+            stdio: ["pipe", "pipe", "pipe"],
+        });
+        return {
+            success: true,
+            output: output.trim(),
+        };
+    }
+    catch (error) {
+        let errorMessage;
+        if (isTimeoutError(error)) {
+            const timeoutSecs = Math.round(timeoutMs / 1000);
+            errorMessage = `Operation timed out after ${timeoutSecs} seconds`;
+        }
+        else if (error instanceof Error) {
+            // Extract meaningful error from stderr
+            const match = error.message.match(/Error: (.+)/);
+            errorMessage = match ? match[1] : error.message;
+        }
+        else {
+            errorMessage = "JXA execution failed with unknown error";
+        }
+        return {
+            success: false,
+            output: "",
+            error: errorMessage,
+        };
+    }
+}
+/**
+ * Builds a JXA script that interacts with Notes.app.
+ *
+ * @param code - JavaScript code to execute within Notes context
+ * @returns Complete JXA script
+ */
+export function buildNotesJXA(code) {
+    return `
+    const Notes = Application("Notes");
+    Notes.includeStandardAdditions = true;
+    ${code}
+  `;
+}

--- a/build/utils/jxa.test.js
+++ b/build/utils/jxa.test.js
@@ -1,0 +1,134 @@
+/**
+ * Tests for JXA Execution Utilities
+ *
+ * These tests verify the JXA executor and compare behavior with AppleScript.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { executeJXA, escapeForJXA, buildNotesJXA } from "./jxa.js";
+// Mock execSync to avoid actual osascript calls
+vi.mock("child_process", () => ({
+    execSync: vi.fn(),
+}));
+import { execSync } from "child_process";
+const mockExecSync = vi.mocked(execSync);
+describe("escapeForJXA", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+    it("returns empty string for null/undefined", () => {
+        expect(escapeForJXA("")).toBe("");
+        expect(escapeForJXA(null)).toBe("");
+        expect(escapeForJXA(undefined)).toBe("");
+    });
+    it("escapes backslashes", () => {
+        expect(escapeForJXA("path\\to\\file")).toBe("path\\\\to\\\\file");
+    });
+    it("escapes double quotes", () => {
+        expect(escapeForJXA('say "hello"')).toBe('say \\"hello\\"');
+    });
+    it("escapes newlines", () => {
+        expect(escapeForJXA("line1\nline2")).toBe("line1\\nline2");
+    });
+    it("escapes tabs", () => {
+        expect(escapeForJXA("col1\tcol2")).toBe("col1\\tcol2");
+    });
+    it("handles complex content", () => {
+        const input = 'John said "Hello\\World"\nNew line';
+        const expected = 'John said \\"Hello\\\\World\\"\\nNew line';
+        expect(escapeForJXA(input)).toBe(expected);
+    });
+    it("preserves single quotes (no escaping needed in double-quoted JS strings)", () => {
+        expect(escapeForJXA("it's working")).toBe("it's working");
+    });
+    it("preserves unicode characters", () => {
+        expect(escapeForJXA("日本語 🎉")).toBe("日本語 🎉");
+    });
+});
+describe("executeJXA", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+    it("returns error for empty script", () => {
+        const result = executeJXA("");
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("empty");
+    });
+    it("executes JXA script via osascript", () => {
+        mockExecSync.mockReturnValue("test output\n");
+        const result = executeJXA("JSON.stringify({test: true})");
+        expect(result.success).toBe(true);
+        expect(result.output).toBe("test output");
+        expect(mockExecSync).toHaveBeenCalledWith(expect.stringContaining("-l JavaScript"), expect.any(Object));
+    });
+    it("handles execution errors", () => {
+        mockExecSync.mockImplementation(() => {
+            throw new Error("Error: Cannot find note");
+        });
+        const result = executeJXA("Notes.notes()");
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("Cannot find note");
+    });
+    describe("hardened executor (#16/#17)", () => {
+        afterEach(() => {
+            delete process.env.APPLE_NOTES_MCP_MAX_BUFFER;
+        });
+        it("passes SIGKILL and a large maxBuffer to execSync", () => {
+            mockExecSync.mockReturnValue("ok");
+            executeJXA("JSON.stringify({})");
+            const opts = mockExecSync.mock.calls[0][1];
+            expect(opts.killSignal).toBe("SIGKILL");
+            expect(opts.maxBuffer).toBe(64 * 1024 * 1024);
+        });
+        it("honors APPLE_NOTES_MCP_MAX_BUFFER override", () => {
+            process.env.APPLE_NOTES_MCP_MAX_BUFFER = "2097152";
+            mockExecSync.mockReturnValue("ok");
+            executeJXA("JSON.stringify({})");
+            const opts = mockExecSync.mock.calls[0][1];
+            expect(opts.maxBuffer).toBe(2097152);
+        });
+    });
+    it("handles timeout errors", () => {
+        const error = new Error("Command failed");
+        error.killed = true;
+        mockExecSync.mockImplementation(() => {
+            throw error;
+        });
+        const result = executeJXA("longRunningScript()", { timeoutMs: 5000 });
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("timed out");
+    });
+});
+describe("buildNotesJXA", () => {
+    it("wraps code with Notes application context", () => {
+        const code = "Notes.accounts().map(a => a.name())";
+        const script = buildNotesJXA(code);
+        expect(script).toContain('Application("Notes")');
+        expect(script).toContain(code);
+    });
+});
+// =============================================================================
+// Comparison Tests: JXA vs AppleScript Escaping
+// =============================================================================
+describe("JXA vs AppleScript escaping comparison", () => {
+    it("JXA handles single quotes without special escaping", () => {
+        // In AppleScript, single quotes need shell escaping: '\''
+        // In JXA, single quotes are fine in double-quoted strings
+        const input = "it's Rob's note";
+        const escaped = escapeForJXA(input);
+        expect(escaped).toBe("it's Rob's note"); // No change needed
+    });
+    it("JXA uses standard escape sequences for control chars", () => {
+        // AppleScript converts to HTML (<br>) for Notes.app
+        // JXA uses standard \n which may need conversion for Notes
+        const input = "line1\nline2";
+        const escaped = escapeForJXA(input);
+        expect(escaped).toBe("line1\\nline2");
+    });
+    it("JXA handles backslashes with standard escaping", () => {
+        // AppleScript needs HTML entity encoding (&#92;) for Notes.app
+        // JXA uses standard \\ escaping
+        const input = "path\\to\\file";
+        const escaped = escapeForJXA(input);
+        expect(escaped).toBe("path\\\\to\\\\file");
+    });
+});

--- a/build/utils/noteMetadata.js
+++ b/build/utils/noteMetadata.js
@@ -1,0 +1,135 @@
+/**
+ * Apple Notes Read-Only Metadata Reader [BETA]
+ *
+ * Reads note metadata that the AppleScript dictionary does not expose (pinned
+ * state, checklist flags, trash/recovery, preview snippet, password hint) by
+ * querying the NoteStore SQLite database directly.
+ *
+ * Unlike the note body (a gzipped protobuf blob in ZICNOTEDATA.ZDATA), these are
+ * plain scalar columns on ZICCLOUDSYNCINGOBJECT, so no protobuf decoding is
+ * needed — an ordinary SELECT is enough.
+ *
+ * BETA / safety:
+ * - The database is opened READ-ONLY (`sqlite3 -readonly`). This code never
+ *   writes to the live store; doing so would corrupt CloudKit sync state.
+ * - Requires Full Disk Access for the host process.
+ * - The schema changes between macOS releases, so the reader feature-detects
+ *   which columns exist (PRAGMA table_info) and only selects those.
+ *
+ * @module utils/noteMetadata
+ * @see TECHNICAL_NOTES.md#read-only-metadata-columns-verified-macos-27--notes-413
+ */
+import { execFileSync } from "child_process";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+const NOTES_DB_PATH = path.join(os.homedir(), "Library/Group Containers/group.com.apple.notes/NoteStore.sqlite");
+const FDA_MESSAGE = "Full Disk Access is required to read note metadata. " +
+    "Grant access in System Settings > Privacy & Security > Full Disk Access, " +
+    "then add and restart this application.";
+/**
+ * Friendly field name -> NoteStore column. This is a fixed allowlist; nothing
+ * here is built from user input, so the column names are never an injection
+ * vector. `bool` columns store 0/1; `text` columns store strings.
+ */
+const COLUMN_MAP = [
+    { key: "pinned", column: "ZISPINNED", type: "bool" },
+    { key: "hasChecklist", column: "ZHASCHECKLIST", type: "bool" },
+    { key: "hasChecklistInProgress", column: "ZHASCHECKLISTINPROGRESS", type: "bool" },
+    { key: "recoveringFromTrash", column: "ZISRECOVERINGFROMTRASH", type: "bool" },
+    { key: "passwordProtected", column: "ZISPASSWORDPROTECTED", type: "bool" },
+    { key: "passwordHint", column: "ZPASSWORDHINT", type: "text" },
+    { key: "snippet", column: "ZSNIPPET", type: "text" },
+    { key: "widgetSnippet", column: "ZWIDGETSNIPPET", type: "text" },
+    { key: "smartFolderQuery", column: "ZSMARTFOLDERQUERYJSON", type: "text" },
+];
+/**
+ * Runs a read-only sqlite3 query against the live NoteStore and returns trimmed
+ * stdout. Throws on failure (callers classify the error).
+ *
+ * Uses execFileSync with an argument array (no shell), so the database path's
+ * spaces and the query string are passed verbatim and shell metacharacters are
+ * never interpreted. The only dynamic value in any query is the note's primary
+ * key, which callers constrain to digits before it reaches here.
+ */
+function runSqlite(query) {
+    return execFileSync("sqlite3", ["-readonly", NOTES_DB_PATH, query], {
+        encoding: "utf8",
+        timeout: 5000,
+        stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+}
+/**
+ * Returns the set of column names present on ZICCLOUDSYNCINGOBJECT, so the
+ * reader can skip columns that do not exist on this macOS version.
+ */
+function presentColumns() {
+    const out = runSqlite("PRAGMA table_info(ZICCLOUDSYNCINGOBJECT);");
+    const cols = new Set();
+    for (const line of out.split("\n")) {
+        // Each row: cid|name|type|notnull|dflt_value|pk
+        const name = line.split("|")[1];
+        if (name)
+            cols.add(name);
+    }
+    return cols;
+}
+/**
+ * Reads read-only metadata for a note by its CoreData ID.
+ *
+ * @param noteId - CoreData URL identifier (e.g., "x-coredata://ABC/ICNote/p123")
+ * @returns Structured result with the metadata, an error type, and a message
+ */
+export function getNoteMetadata(noteId) {
+    const pkMatch = noteId.match(/\/p(\d+)$/);
+    if (!pkMatch) {
+        return {
+            metadata: null,
+            error: "invalid_id",
+            message: `Invalid note ID format: "${noteId}". Expected format: x-coredata://UUID/ICNote/pNNN`,
+        };
+    }
+    const pk = pkMatch[1];
+    if (!fs.existsSync(NOTES_DB_PATH)) {
+        return { metadata: null, error: "no_fda", message: FDA_MESSAGE };
+    }
+    try {
+        const available = presentColumns();
+        const selected = COLUMN_MAP.filter((c) => available.has(c.column));
+        if (selected.length === 0) {
+            // Schema has none of the known columns (very old or very new macOS).
+            return { metadata: {} };
+        }
+        const pairs = selected.map((c) => `'${c.key}', ${c.column}`).join(", ");
+        const row = runSqlite(`SELECT json_object(${pairs}) FROM ZICCLOUDSYNCINGOBJECT WHERE Z_PK = ${pk};`);
+        if (!row) {
+            return {
+                metadata: null,
+                error: "not_found",
+                message: `No note found in the database for ID "${noteId}".`,
+            };
+        }
+        const raw = JSON.parse(row);
+        const metadata = {};
+        for (const c of selected) {
+            const value = raw[c.key];
+            if (value === null || value === undefined)
+                continue;
+            if (c.type === "bool") {
+                metadata[c.key] = value === 1 || value === "1" || value === true;
+            }
+            else {
+                metadata[c.key] = String(value);
+            }
+        }
+        return { metadata: metadata };
+    }
+    catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (message.includes("authorization denied") || message.includes("unable to open database")) {
+            return { metadata: null, error: "no_fda", message: FDA_MESSAGE };
+        }
+        console.error(`Failed to read note metadata: ${message}`);
+        return { metadata: null, error: "query_error", message: "Failed to read note metadata." };
+    }
+}

--- a/build/utils/noteMetadata.test.js
+++ b/build/utils/noteMetadata.test.js
@@ -1,0 +1,106 @@
+/**
+ * Tests for the read-only note metadata reader.
+ *
+ * The NoteStore SQLite access is mocked, so these exercise the pk extraction,
+ * column feature-detection, JSON parsing, boolean coercion, and error
+ * classification without touching a real database.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+vi.mock("child_process", () => ({
+    execFileSync: vi.fn(),
+}));
+vi.mock("fs", () => ({
+    existsSync: vi.fn(() => true),
+}));
+import { execFileSync } from "child_process";
+import { existsSync } from "fs";
+import { getNoteMetadata } from "./noteMetadata.js";
+const mockExecFileSync = vi.mocked(execFileSync);
+const mockExistsSync = vi.mocked(existsSync);
+const NOTE_ID = "x-coredata://ABC/ICNote/p123";
+/** Builds a PRAGMA table_info dump from a list of column names. */
+function tableInfo(columns) {
+    return columns.map((name, i) => `${i}|${name}|INTEGER|0||0`).join("\n");
+}
+/** The query string is the third sqlite3 argument: [-readonly, dbPath, query]. */
+function queryOf(call) {
+    const args = call[1];
+    return args[2];
+}
+describe("getNoteMetadata", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockExistsSync.mockReturnValue(true);
+    });
+    it("rejects a malformed note id without touching the database", () => {
+        const result = getNoteMetadata("not-a-real-id");
+        expect(result.metadata).toBeNull();
+        expect(result.error).toBe("invalid_id");
+        expect(mockExecFileSync).not.toHaveBeenCalled();
+    });
+    it("reads pinned/checklist/snippet and coerces 0/1 to booleans", () => {
+        mockExecFileSync.mockImplementation((_cmd, args) => {
+            const query = args[2];
+            if (query.includes("table_info")) {
+                return tableInfo(["Z_PK", "ZISPINNED", "ZHASCHECKLIST", "ZSNIPPET", "ZPASSWORDHINT"]);
+            }
+            return JSON.stringify({
+                pinned: 1,
+                hasChecklist: 0,
+                snippet: "Hello world",
+                passwordHint: null,
+            });
+        });
+        const result = getNoteMetadata(NOTE_ID);
+        expect(result.error).toBeUndefined();
+        expect(result.metadata).toEqual({
+            pinned: true,
+            hasChecklist: false,
+            snippet: "Hello world",
+        });
+        // A NULL column (passwordHint) is omitted, not included as null.
+        expect(result.metadata).not.toHaveProperty("passwordHint");
+    });
+    it("only selects columns that exist on this schema", () => {
+        mockExecFileSync.mockImplementation((_cmd, args) => {
+            const query = args[2];
+            if (query.includes("table_info"))
+                return tableInfo(["Z_PK", "ZISPINNED"]);
+            return JSON.stringify({ pinned: 1 });
+        });
+        const result = getNoteMetadata(NOTE_ID);
+        expect(result.metadata).toEqual({ pinned: true });
+        // The SELECT must not reference a column the schema lacks.
+        const selectCall = mockExecFileSync.mock.calls.find((c) => queryOf(c).includes("json_object"));
+        expect(selectCall).toBeDefined();
+        expect(queryOf(selectCall)).toContain("ZISPINNED");
+        expect(queryOf(selectCall)).not.toContain("ZSNIPPET");
+    });
+    it("returns not_found when no row matches the primary key", () => {
+        mockExecFileSync.mockImplementation((_cmd, args) => {
+            const query = args[2];
+            if (query.includes("table_info"))
+                return tableInfo(["Z_PK", "ZISPINNED"]);
+            return "";
+        });
+        const result = getNoteMetadata(NOTE_ID);
+        expect(result.metadata).toBeNull();
+        expect(result.error).toBe("not_found");
+    });
+    it("classifies a Full Disk Access denial", () => {
+        mockExecFileSync.mockImplementation(() => {
+            throw new Error("Error: authorization denied");
+        });
+        const result = getNoteMetadata(NOTE_ID);
+        expect(result.metadata).toBeNull();
+        expect(result.error).toBe("no_fda");
+        expect(result.message).toContain("Full Disk Access");
+    });
+    it("returns no_fda when the database file is missing", () => {
+        mockExistsSync.mockReturnValue(false);
+        const result = getNoteMetadata(NOTE_ID);
+        expect(result.metadata).toBeNull();
+        expect(result.error).toBe("no_fda");
+        expect(mockExecFileSync).not.toHaveBeenCalled();
+    });
+});

--- a/build/utils/protobuf.js
+++ b/build/utils/protobuf.js
@@ -1,0 +1,151 @@
+/**
+ * Minimal Protobuf Wire Format Decoder
+ *
+ * Decodes raw protobuf binary data without requiring a .proto schema file.
+ * Only implements the subset of wire types needed for reading Apple Notes
+ * checklist state from the NoteStore protobuf format.
+ *
+ * Wire types supported:
+ * - 0: Varint (integers, booleans)
+ * - 2: Length-delimited (strings, bytes, embedded messages)
+ *
+ * @module utils/protobuf
+ */
+/**
+ * Protobuf wire types used in Apple Notes data.
+ */
+export const WIRE_TYPE = {
+    VARINT: 0,
+    LENGTH_DELIMITED: 2,
+};
+/**
+ * Decodes a varint from the buffer at the given offset.
+ *
+ * Varints use 7 bits per byte with the high bit as a continuation flag.
+ * Supports up to 64-bit values (though we only need small integers).
+ *
+ * @param buf - The protobuf binary data
+ * @param offset - Starting byte position
+ * @returns Tuple of [decoded value, new offset after the varint]
+ */
+export function decodeVarint(buf, offset) {
+    let result = 0;
+    let shift = 0;
+    let pos = offset;
+    while (pos < buf.length) {
+        const byte = buf[pos];
+        result |= (byte & 0x7f) << shift;
+        pos++;
+        if ((byte & 0x80) === 0) {
+            return [result, pos];
+        }
+        shift += 7;
+        if (shift > 35) {
+            // For our use case (small field numbers, small integers),
+            // values requiring more than 35 bits are unexpected
+            throw new Error(`Varint too long at offset ${offset}`);
+        }
+    }
+    throw new Error(`Unexpected end of buffer reading varint at offset ${offset}`);
+}
+/**
+ * Decodes all fields from a protobuf message buffer.
+ *
+ * Iterates through the buffer, decoding tag-value pairs. Unknown wire types
+ * cause parsing to stop (returns fields decoded so far).
+ *
+ * @param buf - The protobuf binary data
+ * @returns Array of decoded fields in order
+ */
+export function decodeMessage(buf) {
+    const fields = [];
+    let offset = 0;
+    while (offset < buf.length) {
+        let tag;
+        [tag, offset] = decodeVarint(buf, offset);
+        const fieldNumber = tag >>> 3;
+        const wireType = tag & 0x07;
+        if (wireType === WIRE_TYPE.VARINT) {
+            let value;
+            [value, offset] = decodeVarint(buf, offset);
+            fields.push({ fieldNumber, wireType, value });
+        }
+        else if (wireType === WIRE_TYPE.LENGTH_DELIMITED) {
+            let length;
+            [length, offset] = decodeVarint(buf, offset);
+            if (offset + length > buf.length) {
+                break; // Truncated data, return what we have
+            }
+            const value = buf.slice(offset, offset + length);
+            fields.push({ fieldNumber, wireType, value });
+            offset += length;
+        }
+        else if (wireType === 5) {
+            // 32-bit fixed — skip 4 bytes
+            offset += 4;
+        }
+        else if (wireType === 1) {
+            // 64-bit fixed — skip 8 bytes
+            offset += 8;
+        }
+        else {
+            // Unknown wire type — stop parsing
+            break;
+        }
+    }
+    return fields;
+}
+/**
+ * Gets all fields with a specific field number from decoded message fields.
+ *
+ * @param fields - Decoded protobuf fields
+ * @param fieldNumber - The field number to filter for
+ * @returns Matching fields
+ */
+export function getFields(fields, fieldNumber) {
+    return fields.filter((f) => f.fieldNumber === fieldNumber);
+}
+/**
+ * Gets the first field with a specific field number.
+ *
+ * @param fields - Decoded protobuf fields
+ * @param fieldNumber - The field number to find
+ * @returns The first matching field, or undefined
+ */
+export function getField(fields, fieldNumber) {
+    return fields.find((f) => f.fieldNumber === fieldNumber);
+}
+/**
+ * Extracts the varint value from a field, returning undefined if not a varint.
+ */
+export function varintValue(field) {
+    if (!field || typeof field.value !== "number")
+        return undefined;
+    return field.value;
+}
+/**
+ * Extracts the bytes value from a field, returning undefined if not length-delimited.
+ */
+export function bytesValue(field) {
+    if (!field || !(field.value instanceof Uint8Array))
+        return undefined;
+    return field.value;
+}
+/**
+ * Decodes a length-delimited field as a UTF-8 string.
+ */
+export function stringValue(field) {
+    const bytes = bytesValue(field);
+    if (!bytes)
+        return undefined;
+    return new TextDecoder().decode(bytes);
+}
+/**
+ * Decodes a length-delimited field as an embedded message.
+ */
+export function embeddedMessage(field) {
+    const bytes = bytesValue(field);
+    if (!bytes)
+        return undefined;
+    return decodeMessage(bytes);
+}

--- a/build/utils/protobuf.test.js
+++ b/build/utils/protobuf.test.js
@@ -1,0 +1,138 @@
+/**
+ * Tests for the minimal protobuf wire format decoder.
+ */
+import { describe, it, expect } from "vitest";
+import { decodeVarint, decodeMessage, getField, getFields, varintValue, bytesValue, stringValue, embeddedMessage, WIRE_TYPE, } from "./protobuf.js";
+describe("decodeVarint", () => {
+    it("decodes single-byte varint", () => {
+        // 0x08 = field 1, varint; 0x05 = value 5
+        const [value, offset] = decodeVarint(new Uint8Array([5]), 0);
+        expect(value).toBe(5);
+        expect(offset).toBe(1);
+    });
+    it("decodes multi-byte varint", () => {
+        // 300 = 0xAC 0x02
+        const [value, offset] = decodeVarint(new Uint8Array([0xac, 0x02]), 0);
+        expect(value).toBe(300);
+        expect(offset).toBe(2);
+    });
+    it("decodes varint at non-zero offset", () => {
+        const [value, offset] = decodeVarint(new Uint8Array([0xff, 0x03]), 1);
+        expect(value).toBe(3);
+        expect(offset).toBe(2);
+    });
+    it("decodes zero", () => {
+        const [value, offset] = decodeVarint(new Uint8Array([0x00]), 0);
+        expect(value).toBe(0);
+        expect(offset).toBe(1);
+    });
+    it("throws on truncated varint", () => {
+        expect(() => decodeVarint(new Uint8Array([0x80]), 0)).toThrow("Unexpected end of buffer");
+    });
+});
+describe("decodeMessage", () => {
+    it("decodes a message with a varint field", () => {
+        // Field 1, wire type 0 (varint), value 150
+        // Tag: (1 << 3) | 0 = 0x08
+        // Value: 150 = 0x96 0x01
+        const buf = new Uint8Array([0x08, 0x96, 0x01]);
+        const fields = decodeMessage(buf);
+        expect(fields).toHaveLength(1);
+        expect(fields[0].fieldNumber).toBe(1);
+        expect(fields[0].wireType).toBe(WIRE_TYPE.VARINT);
+        expect(fields[0].value).toBe(150);
+    });
+    it("decodes a message with a length-delimited field", () => {
+        // Field 2, wire type 2 (length-delimited), value "hi"
+        // Tag: (2 << 3) | 2 = 0x12
+        // Length: 2
+        // Data: 0x68 0x69 = "hi"
+        const buf = new Uint8Array([0x12, 0x02, 0x68, 0x69]);
+        const fields = decodeMessage(buf);
+        expect(fields).toHaveLength(1);
+        expect(fields[0].fieldNumber).toBe(2);
+        expect(fields[0].wireType).toBe(WIRE_TYPE.LENGTH_DELIMITED);
+        expect(fields[0].value).toBeInstanceOf(Uint8Array);
+        expect(new TextDecoder().decode(fields[0].value)).toBe("hi");
+    });
+    it("decodes multiple fields", () => {
+        // Field 1 varint=1, Field 2 varint=2
+        const buf = new Uint8Array([0x08, 0x01, 0x10, 0x02]);
+        const fields = decodeMessage(buf);
+        expect(fields).toHaveLength(2);
+        expect(fields[0].fieldNumber).toBe(1);
+        expect(fields[0].value).toBe(1);
+        expect(fields[1].fieldNumber).toBe(2);
+        expect(fields[1].value).toBe(2);
+    });
+    it("handles empty buffer", () => {
+        const fields = decodeMessage(new Uint8Array([]));
+        expect(fields).toHaveLength(0);
+    });
+    it("handles truncated length-delimited field gracefully", () => {
+        // Tag for field 2 length-delimited, length=10, but only 2 bytes of data
+        const buf = new Uint8Array([0x12, 0x0a, 0x68, 0x69]);
+        const fields = decodeMessage(buf);
+        // Should stop parsing rather than crash
+        expect(fields).toHaveLength(0);
+    });
+});
+describe("field accessors", () => {
+    // Build a test message with: field 1 = varint 42, field 2 = "hello", field 2 = "world"
+    const buf = new Uint8Array([
+        0x08,
+        0x2a, // field 1, varint, value 42
+        0x12,
+        0x05,
+        0x68,
+        0x65,
+        0x6c,
+        0x6c,
+        0x6f, // field 2, "hello"
+        0x12,
+        0x05,
+        0x77,
+        0x6f,
+        0x72,
+        0x6c,
+        0x64, // field 2, "world"
+    ]);
+    const fields = decodeMessage(buf);
+    it("getField returns first matching field", () => {
+        const f = getField(fields, 2);
+        expect(f).toBeDefined();
+        expect(new TextDecoder().decode(f.value)).toBe("hello");
+    });
+    it("getFields returns all matching fields", () => {
+        const matches = getFields(fields, 2);
+        expect(matches).toHaveLength(2);
+    });
+    it("getField returns undefined for missing field", () => {
+        expect(getField(fields, 99)).toBeUndefined();
+    });
+    it("varintValue extracts number", () => {
+        expect(varintValue(getField(fields, 1))).toBe(42);
+    });
+    it("varintValue returns undefined for non-varint", () => {
+        expect(varintValue(getField(fields, 2))).toBeUndefined();
+    });
+    it("bytesValue extracts Uint8Array", () => {
+        const bytes = bytesValue(getField(fields, 2));
+        expect(bytes).toBeInstanceOf(Uint8Array);
+        expect(bytes.length).toBe(5);
+    });
+    it("stringValue decodes UTF-8", () => {
+        expect(stringValue(getField(fields, 2))).toBe("hello");
+    });
+    it("embeddedMessage decodes nested message", () => {
+        // Create a field 1 containing an embedded message with field 1 = varint 7
+        const inner = new Uint8Array([0x08, 0x07]); // field 1, varint 7
+        // Wrap as field 1, length-delimited
+        const outer = new Uint8Array([0x0a, 0x02, ...inner]);
+        const outerFields = decodeMessage(outer);
+        const nested = embeddedMessage(getField(outerFields, 1));
+        expect(nested).toBeDefined();
+        expect(nested).toHaveLength(1);
+        expect(varintValue(getField(nested, 1))).toBe(7);
+    });
+});

--- a/build/utils/syncDetection.js
+++ b/build/utils/syncDetection.js
@@ -1,0 +1,242 @@
+/**
+ * iCloud Sync Detection Utilities
+ *
+ * Detects when iCloud sync is in progress or has pending changes,
+ * allowing operations to warn users and verify results.
+ *
+ * Detection methods:
+ * 1. Query NoteStore.sqlite for pending sync changes (ZICCLOUDSTATE)
+ * 2. Check for recent database transaction activity
+ * 3. Monitor WAL file modification time
+ *
+ * @module utils/syncDetection
+ */
+import { execFileSync } from "child_process";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+const NOTES_DB_PATH = path.join(os.homedir(), "Library/Group Containers/group.com.apple.notes/NoteStore.sqlite");
+const WAL_PATH = `${NOTES_DB_PATH}-wal`;
+// How recent (in seconds) activity must be to be considered "active sync"
+const RECENT_ACTIVITY_THRESHOLD_SECONDS = 5;
+// Delay between operation and verification read (ms)
+const VERIFICATION_DELAY_MS = 500;
+// Cache TTL in milliseconds (2 seconds default)
+const SYNC_STATUS_CACHE_TTL_MS = 2000;
+// Cached sync status
+let cachedSyncStatus = null;
+let cacheTimestamp = 0;
+/**
+ * Clears the sync status cache.
+ * Useful for testing or when forcing a fresh check.
+ */
+export function clearSyncStatusCache() {
+    cachedSyncStatus = null;
+    cacheTimestamp = 0;
+}
+/**
+ * Gets the current iCloud sync status by querying the Notes database.
+ *
+ * Results are cached for 2 seconds to avoid excessive database queries
+ * during rapid successive operations.
+ *
+ * @param useCache - Whether to use cached results (default: true)
+ * @returns Sync status information
+ */
+export function getSyncStatus(useCache = true) {
+    // Return cached result if valid
+    if (useCache && cachedSyncStatus && Date.now() - cacheTimestamp < SYNC_STATUS_CACHE_TTL_MS) {
+        return cachedSyncStatus;
+    }
+    const status = {
+        syncDetected: false,
+        pendingUpload: 0,
+        secondsSinceLastChange: Infinity,
+        recentActivity: false,
+    };
+    try {
+        // Check if database exists
+        if (!fs.existsSync(NOTES_DB_PATH)) {
+            status.error = "Notes database not found";
+            cachedSyncStatus = status;
+            cacheTimestamp = Date.now();
+            return status;
+        }
+        // Check WAL file modification time for recent activity
+        if (fs.existsSync(WAL_PATH)) {
+            const walStats = fs.statSync(WAL_PATH);
+            const secondsAgo = (Date.now() - walStats.mtimeMs) / 1000;
+            status.secondsSinceLastChange = Math.round(secondsAgo);
+            status.recentActivity = secondsAgo < RECENT_ACTIVITY_THRESHOLD_SECONDS;
+        }
+        // Query for pending sync changes
+        // Use a read-only connection and timeout to avoid blocking
+        const query = `
+      SELECT COUNT(*) FROM ZICCLOUDSTATE
+      WHERE ZCURRENTLOCALVERSION > ZLATESTVERSIONSYNCEDTOCLOUD
+      AND ZLATESTVERSIONSYNCEDTOCLOUD IS NOT NULL;
+    `;
+        // Use execFileSync (argv array, no shell) to match the sibling sqlite callers
+        // (checklistParser.ts, noteMetadata.ts). The values here aren't user-controlled,
+        // but argv form avoids shell quoting/interpolation entirely.
+        const result = execFileSync("sqlite3", ["-readonly", NOTES_DB_PATH, query.replace(/\n/g, " ")], {
+            encoding: "utf8",
+            timeout: 5000,
+            stdio: ["pipe", "pipe", "pipe"],
+        });
+        status.pendingUpload = parseInt(result.trim(), 10) || 0;
+        // Determine if sync is detected
+        status.syncDetected = status.pendingUpload > 0 || status.recentActivity;
+        // Generate warning message
+        if (status.syncDetected) {
+            const reasons = [];
+            if (status.pendingUpload > 0) {
+                reasons.push(`${status.pendingUpload} item(s) pending upload`);
+            }
+            if (status.recentActivity) {
+                reasons.push(`database modified ${status.secondsSinceLastChange}s ago`);
+            }
+            status.warning = `iCloud sync in progress: ${reasons.join(", ")}. Results may be incomplete or change shortly.`;
+        }
+    }
+    catch (error) {
+        // Don't fail the operation due to sync detection errors
+        status.error = error instanceof Error ? error.message : "Failed to check sync status";
+    }
+    // Cache the result
+    cachedSyncStatus = status;
+    cacheTimestamp = Date.now();
+    return status;
+}
+/**
+ * Logs a sync warning if sync is detected.
+ *
+ * @param status - The sync status to check
+ * @param operation - Name of the operation being performed
+ */
+export function logSyncWarning(status, operation) {
+    if (status.warning) {
+        console.error(`[Sync Warning] ${operation}: ${status.warning}`);
+    }
+}
+/**
+ * Wraps an async operation with sync detection and verification.
+ *
+ * 1. Checks sync status before the operation
+ * 2. Logs a warning if sync is detected
+ * 3. Executes the operation
+ * 4. Waits briefly and checks sync status again
+ * 5. Determines if sync may have interfered
+ *
+ * @param operation - Name of the operation (for logging)
+ * @param fn - The async operation to execute
+ * @returns Result with sync status information
+ */
+export async function withSyncAwareness(operation, fn) {
+    // Check sync status before operation
+    const syncBefore = getSyncStatus();
+    // Log warning if sync detected
+    if (syncBefore.syncDetected) {
+        logSyncWarning(syncBefore, operation);
+    }
+    // Execute the operation
+    const result = await fn();
+    // Wait briefly for any sync activity to settle
+    await new Promise((resolve) => setTimeout(resolve, VERIFICATION_DELAY_MS));
+    // Check sync status after operation (bypass cache for fresh data)
+    const syncAfter = getSyncStatus(false);
+    // Determine if sync may have interfered
+    // Interference is likely if:
+    // 1. Sync was active before and pending count changed
+    // 2. Database was modified during the operation
+    const pendingChanged = syncBefore.pendingUpload !== syncAfter.pendingUpload;
+    const wasRecentBefore = syncBefore.recentActivity;
+    const isRecentAfter = syncAfter.recentActivity;
+    const syncInterference = (syncBefore.syncDetected && pendingChanged) || (wasRecentBefore && isRecentAfter);
+    let interferenceWarning;
+    if (syncInterference) {
+        interferenceWarning =
+            `iCloud sync activity detected during "${operation}". ` +
+                `Pending items: ${syncBefore.pendingUpload} → ${syncAfter.pendingUpload}. ` +
+                `Results may have been affected by sync.`;
+        console.error(`[Sync Interference] ${interferenceWarning}`);
+    }
+    return {
+        result,
+        syncBefore,
+        syncAfter,
+        syncInterference,
+        interferenceWarning,
+    };
+}
+/**
+ * Wraps a sync operation with sync detection and verification.
+ * Synchronous version for AppleScript operations.
+ *
+ * @param operation - Name of the operation (for logging)
+ * @param fn - The sync operation to execute
+ * @returns Result with sync status information
+ */
+export function withSyncAwarenessSync(operation, fn) {
+    // Check sync status before operation
+    const syncBefore = getSyncStatus();
+    // Log warning if sync detected
+    if (syncBefore.syncDetected) {
+        logSyncWarning(syncBefore, operation);
+    }
+    // Execute the operation
+    const result = fn();
+    // Check sync status after operation (bypass cache for fresh data)
+    const syncAfter = getSyncStatus(false);
+    // Determine if sync may have interfered
+    const pendingChanged = syncBefore.pendingUpload !== syncAfter.pendingUpload;
+    const wasRecentBefore = syncBefore.recentActivity;
+    const isRecentAfter = syncAfter.recentActivity;
+    const syncInterference = (syncBefore.syncDetected && pendingChanged) || (wasRecentBefore && isRecentAfter);
+    let interferenceWarning;
+    if (syncInterference) {
+        interferenceWarning =
+            `iCloud sync activity detected during "${operation}". ` +
+                `Pending items: ${syncBefore.pendingUpload} → ${syncAfter.pendingUpload}. ` +
+                `Results may have been affected by sync.`;
+        console.error(`[Sync Interference] ${interferenceWarning}`);
+    }
+    return {
+        result,
+        syncBefore,
+        syncAfter,
+        syncInterference,
+        interferenceWarning,
+    };
+}
+/**
+ * Checks if sync is currently active.
+ * Convenience method for simple sync checks.
+ *
+ * @returns true if sync activity is detected
+ */
+export function isSyncActive() {
+    return getSyncStatus().syncDetected;
+}
+/**
+ * Gets a human-readable sync status summary.
+ *
+ * @returns Status summary string
+ */
+export function getSyncStatusSummary() {
+    const status = getSyncStatus();
+    if (status.error) {
+        return `Sync status unknown: ${status.error}`;
+    }
+    if (!status.syncDetected) {
+        return "iCloud sync: Idle";
+    }
+    const parts = ["iCloud sync: Active"];
+    if (status.pendingUpload > 0) {
+        parts.push(`${status.pendingUpload} pending upload(s)`);
+    }
+    if (status.recentActivity) {
+        parts.push(`last activity ${status.secondsSinceLastChange}s ago`);
+    }
+    return parts.join(" - ");
+}

--- a/build/utils/syncDetection.test.js
+++ b/build/utils/syncDetection.test.js
@@ -1,0 +1,228 @@
+/**
+ * Tests for iCloud Sync Detection Utilities
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getSyncStatus, logSyncWarning, withSyncAwareness, withSyncAwarenessSync, isSyncActive, getSyncStatusSummary, clearSyncStatusCache, } from "./syncDetection.js";
+// Mock child_process
+vi.mock("child_process", () => ({
+    execFileSync: vi.fn(),
+}));
+// Mock fs
+vi.mock("fs", () => ({
+    existsSync: vi.fn(),
+    statSync: vi.fn(),
+}));
+import { execFileSync } from "child_process";
+import * as fs from "fs";
+const mockExecSync = vi.mocked(execFileSync);
+const mockExistsSync = vi.mocked(fs.existsSync);
+const mockStatSync = vi.mocked(fs.statSync);
+describe("getSyncStatus", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        clearSyncStatusCache(); // Clear cache between tests
+    });
+    it("returns error when database not found", () => {
+        mockExistsSync.mockReturnValue(false);
+        const status = getSyncStatus();
+        expect(status.error).toBe("Notes database not found");
+        expect(status.syncDetected).toBe(false);
+    });
+    it("detects no sync activity when idle", () => {
+        mockExistsSync.mockReturnValue(true);
+        mockStatSync.mockReturnValue({
+            mtimeMs: Date.now() - 60000, // 60 seconds ago
+        });
+        mockExecSync.mockReturnValue("0\n");
+        const status = getSyncStatus();
+        expect(status.syncDetected).toBe(false);
+        expect(status.pendingUpload).toBe(0);
+        expect(status.recentActivity).toBe(false);
+        expect(status.warning).toBeUndefined();
+    });
+    it("detects pending uploads", () => {
+        mockExistsSync.mockReturnValue(true);
+        mockStatSync.mockReturnValue({
+            mtimeMs: Date.now() - 60000,
+        });
+        mockExecSync.mockReturnValue("5\n");
+        const status = getSyncStatus();
+        expect(status.syncDetected).toBe(true);
+        expect(status.pendingUpload).toBe(5);
+        expect(status.warning).toContain("5 item(s) pending upload");
+    });
+    it("detects recent database activity", () => {
+        mockExistsSync.mockReturnValue(true);
+        mockStatSync.mockReturnValue({
+            mtimeMs: Date.now() - 2000, // 2 seconds ago
+        });
+        mockExecSync.mockReturnValue("0\n");
+        const status = getSyncStatus();
+        expect(status.syncDetected).toBe(true);
+        expect(status.recentActivity).toBe(true);
+        expect(status.secondsSinceLastChange).toBeLessThan(5);
+        expect(status.warning).toContain("database modified");
+    });
+    it("detects both pending uploads and recent activity", () => {
+        mockExistsSync.mockReturnValue(true);
+        mockStatSync.mockReturnValue({
+            mtimeMs: Date.now() - 1000,
+        });
+        mockExecSync.mockReturnValue("3\n");
+        const status = getSyncStatus();
+        expect(status.syncDetected).toBe(true);
+        expect(status.pendingUpload).toBe(3);
+        expect(status.recentActivity).toBe(true);
+        expect(status.warning).toContain("3 item(s) pending upload");
+        expect(status.warning).toContain("database modified");
+    });
+    it("handles sqlite3 errors gracefully", () => {
+        mockExistsSync.mockReturnValue(true);
+        mockStatSync.mockReturnValue({
+            mtimeMs: Date.now() - 60000,
+        });
+        mockExecSync.mockImplementation(() => {
+            throw new Error("database is locked");
+        });
+        const status = getSyncStatus();
+        expect(status.error).toContain("database is locked");
+        expect(status.syncDetected).toBe(false);
+    });
+});
+describe("logSyncWarning", () => {
+    beforeEach(() => {
+        vi.spyOn(console, "error").mockImplementation(() => { });
+    });
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+    it("logs warning when sync detected", () => {
+        const status = {
+            syncDetected: true,
+            pendingUpload: 2,
+            secondsSinceLastChange: 3,
+            recentActivity: true,
+            warning: "iCloud sync in progress",
+        };
+        logSyncWarning(status, "test-operation");
+        expect(console.error).toHaveBeenCalledWith(expect.stringContaining("[Sync Warning]"));
+        expect(console.error).toHaveBeenCalledWith(expect.stringContaining("test-operation"));
+    });
+    it("does not log when no warning", () => {
+        const status = {
+            syncDetected: false,
+            pendingUpload: 0,
+            secondsSinceLastChange: 60,
+            recentActivity: false,
+        };
+        logSyncWarning(status, "test-operation");
+        expect(console.error).not.toHaveBeenCalled();
+    });
+});
+describe("withSyncAwareness", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        clearSyncStatusCache();
+        vi.spyOn(console, "error").mockImplementation(() => { });
+    });
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+    it("executes operation and returns result with sync info", async () => {
+        mockExistsSync.mockReturnValue(true);
+        mockStatSync.mockReturnValue({
+            mtimeMs: Date.now() - 60000,
+        });
+        mockExecSync.mockReturnValue("0\n");
+        const result = await withSyncAwareness("test", async () => "success");
+        expect(result.result).toBe("success");
+        expect(result.syncBefore).toBeDefined();
+        expect(result.syncAfter).toBeDefined();
+        expect(result.syncInterference).toBe(false);
+    });
+    it("detects sync interference when pending count changes", async () => {
+        mockExistsSync.mockReturnValue(true);
+        mockStatSync.mockReturnValue({
+            mtimeMs: Date.now() - 1000,
+        });
+        // First call: 5 pending, second call: 3 pending
+        mockExecSync.mockReturnValueOnce("5\n").mockReturnValueOnce("3\n");
+        const result = await withSyncAwareness("test", async () => "data");
+        expect(result.syncBefore.pendingUpload).toBe(5);
+        expect(result.syncAfter?.pendingUpload).toBe(3);
+        expect(result.syncInterference).toBe(true);
+        expect(result.interferenceWarning).toContain("sync activity detected");
+    });
+});
+describe("withSyncAwarenessSync", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        clearSyncStatusCache();
+        vi.spyOn(console, "error").mockImplementation(() => { });
+    });
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+    it("executes sync operation with sync awareness", () => {
+        mockExistsSync.mockReturnValue(true);
+        mockStatSync.mockReturnValue({
+            mtimeMs: Date.now() - 60000,
+        });
+        mockExecSync.mockReturnValue("0\n");
+        const result = withSyncAwarenessSync("test", () => 42);
+        expect(result.result).toBe(42);
+        expect(result.syncBefore).toBeDefined();
+        expect(result.syncAfter).toBeDefined();
+    });
+});
+describe("isSyncActive", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        clearSyncStatusCache();
+    });
+    it("returns true when sync is active", () => {
+        mockExistsSync.mockReturnValue(true);
+        mockStatSync.mockReturnValue({
+            mtimeMs: Date.now() - 2000,
+        });
+        mockExecSync.mockReturnValue("0\n");
+        expect(isSyncActive()).toBe(true);
+    });
+    it("returns false when sync is idle", () => {
+        mockExistsSync.mockReturnValue(true);
+        mockStatSync.mockReturnValue({
+            mtimeMs: Date.now() - 60000,
+        });
+        mockExecSync.mockReturnValue("0\n");
+        expect(isSyncActive()).toBe(false);
+    });
+});
+describe("getSyncStatusSummary", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        clearSyncStatusCache();
+    });
+    it("returns idle message when no sync activity", () => {
+        mockExistsSync.mockReturnValue(true);
+        mockStatSync.mockReturnValue({
+            mtimeMs: Date.now() - 60000,
+        });
+        mockExecSync.mockReturnValue("0\n");
+        expect(getSyncStatusSummary()).toBe("iCloud sync: Idle");
+    });
+    it("returns active message with details", () => {
+        mockExistsSync.mockReturnValue(true);
+        mockStatSync.mockReturnValue({
+            mtimeMs: Date.now() - 2000,
+        });
+        mockExecSync.mockReturnValue("3\n");
+        const summary = getSyncStatusSummary();
+        expect(summary).toContain("iCloud sync: Active");
+        expect(summary).toContain("3 pending upload(s)");
+    });
+    it("returns error message when detection fails", () => {
+        mockExistsSync.mockReturnValue(false);
+        const summary = getSyncStatusSummary();
+        expect(summary).toContain("Sync status unknown");
+    });
+});


### PR DESCRIPTION
## What

Stop gitignoring `build/` and commit the compiled output, matching **apple-mail-mcp** and **apple-numbers-mcp** (both already track `build/`).

Concretely:
- `.gitignore`: replace the `build/` ignore with `!build/` + `!build/**` (overriding the global `~/.gitignore build/` rule), using the same comment/wording as mail+numbers.
- Commit the compiled `build/` output.

## Why

The repo's `.claude-plugin/plugin.json` launches `node ${CLAUDE_PLUGIN_ROOT}/build/index.js` directly. Claude Code does **not** run an install/build step for a git- or marketplace-installed plugin, so `build/` must be committed for those installs to work. mail and numbers already do this; notes was the outlier.

## No version bump

Build-infra/hygiene only — no `src/**` change and no runtime behavior change, so this does **not** bump `package.json`. `version-guard`/`require-version-bump` exempts non-`src` changes, so that check passes without a bump. `publish.yml` will see the version unchanged and skip publishing — npm stays at the current version (no accidental release).