### PR TITLE
Fix save-attachment: successful saves misreported as failures, plus path and error-clarity hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.10] - 2026-07-06
+### Fixed
+- **`save-attachment` misreported every successful save as "attachment not found".** The OK/ERR sentinel interpolated the field separator inside the AppleScript string literal (`return "OK${AS_FIELD_SEP}" & ...`), so the script returned the literal text `OK(ASCII character 31)...` instead of a control character and the TypeScript split never matched, even though the file landed on disk. Separators are now concatenated as expressions, matching the list methods; `show-attachment` had the same quirk in its ERR return and is fixed for consistency. A regression test inspects the generated script for separators inside string literals. (#73)
+- **`/private/tmp` destinations are allowed.** `allowedSaveRoots` accepted `/tmp` but rejected `/private/tmp`, the real directory behind macOS's `/tmp` symlink. (#73)
+- **Missing parent directories no longer fail the save.** Notes' `save` does not create intermediate directories and raised an opaque "Failed saving an attachment" error; the parent directory is now created up front. (#73)
+- **Link-preview attachments get a clear error.** Saving the rich preview Notes builds for a pasted URL raised a bare "AppleEvent handler failed"; the error now explains that link previews have no file payload and includes the preview's URL. (#73)
+
 ## [2.5.8] - 2026-07-06
 ### Added
 - **Process-wide reliability knobs for AppleScript execution** (thanks [@oliverames](https://github.com/oliverames), #70). Three env vars now tune the AppleScript layer without a per-call override: `APPLE_NOTES_MCP_TIMEOUT_MS` (default `30000`) raises the per-call timeout for full-library operations on very large Notes libraries; `APPLE_NOTES_MCP_MAX_RETRIES` (default `2`, i.e. one retry) sets the total attempt count for transient failures, with `1` restoring the old fail-fast behavior; `APPLE_NOTES_MCP_RETRY_DELAY_MS` (default `1000`) sets the base retry delay before exponential back-off. Precedence is per-call options → env knob → built-in default; invalid values fall through to the default. A shared `envPositiveNumber()` helper validates all of them (and the existing `APPLE_NOTES_MCP_MAX_BUFFER`) the same way. Documented in the README.

--- a/build/index.js
+++ b/build/index.js
@@ -39140,11 +39140,21 @@ function getChecklistItems(noteId) {
 }
 
 // src/utils/attachmentFs.ts
-import { existsSync as existsSync2, mkdtempSync, readFileSync, rmSync, statSync } from "fs";
-import { isAbsolute, resolve, sep } from "path";
+import { existsSync as existsSync2, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync } from "fs";
+import { dirname, isAbsolute, resolve, sep } from "path";
 import { homedir as homedir2, tmpdir } from "os";
 function allowedSaveRoots() {
-  return [resolve(homedir2()), resolve(tmpdir()), "/Volumes", "/private/var/folders", "/tmp"];
+  return [
+    resolve(homedir2()),
+    resolve(tmpdir()),
+    "/Volumes",
+    "/private/var/folders",
+    "/tmp",
+    "/private/tmp"
+  ];
+}
+function ensureParentDir(abs) {
+  mkdirSync(dirname(abs), { recursive: true });
 }
 function assertSafeSavePath(p, roots = allowedSaveRoots()) {
   if (!p || !p.trim()) throw new Error("A destination path is required.");
@@ -40471,7 +40481,7 @@ var AppleNotesManager = class {
           end if
         end repeat
         if theAttachment is missing value then
-          return "ERR${AS_FIELD_SEP}attachment not found"
+          return "ERR" & ${AS_FIELD_SEP} & "attachment not found"
         end if
         show theAttachment${separatelyClause}
         return "OK"
@@ -40847,6 +40857,7 @@ var AppleNotesManager = class {
     let abs;
     try {
       abs = assertSafeSavePath(savePath);
+      ensureParentDir(abs);
     } catch (e) {
       return { success: false, error: e instanceof Error ? e.message : String(e) };
     }
@@ -40864,10 +40875,18 @@ var AppleNotesManager = class {
           end if
         end repeat
         if theAttachment is missing value then
-          return "ERR${AS_FIELD_SEP}attachment not found"
+          return "ERR" & ${AS_FIELD_SEP} & "attachment not found"
         end if
-        save theAttachment in (POSIX file "${safePath}")
-        return "OK${AS_FIELD_SEP}" & (name of theAttachment) & "${AS_FIELD_SEP}" & (content identifier of theAttachment)
+        set attachUrl to ""
+        try
+          set attachUrl to URL of theAttachment as text
+        end try
+        try
+          save theAttachment in (POSIX file "${safePath}")
+        on error errMsg
+          return "ERRSAVE" & ${AS_FIELD_SEP} & errMsg & ${AS_FIELD_SEP} & attachUrl
+        end try
+        return "OK" & ${AS_FIELD_SEP} & (name of theAttachment) & ${AS_FIELD_SEP} & (content identifier of theAttachment)
       end tell
     `;
     const result = executeAppleScript(script);
@@ -40875,6 +40894,16 @@ var AppleNotesManager = class {
       return { success: false, error: result.error ?? "unknown error" };
     }
     const parts = (result.output ?? "").trim().split(FIELD_SEP);
+    if (parts[0] === "ERRSAVE") {
+      const saveErr = (parts[1]?.trim() || "unknown error").replace(/\.$/, "");
+      const rawUrl = parts[2]?.trim();
+      const attachUrl = rawUrl && rawUrl !== "missing value" ? rawUrl : void 0;
+      const linkHint = attachUrl ? ` This attachment appears to be a link preview (URL: ${attachUrl}) rather than a file, and link previews have no file payload to save.` : "";
+      return {
+        success: false,
+        error: `Notes could not save this attachment: ${saveErr}.${linkHint}`
+      };
+    }
     if (parts[0] !== "OK") {
       return { success: false, error: parts[1]?.trim() || "attachment not found" };
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes-mcp",
-  "version": "2.5.8",
+  "version": "2.5.10",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Notes - create, search, update, and manage notes via Claude and other AI assistants",
   "type": "module",

--- a/src/services/appleNotesManager.ts
+++ b/src/services/appleNotesManager.ts
@@ -40,6 +40,7 @@ import {
   fileSize,
   makeTempDir,
   cleanupTempDir,
+  ensureParentDir,
 } from "@/utils/attachmentFs.js";
 import { existsSync } from "fs";
 import TurndownService from "turndown";
@@ -1963,7 +1964,7 @@ export class AppleNotesManager {
           end if
         end repeat
         if theAttachment is missing value then
-          return "ERR${AS_FIELD_SEP}attachment not found"
+          return "ERR" & ${AS_FIELD_SEP} & "attachment not found"
         end if
         show theAttachment${separatelyClause}
         return "OK"
@@ -2416,6 +2417,9 @@ export class AppleNotesManager {
     let abs: string;
     try {
       abs = assertSafeSavePath(savePath);
+      // Notes' `save` does not create intermediate directories and fails with
+      // an opaque error when the parent is missing, so create it up front.
+      ensureParentDir(abs);
     } catch (e) {
       return { success: false, error: e instanceof Error ? e.message : String(e) };
     }
@@ -2435,10 +2439,18 @@ export class AppleNotesManager {
           end if
         end repeat
         if theAttachment is missing value then
-          return "ERR${AS_FIELD_SEP}attachment not found"
+          return "ERR" & ${AS_FIELD_SEP} & "attachment not found"
         end if
-        save theAttachment in (POSIX file "${safePath}")
-        return "OK${AS_FIELD_SEP}" & (name of theAttachment) & "${AS_FIELD_SEP}" & (content identifier of theAttachment)
+        set attachUrl to ""
+        try
+          set attachUrl to URL of theAttachment as text
+        end try
+        try
+          save theAttachment in (POSIX file "${safePath}")
+        on error errMsg
+          return "ERRSAVE" & ${AS_FIELD_SEP} & errMsg & ${AS_FIELD_SEP} & attachUrl
+        end try
+        return "OK" & ${AS_FIELD_SEP} & (name of theAttachment) & ${AS_FIELD_SEP} & (content identifier of theAttachment)
       end tell
     `;
 
@@ -2447,6 +2459,20 @@ export class AppleNotesManager {
       return { success: false, error: result.error ?? "unknown error" };
     }
     const parts = (result.output ?? "").trim().split(FIELD_SEP);
+    if (parts[0] === "ERRSAVE") {
+      const saveErr = (parts[1]?.trim() || "unknown error").replace(/\.$/, "");
+      const rawUrl = parts[2]?.trim();
+      const attachUrl = rawUrl && rawUrl !== "missing value" ? rawUrl : undefined;
+      // Link-preview attachments (a pasted URL's rich preview) have no file
+      // payload; Notes' `save` raises "AppleEvent handler failed" for them.
+      const linkHint = attachUrl
+        ? ` This attachment appears to be a link preview (URL: ${attachUrl}) rather than a file, and link previews have no file payload to save.`
+        : "";
+      return {
+        success: false,
+        error: `Notes could not save this attachment: ${saveErr}.${linkHint}`,
+      };
+    }
     if (parts[0] !== "OK") {
       return { success: false, error: parts[1]?.trim() || "attachment not found" };
     }

--- a/src/services/attachmentSave.test.ts
+++ b/src/services/attachmentSave.test.ts
@@ -47,6 +47,71 @@ describe("saveAttachmentById (#27)", () => {
     expect(r.contentType).toBe("public.png");
   });
 
+  it("emits real separator characters in the OK/ERR sentinel protocol", () => {
+    // Regression: `return "OK${AS_FIELD_SEP}" & ...` interpolated the
+    // separator INSIDE the AppleScript string literal, so the script returned
+    // the literal text "OK(ASCII character 31)..." instead of a control
+    // character. The TS split never matched and every successful save was
+    // misreported as "attachment not found" even though the file was written.
+    mockExec.mockReturnValueOnce({ success: true, output: "" });
+
+    manager.saveAttachmentById("x-coredata://A/ICNote/p1", "att-1", join(tmpdir(), "x.png"));
+
+    const script = mockExec.mock.calls[0][0] as string;
+    expect(script).not.toMatch(/"(?:OK|ERR|ERRSAVE)\(ASCII character/);
+    expect(script).toContain('return "OK" & (ASCII character 31) &');
+  });
+
+  it("creates missing parent directories before invoking Notes", () => {
+    // Notes' `save` does not create intermediate directories and fails with an
+    // opaque error when the parent is missing.
+    const dir = mkdtempSync(join(tmpdir(), "anatt-"));
+    tmpDirs.push(dir);
+    const dest = join(dir, "not", "yet", "created", "photo.png");
+    mockExec.mockImplementation((script: string) => {
+      const m = script.match(/POSIX file "([^"]+)"/);
+      if (m) writeFileSync(m[1], Buffer.from("PNGDATA"));
+      return { success: true, output: ["OK", "photo.png", "public.png"].join(F) };
+    });
+
+    const r = manager.saveAttachmentById("x-coredata://A/ICNote/p1", "att-1", dest);
+    expect(r.success).toBe(true);
+    expect(r.savedPath).toBe(dest);
+  });
+
+  it("explains link-preview attachments when Notes' save raises an AppleEvent error", () => {
+    mockExec.mockReturnValueOnce({
+      success: true,
+      output: ["ERRSAVE", "AppleEvent handler failed.", "https://example.com/app"].join(F),
+    });
+
+    const r = manager.saveAttachmentById(
+      "x-coredata://A/ICNote/p1",
+      "att-1",
+      join(tmpdir(), "x.bin")
+    );
+    expect(r.success).toBe(false);
+    expect(r.error).toContain("AppleEvent handler failed");
+    expect(r.error).toContain("link preview");
+    expect(r.error).toContain("https://example.com/app");
+  });
+
+  it("reports a plain save error without the link hint when the attachment has no URL", () => {
+    mockExec.mockReturnValueOnce({
+      success: true,
+      output: ["ERRSAVE", "Failed saving an attachment to /nope.", "missing value"].join(F),
+    });
+
+    const r = manager.saveAttachmentById(
+      "x-coredata://A/ICNote/p1",
+      "att-1",
+      join(tmpdir(), "x.bin")
+    );
+    expect(r.success).toBe(false);
+    expect(r.error).toContain("Failed saving an attachment");
+    expect(r.error).not.toContain("link preview");
+  });
+
   it("rejects an unsafe destination before running AppleScript", () => {
     const r = manager.saveAttachmentById("x-coredata://A/ICNote/p1", "att-1", "/etc/evil.png");
     expect(r.success).toBe(false);

--- a/src/utils/attachmentFs.test.ts
+++ b/src/utils/attachmentFs.test.ts
@@ -11,6 +11,7 @@ import {
   makeTempDir,
   cleanupTempDir,
   allowedSaveRoots,
+  ensureParentDir,
 } from "@/utils/attachmentFs.js";
 
 const dirs: string[] = [];
@@ -22,6 +23,13 @@ describe("assertSafeSavePath (#27)", () => {
     expect(assertSafeSavePath(p)).toBe(p);
     const h = join(homedir(), "Downloads", "x.png");
     expect(assertSafeSavePath(h)).toBe(h);
+  });
+
+  it("accepts /private/tmp, the real path behind the /tmp symlink", () => {
+    // macOS's /tmp is a symlink to /private/tmp. A caller passing the resolved
+    // real path must not be rejected while the symlinked spelling is accepted.
+    expect(assertSafeSavePath("/private/tmp/x.png")).toBe("/private/tmp/x.png");
+    expect(assertSafeSavePath("/tmp/x.png")).toBe("/tmp/x.png");
   });
 
   it("rejects empty, relative, and out-of-root paths", () => {
@@ -91,5 +99,24 @@ describe("readFileBase64Capped / maxAttachmentBytes (size guard)", () => {
       25 * 1024 * 1024
     );
     expect(maxAttachmentBytes({})).toBe(25 * 1024 * 1024);
+  });
+});
+
+describe("ensureParentDir", () => {
+  it("creates missing intermediate directories for a save destination", () => {
+    const dir = makeTempDir();
+    dirs.push(dir);
+    const dest = join(dir, "deep", "nested", "photo.png");
+    expect(existsSync(join(dir, "deep", "nested"))).toBe(false);
+    ensureParentDir(dest);
+    expect(existsSync(join(dir, "deep", "nested"))).toBe(true);
+    writeFileSync(dest, "x");
+    expect(existsSync(dest)).toBe(true);
+  });
+
+  it("is a no-op when the parent already exists", () => {
+    const dir = makeTempDir();
+    dirs.push(dir);
+    expect(() => ensureParentDir(join(dir, "photo.png"))).not.toThrow();
   });
 });

--- a/src/utils/attachmentFs.ts
+++ b/src/utils/attachmentFs.ts
@@ -7,13 +7,34 @@
  *
  * @module utils/attachmentFs
  */
-import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from "fs";
-import { isAbsolute, resolve, sep } from "path";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync } from "fs";
+import { dirname, isAbsolute, resolve, sep } from "path";
 import { homedir, tmpdir } from "os";
 
-/** Roots an attachment may be written to. */
+/**
+ * Roots an attachment may be written to. `/private/tmp` is listed alongside
+ * `/tmp` because macOS's `/tmp` is a symlink to it: a caller that passes the
+ * resolved real path must not be rejected while the symlinked spelling of the
+ * same directory is accepted (the same reason `/private/var/folders` is here).
+ */
 export function allowedSaveRoots(): string[] {
-  return [resolve(homedir()), resolve(tmpdir()), "/Volumes", "/private/var/folders", "/tmp"];
+  return [
+    resolve(homedir()),
+    resolve(tmpdir()),
+    "/Volumes",
+    "/private/var/folders",
+    "/tmp",
+    "/private/tmp",
+  ];
+}
+
+/**
+ * Ensure the parent directory of a save destination exists. Notes.app's
+ * AppleScript `save` does not create intermediate directories; without this it
+ * fails with an opaque "Failed saving an attachment to <path>" error.
+ */
+export function ensureParentDir(abs: string): void {
+  mkdirSync(dirname(abs), { recursive: true });
 }
 
 /**


### PR DESCRIPTION
## The headline bug

`saveAttachmentById` builds its return value as `return "OK${AS_FIELD_SEP}" & ...`. The interpolation lands inside the AppleScript string literal, so the script returns the literal text `OK(ASCII character 31)...` rather than a real control character. The TypeScript side splits on `\x1f`, finds nothing, and reports "attachment not found" even though the file was written to disk. As far as I can tell every successful save-attachment call has been misreported this way; the unit tests never caught it because they mock `executeAppleScript` and hand the parser correctly separated strings.

I found this the honest way: a session where `ls` showed the saved file sitting on disk while the tool insisted the attachment didn't exist.

## Also in this change

- `allowedSaveRoots` accepted `/tmp` but rejected `/private/tmp`, which is the real directory behind macOS's `/tmp` symlink. Same rationale as the existing `/private/var/folders` entry.
- Notes' `save` does not create intermediate directories and fails with an opaque "Failed saving an attachment to <path>" when the parent is missing. The manager now creates the parent directory before invoking Notes.
- Link-preview attachments (the rich preview Notes builds for a pasted URL) have no file payload, and `save` raises a bare "AppleEvent handler failed" for them. The error now explains that and includes the preview's URL so the caller has something actionable.
- `show-attachment` had the same quoted-literal quirk in its ERR return; it happened to work because it only checks `startsWith("ERR")`, but it is fixed for consistency.

## Tests

New regression test captures the generated script and asserts the sentinel protocol emits real separator expressions rather than text inside string literals, plus tests for parent-directory creation, the link-preview error, the plain error path, and the `/private/tmp` root. `lint`, `format:check`, `test` (455), and `build` all pass.

## Verified live

macOS 27.0, Notes 4.13. An image attachment saved into a not-yet-existing `/private/tmp` subdirectory returns success with metadata (previously: "attachment not found" despite the file landing), and saving an App Store link preview returns the explanatory error with its URL.