### PR TITLE
Fix list-attachments always returning empty: reserved word `item` broke script compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.9] - 2026-07-06
+### Fixed
+- **`list-attachments` always returned an empty list.** Both `listAttachmentsById` and `listAttachments` built their output with `repeat with item in attachmentList`; `item` is an AppleScript class name, so the generated script failed to compile ("Expected variable name or property but found class name", -2741) and every call surfaced as zero attachments. The silent empty array defeated the attachment-safety check callers are told to run before `update-note`, which replaces the whole body and drops attachments. The loop variable is renamed, and a regression test now inspects the generated script for reserved loop variables, which the mocked unit tests cannot catch on their own. (#72)
+- **`url` no longer leaks the literal string `"missing value"`.** `URL of a as text` renders as `missing value` for attachments without a URL (most images); the parsed `url` field is now absent in that case. (#72)
+
 ## [2.5.8] - 2026-07-06
 ### Added
 - **Process-wide reliability knobs for AppleScript execution** (thanks [@oliverames](https://github.com/oliverames), #70). Three env vars now tune the AppleScript layer without a per-call override: `APPLE_NOTES_MCP_TIMEOUT_MS` (default `30000`) raises the per-call timeout for full-library operations on very large Notes libraries; `APPLE_NOTES_MCP_MAX_RETRIES` (default `2`, i.e. one retry) sets the total attempt count for transient failures, with `1` restoring the old fail-fast behavior; `APPLE_NOTES_MCP_RETRY_DELAY_MS` (default `1000`) sets the base retry delay before exponential back-off. Precedence is per-call options → env knob → built-in default; invalid values fall through to the default. A shared `envPositiveNumber()` helper validates all of them (and the existing `APPLE_NOTES_MCP_MAX_BUFFER`) the same way. Documented in the README.

--- a/build/index.js
+++ b/build/index.js
@@ -39282,6 +39282,10 @@ function buildAppleScriptDateVar(date3, varName = "thresholdDate") {
 function asDatePartsExpr(v) {
   return `((year of ${v}) as text) & "-" & ((month of ${v}) as integer as text) & "-" & ((day of ${v}) as text) & "-" & ((hours of ${v}) as text) & "-" & ((minutes of ${v}) as text) & "-" & ((seconds of ${v}) as text)`;
 }
+function normalizeAppleScriptText(field) {
+  const trimmed = field?.trim();
+  return trimmed && trimmed !== "missing value" ? trimmed : void 0;
+}
 function parseNotePropertiesOutput(output) {
   const parts = output.split(FIELD_SEP);
   if (parts.length < 6) {
@@ -40737,8 +40741,8 @@ var AppleNotesManager = class {
           set end of attachmentList to attachId & ${AS_FIELD_SEP} & attachName & ${AS_FIELD_SEP} & attachContentId & ${AS_FIELD_SEP} & attachUrl & ${AS_FIELD_SEP} & createdParts & ${AS_FIELD_SEP} & modifiedParts & ${AS_FIELD_SEP} & sharedFlag
         end repeat
         set output to ""
-        repeat with item in attachmentList
-          set output to output & item & ${AS_RECORD_SEP}
+        repeat with recordItem in attachmentList
+          set output to output & recordItem & ${AS_RECORD_SEP}
         end repeat
         return output
       end tell
@@ -40760,7 +40764,7 @@ var AppleNotesManager = class {
           name: parts[1].trim(),
           contentType: parts[2].trim(),
           contentId: parts[2].trim() || void 0,
-          url: parts[3]?.trim() || void 0,
+          url: normalizeAppleScriptText(parts[3]),
           created: parts[4] ? parseAppleScriptDate(parts[4].trim()) : void 0,
           modified: parts[5] ? parseAppleScriptDate(parts[5].trim()) : void 0,
           shared: parts[6] ? parts[6].trim().toLowerCase() === "true" : void 0
@@ -40801,8 +40805,8 @@ var AppleNotesManager = class {
           set end of attachmentList to attachId & ${AS_FIELD_SEP} & attachName & ${AS_FIELD_SEP} & attachContentId & ${AS_FIELD_SEP} & attachUrl & ${AS_FIELD_SEP} & createdParts & ${AS_FIELD_SEP} & modifiedParts & ${AS_FIELD_SEP} & sharedFlag
         end repeat
           set output to ""
-          repeat with item in attachmentList
-            set output to output & item & ${AS_RECORD_SEP}
+          repeat with recordItem in attachmentList
+            set output to output & recordItem & ${AS_RECORD_SEP}
           end repeat
           return output
         end tell
@@ -40825,7 +40829,7 @@ var AppleNotesManager = class {
           name: parts[1].trim(),
           contentType: parts[2].trim(),
           contentId: parts[2].trim() || void 0,
-          url: parts[3]?.trim() || void 0,
+          url: normalizeAppleScriptText(parts[3]),
           created: parts[4] ? parseAppleScriptDate(parts[4].trim()) : void 0,
           modified: parts[5] ? parseAppleScriptDate(parts[5].trim()) : void 0,
           shared: parts[6] ? parts[6].trim().toLowerCase() === "true" : void 0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes-mcp",
-  "version": "2.5.8",
+  "version": "2.5.9",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Notes - create, search, update, and manage notes via Claude and other AI assistants",
   "type": "module",

--- a/src/services/appleNotesManager.test.ts
+++ b/src/services/appleNotesManager.test.ts
@@ -2571,6 +2571,42 @@ describe("AppleNotesManager", () => {
         expect.stringContaining('note id "x-coredata://ABC/ICNote/p123"')
       );
     });
+
+    it("does not use the reserved word `item` as a repeat loop variable", () => {
+      // Regression: `repeat with item in ...` fails to COMPILE ("Expected
+      // variable name or property but found class name", -2741), so every
+      // list-attachments call errored and surfaced as an empty array.
+      mockExecuteAppleScript.mockReturnValueOnce({ success: true, output: "" });
+
+      manager.listAttachmentsById("x-coredata://ABC/ICNote/p123");
+
+      const script = mockExecuteAppleScript.mock.calls[0][0] as string;
+      expect(script).not.toMatch(/repeat with item\b/);
+      expect(script).toContain("repeat with recordItem in attachmentList");
+    });
+
+    it("normalizes a 'missing value' URL to undefined", () => {
+      // `URL of a as text` renders as the literal string "missing value" for
+      // attachments without a URL (most images); that sentinel must not leak
+      // into the parsed url field.
+      mockExecuteAppleScript.mockReturnValueOnce({
+        success: true,
+        output: [
+          "x-coredata://ABC/ICAttachment/p1",
+          "photo.png",
+          "cid:abc",
+          "missing value",
+          "2026-7-5-22-7-39",
+          "2026-7-5-22-7-39",
+          "false",
+        ].join(F),
+      });
+
+      const attachments = manager.listAttachmentsById("x-coredata://ABC/ICNote/p123");
+
+      expect(attachments).toHaveLength(1);
+      expect(attachments[0].url).toBeUndefined();
+    });
   });
 
   describe("listAttachments", () => {

--- a/src/services/appleNotesManager.ts
+++ b/src/services/appleNotesManager.ts
@@ -351,6 +351,18 @@ export function asDatePartsExpr(v: string): string {
 }
 
 /**
+ * Normalizes an optional AppleScript text field: trims it and converts the
+ * literal "missing value" (what `URL of a as text` yields when the property is
+ * unset) to undefined, so callers never see the sentinel string as data.
+ *
+ * @param field - raw field text from the AppleScript record, if any
+ */
+function normalizeAppleScriptText(field: string | undefined): string | undefined {
+  const trimmed = field?.trim();
+  return trimmed && trimmed !== "missing value" ? trimmed : undefined;
+}
+
+/**
  * Parsed note properties from AppleScript output.
  */
 interface ParsedNoteProperties {
@@ -2289,8 +2301,8 @@ export class AppleNotesManager {
           set end of attachmentList to attachId & ${AS_FIELD_SEP} & attachName & ${AS_FIELD_SEP} & attachContentId & ${AS_FIELD_SEP} & attachUrl & ${AS_FIELD_SEP} & createdParts & ${AS_FIELD_SEP} & modifiedParts & ${AS_FIELD_SEP} & sharedFlag
         end repeat
         set output to ""
-        repeat with item in attachmentList
-          set output to output & item & ${AS_RECORD_SEP}
+        repeat with recordItem in attachmentList
+          set output to output & recordItem & ${AS_RECORD_SEP}
         end repeat
         return output
       end tell
@@ -2316,7 +2328,7 @@ export class AppleNotesManager {
           name: parts[1].trim(),
           contentType: parts[2].trim(),
           contentId: parts[2].trim() || undefined,
-          url: parts[3]?.trim() || undefined,
+          url: normalizeAppleScriptText(parts[3]),
           created: parts[4] ? parseAppleScriptDate(parts[4].trim()) : undefined,
           modified: parts[5] ? parseAppleScriptDate(parts[5].trim()) : undefined,
           shared: parts[6] ? parts[6].trim().toLowerCase() === "true" : undefined,
@@ -2360,8 +2372,8 @@ export class AppleNotesManager {
           set end of attachmentList to attachId & ${AS_FIELD_SEP} & attachName & ${AS_FIELD_SEP} & attachContentId & ${AS_FIELD_SEP} & attachUrl & ${AS_FIELD_SEP} & createdParts & ${AS_FIELD_SEP} & modifiedParts & ${AS_FIELD_SEP} & sharedFlag
         end repeat
           set output to ""
-          repeat with item in attachmentList
-            set output to output & item & ${AS_RECORD_SEP}
+          repeat with recordItem in attachmentList
+            set output to output & recordItem & ${AS_RECORD_SEP}
           end repeat
           return output
         end tell
@@ -2388,7 +2400,7 @@ export class AppleNotesManager {
           name: parts[1].trim(),
           contentType: parts[2].trim(),
           contentId: parts[2].trim() || undefined,
-          url: parts[3]?.trim() || undefined,
+          url: normalizeAppleScriptText(parts[3]),
           created: parts[4] ? parseAppleScriptDate(parts[4].trim()) : undefined,
           modified: parts[5] ? parseAppleScriptDate(parts[5].trim()) : undefined,
           shared: parts[6] ? parts[6].trim().toLowerCase() === "true" : undefined,


### PR DESCRIPTION
## What happened

Both `listAttachmentsById` and `listAttachments` build their return value with a second loop, `repeat with item in attachmentList`. AppleScript refuses to compile that line because `item` is a class name ("Expected variable name or property but found class name", error -2741). Every list-attachments call has been failing before any Apple Event reached Notes, and the error handler turns that into an empty array.

The silent empty array is the part that worried me. The tool descriptions tell callers to run list-attachments as a safety check before `update-note`, which replaces the whole note body and drops attachments. A false zero waves that check through. I hit this on a real note with 7 images; the tool said 0 while `count of attachments` via osascript said 7.

## The fix

- Rename the loop variable to `recordItem` in both methods.
- Normalize the literal string `"missing value"` (what `URL of a as text` yields when an attachment has no URL, which is most images) to `undefined` in the parsed `url` field, so the sentinel doesn't leak into results.

## Tests

The unit tests mock `executeAppleScript`, so a compile-time failure in the generated script is invisible to them. I added a regression test that captures the generated script and asserts the reserved word isn't used as a loop variable, plus a parser test for the `"missing value"` URL case. `lint`, `format:check`, `test` (450), and `build` all pass.

## Verified live

macOS 27.0, Notes 4.13. Against the 7-attachment note: count 0 before the fix, 7 after, and `url` is absent instead of `"missing value"`. JSON-RPC probe against the built bundle confirms the same through the MCP surface.