### PR TITLE
chore(ci): pin pnpm minimumReleaseAge (document the supply-chain default)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,7 @@
 # failing with ERR_PNPM_IGNORED_BUILDS.
 allowBuilds:
   esbuild: true
+
+# Pin pnpm 11's supply-chain minimum-release-age default explicitly (1440 min = 1 day)
+# so it is documented and stable across pnpm upgrades. See https://pnpm.io/supply-chain-security.
+minimumReleaseAge: 1440


### PR DESCRIPTION
## What

Pin pnpm 11's built-in supply-chain `minimumReleaseAge` default **explicitly** in `pnpm-workspace.yaml`:

```yaml
minimumReleaseAge: 1440
```

`1440` minutes (1 day) is exactly the value pnpm 11 already enforces by default. Setting it explicitly documents the policy in-repo and keeps it **stable across pnpm upgrades**, so a future default change upstream can't silently loosen (or tighten) our supply-chain window without an intentional edit here. See https://pnpm.io/supply-chain-security.

## Why it's safe

- **Config-only** — no `src/**` or `requirements.txt` change, so `version-guard` passes with no version bump required.
- **No dependency re-resolution** — because `1440` equals the default already in effect, `pnpm install` resolves the exact same tree. `git diff pnpm-lock.yaml` is **empty** (pnpm 11.9.0 does not record `minimumReleaseAge` in the lockfile settings block, and no resolved versions changed).
- **`pnpm install --frozen-lockfile` stays green** — verified locally: "Already up to date", exit 0, no out-of-date / supply-chain policy error. The lockfile needs no update.

## Verification (local)

- `pnpm install --frozen-lockfile` → exit 0 (passes supply-chain policy)
- `pnpm run lint` → 0
- `pnpm run typecheck` → 0
- `pnpm test` → 467/467 passed
- `pnpm run format:check` → 0
- `pnpm run build` → 0; committed `build/index.js` bundle unchanged (`git status build/` clean)
