### PR TITLE
Run osascript without a shell, and fix timeout detection that never fired in production

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-notes",
-      "version": "2.5.8",
+      "version": "2.5.10",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-notes",
-      "version": "2.5.8",
+      "version": "2.5.10",
       "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.5.8",
+  "version": "2.5.10",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "apple-notes",
       "description": "Manage Apple Notes through natural language - create, search, read, update, delete, and organize notes and folders",
-      "version": "2.5.8",
+      "version": "2.5.10",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.5.8",
+  "version": "2.5.10",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, and organize notes and folders (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.5.10] - 2026-07-08
 ### Fixed
 - **Timeouts were never actually detected in production.** `isTimeoutError` in both executors checked `killed === true || signal === "SIGTERM"`, which is the error shape of the *async* `exec` API. A timed-out `execSync`/`execFileSync` call throws the underlying spawnSync error instead: `code: "ETIMEDOUT"` with `signal` set to the configured kill signal (`SIGKILL`, per #17). So a real timeout fell through to generic error parsing (surfacing as the raw `spawnSync /bin/sh ETIMEDOUT`) and, because the retry gate keys off timeout detection and `ETIMEDOUT` does not match the `/timed? out/i` transient pattern, **timeouts were never retried** despite the retry-on-timeout behavior shipped in #70. The mocked unit tests passed because their fake errors used the async shape; the detection now checks `ETIMEDOUT`/`SIGKILL` first (keeping the old checks as a fallback), the tests use the real error shape, and the fix was verified against a live forced timeout.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- **Timeouts were never actually detected in production.** `isTimeoutError` in both executors checked `killed === true || signal === "SIGTERM"`, which is the error shape of the *async* `exec` API. A timed-out `execSync`/`execFileSync` call throws the underlying spawnSync error instead: `code: "ETIMEDOUT"` with `signal` set to the configured kill signal (`SIGKILL`, per #17). So a real timeout fell through to generic error parsing (surfacing as the raw `spawnSync /bin/sh ETIMEDOUT`) and, because the retry gate keys off timeout detection and `ETIMEDOUT` does not match the `/timed? out/i` transient pattern, **timeouts were never retried** despite the retry-on-timeout behavior shipped in #70. The mocked unit tests passed because their fake errors used the async shape; the detection now checks `ETIMEDOUT`/`SIGKILL` first (keeping the old checks as a fallback), the tests use the real error shape, and the fix was verified against a live forced timeout.
+
+### Security
+- **AppleScript and JXA no longer pass through `/bin/sh`.** Both executors composed `osascript -e '<script>'` as a shell string for `execSync`, making single-quote escaping the only barrier between note content and arbitrary shell execution, and capping script size at the kernel's argv limit (a sufficiently large generated script — big note bodies — would fail with E2BIG). They now call `execFileSync("osascript", ["-"], ...)` with the script delivered over stdin: no shell is involved at all, so the shell-injection class of bug is structurally impossible, script size is unbounded, and each call saves a `/bin/sh` fork. The retry sleep also no longer forks a `sleep` subprocess per attempt; it blocks in-process via `Atomics.wait`.
 
 ## [2.5.9] - 2026-07-08
 ### Fixed

--- a/build/index.js
+++ b/build/index.js
@@ -38656,7 +38656,7 @@ var StdioServerTransport = class {
 };
 
 // src/utils/applescript.ts
-import { execSync, spawnSync } from "child_process";
+import { execFileSync } from "child_process";
 var DEFAULT_TIMEOUT_MS = 3e4;
 var DEFAULT_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
 function envPositiveNumber(name) {
@@ -38693,13 +38693,10 @@ function debugLog(message, data) {
     console.error(`[DEBUG ${timestamp}] ${message}`);
   }
 }
-function escapeForShell(script) {
-  return script.replace(/'/g, "'\\''");
-}
 function isTimeoutError(error2) {
   if (error2 instanceof Error) {
     const execError = error2;
-    return execError.killed === true || execError.signal === "SIGTERM";
+    return execError.code === "ETIMEDOUT" || execError.killed === true || execError.signal === "SIGKILL" || execError.signal === "SIGTERM";
   }
   return false;
 }
@@ -38714,13 +38711,7 @@ function isRetryableError(errorMessage) {
   return RETRYABLE_ERROR_PATTERNS.some((pattern) => pattern.test(errorMessage));
 }
 function sleep(ms) {
-  const seconds = ms / 1e3;
-  const result = spawnSync("sleep", [seconds.toString()], { stdio: "ignore" });
-  if (result.error) {
-    const end = Date.now() + ms;
-    while (Date.now() < end) {
-    }
-  }
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 var ERROR_MAPPINGS = [
   // Permission errors
@@ -38812,8 +38803,7 @@ function executeAppleScript(script, options = {}) {
       error: "Cannot execute empty AppleScript"
     };
   }
-  const preparedScript = escapeForShell(wrapWithTimeout(script.trim(), timeoutMs));
-  const command = `osascript -e '${preparedScript}'`;
+  const preparedScript = wrapWithTimeout(script.trim(), timeoutMs);
   debugLog("Executing AppleScript", {
     scriptPreview: script.trim().substring(0, 200) + (script.length > 200 ? "..." : ""),
     timeout: timeoutMs,
@@ -38824,7 +38814,8 @@ function executeAppleScript(script, options = {}) {
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     const attemptStart = Date.now();
     try {
-      const output = execSync(command, {
+      const output = execFileSync("osascript", ["-"], {
+        input: preparedScript,
         encoding: "utf8",
         timeout: timeoutMs,
         // SIGKILL (not the default SIGTERM): a wedged osascript blocked on an
@@ -38833,9 +38824,7 @@ function executeAppleScript(script, options = {}) {
         killSignal: "SIGKILL",
         // Raise the output cap above Node's 1 MB default so large exports /
         // long notes aren't truncated into an ENOBUFS failure. (#16)
-        maxBuffer: getMaxBuffer(),
-        // Capture stderr separately to get error details
-        stdio: ["pipe", "pipe", "pipe"]
+        maxBuffer: getMaxBuffer()
       });
       const duration3 = Date.now() - attemptStart;
       debugLog("AppleScript succeeded", {
@@ -38901,7 +38890,7 @@ function executeAppleScript(script, options = {}) {
 }
 
 // src/utils/checklistParser.ts
-import { execFileSync } from "child_process";
+import { execFileSync as execFileSync2 } from "child_process";
 import * as zlib from "zlib";
 import * as fs from "fs";
 import * as path from "path";
@@ -38995,7 +38984,7 @@ var NOTES_DB_PATH = path.join(
 function hasFullDiskAccess() {
   try {
     if (!fs.existsSync(NOTES_DB_PATH)) return false;
-    execFileSync("sqlite3", ["-readonly", NOTES_DB_PATH, "SELECT 1;"], {
+    execFileSync2("sqlite3", ["-readonly", NOTES_DB_PATH, "SELECT 1;"], {
       encoding: "utf8",
       timeout: 3e3,
       stdio: ["pipe", "pipe", "pipe"]
@@ -39014,7 +39003,7 @@ function queryNoteData(noteId) {
   const pk = pkMatch[1];
   const query = `SELECT hex(nd.ZDATA) FROM ZICNOTEDATA nd JOIN ZICCLOUDSYNCINGOBJECT n ON nd.ZNOTE = n.Z_PK WHERE n.Z_PK = ${pk};`;
   try {
-    const result = execFileSync("sqlite3", ["-readonly", NOTES_DB_PATH, query], {
+    const result = execFileSync2("sqlite3", ["-readonly", NOTES_DB_PATH, query], {
       encoding: "utf8",
       timeout: 5e3,
       stdio: ["pipe", "pipe", "pipe"]
@@ -41366,7 +41355,7 @@ var AppleNotesManager = class {
 };
 
 // src/utils/syncDetection.ts
-import { execFileSync as execFileSync2 } from "child_process";
+import { execFileSync as execFileSync3 } from "child_process";
 import * as fs2 from "fs";
 import * as path2 from "path";
 import * as os2 from "os";
@@ -41407,7 +41396,7 @@ function getSyncStatus(useCache = true) {
       WHERE ZCURRENTLOCALVERSION > ZLATESTVERSIONSYNCEDTOCLOUD
       AND ZLATESTVERSIONSYNCEDTOCLOUD IS NOT NULL;
     `;
-    const result = execFileSync2(
+    const result = execFileSync3(
       "sqlite3",
       ["-readonly", NOTES_DB_PATH2, query.replace(/\n/g, " ")],
       {
@@ -41466,7 +41455,7 @@ function withSyncAwarenessSync(operation, fn) {
 }
 
 // src/utils/noteMetadata.ts
-import { execFileSync as execFileSync3 } from "child_process";
+import { execFileSync as execFileSync4 } from "child_process";
 import * as fs3 from "fs";
 import * as path3 from "path";
 import * as os3 from "os";
@@ -41487,7 +41476,7 @@ var COLUMN_MAP = [
   { key: "smartFolderQuery", column: "ZSMARTFOLDERQUERYJSON", type: "text" }
 ];
 function runSqlite(query) {
-  return execFileSync3("sqlite3", ["-readonly", NOTES_DB_PATH3, query], {
+  return execFileSync4("sqlite3", ["-readonly", NOTES_DB_PATH3, query], {
     encoding: "utf8",
     timeout: 5e3,
     stdio: ["pipe", "pipe", "pipe"]
@@ -41626,7 +41615,7 @@ function strippedImagesWarning(stripped) {
 }
 
 // src/tools/doctor.ts
-import { spawnSync as spawnSync2 } from "child_process";
+import { spawnSync } from "child_process";
 function runDoctor(manager) {
   const checks = [];
   const hc = manager.healthCheck();
@@ -41664,7 +41653,7 @@ function runDoctor(manager) {
 function checkNodeRuntimeSignature() {
   const name = "Node runtime signature";
   try {
-    const r = spawnSync2("codesign", ["-dvvv", process.execPath], { encoding: "utf8" });
+    const r = spawnSync("codesign", ["-dvvv", process.execPath], { encoding: "utf8" });
     const out = `${r.stdout ?? ""}${r.stderr ?? ""}`;
     if (r.error || !out.trim()) {
       return {

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.5.8",
+  "version": "2.5.10",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes-mcp",
-  "version": "2.5.9",
+  "version": "2.5.10",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Notes - create, search, update, and manage notes via Claude and other AI assistants",
   "type": "module",

--- a/src/utils/applescript.test.ts
+++ b/src/utils/applescript.test.ts
@@ -1,21 +1,45 @@
 /**
  * Tests for AppleScript execution utilities
  *
- * These tests mock the child_process.execSync function to avoid
+ * These tests mock the child_process.execFileSync function to avoid
  * requiring actual AppleScript execution during testing.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import { executeAppleScript } from "./applescript.js";
 
 // Mock the child_process module
 vi.mock("child_process", () => ({
-  execSync: vi.fn(),
-  spawnSync: vi.fn(() => ({ error: null })), // Mock sleep to return immediately
+  execFileSync: vi.fn(),
 }));
 
-const mockExecSync = vi.mocked(execSync);
+const mockExecFileSync = vi.mocked(execFileSync);
+
+/** The script passed to osascript over stdin on the given call. */
+function scriptInput(call = 0): string {
+  return (mockExecFileSync.mock.calls[call][2] as { input: string }).input;
+}
+
+/** The options object passed to execFileSync on the given call. */
+function execOptions(call = 0): Record<string, unknown> {
+  return mockExecFileSync.mock.calls[call][2] as Record<string, unknown>;
+}
+
+/**
+ * Build an error shaped like a real sync-exec timeout: spawnSync surfaces
+ * ETIMEDOUT with the configured killSignal (SIGKILL here), and there is no
+ * `killed` flag on the sync API's error.
+ */
+function makeTimeoutError(): Error {
+  const err = new Error("spawnSync osascript ETIMEDOUT") as Error & {
+    code: string;
+    signal: string;
+  };
+  err.code = "ETIMEDOUT";
+  err.signal = "SIGKILL";
+  return err;
+}
 
 describe("executeAppleScript", () => {
   beforeEach(() => {
@@ -25,7 +49,7 @@ describe("executeAppleScript", () => {
   describe("successful execution", () => {
     it("returns success result with trimmed output", () => {
       // Arrange: Mock a successful AppleScript execution
-      mockExecSync.mockReturnValue("  Note Title  \n");
+      mockExecFileSync.mockReturnValue("  Note Title  \n");
 
       // Act: Execute a simple script
       const result = executeAppleScript('tell app "Notes" to get name of note 1');
@@ -37,7 +61,7 @@ describe("executeAppleScript", () => {
     });
 
     it("preserves newlines within the script for AppleScript syntax", () => {
-      mockExecSync.mockReturnValue("success");
+      mockExecFileSync.mockReturnValue("success");
 
       // Multi-line AppleScript with tell blocks
       const script = `
@@ -51,20 +75,22 @@ describe("executeAppleScript", () => {
       executeAppleScript(script);
 
       // Verify the script was passed with newlines preserved
-      const calledCommand = mockExecSync.mock.calls[0][0] as string;
-      expect(calledCommand).toContain("tell application");
-      expect(calledCommand).toContain("end tell");
+      expect(scriptInput()).toContain("tell application");
+      expect(scriptInput()).toContain("end tell");
     });
 
-    it("escapes single quotes in the script for shell safety", () => {
-      mockExecSync.mockReturnValue("content");
+    it("invokes osascript directly with the script on stdin (no shell)", () => {
+      mockExecFileSync.mockReturnValue("content");
 
       // Script containing a single quote (e.g., in a note title)
       executeAppleScript('get note "Rob\'s Notes"');
 
-      // Verify the quote was escaped for shell
-      const calledCommand = mockExecSync.mock.calls[0][0] as string;
-      expect(calledCommand).toContain("Rob'\\''s");
+      // osascript is called directly with "-" (read script from stdin)
+      expect(mockExecFileSync.mock.calls[0][0]).toBe("osascript");
+      expect(mockExecFileSync.mock.calls[0][1]).toEqual(["-"]);
+      // The script goes over stdin verbatim: no shell, so no shell escaping
+      expect(scriptInput()).toContain("Rob's Notes");
+      expect(scriptInput()).not.toContain("'\\''");
     });
   });
 
@@ -74,36 +100,35 @@ describe("executeAppleScript", () => {
     });
 
     it("wraps the script in `with timeout` so Notes.app aborts cleanly", () => {
-      mockExecSync.mockReturnValue("ok");
+      mockExecFileSync.mockReturnValue("ok");
       executeAppleScript("get name of notes", { timeoutMs: 30000 });
-      const cmd = mockExecSync.mock.calls[0][0] as string;
-      expect(cmd).toContain("with timeout of");
-      expect(cmd).toContain("end timeout");
+      const script = scriptInput();
+      expect(script).toContain("with timeout of");
+      expect(script).toContain("end timeout");
       // 30s process timeout − 5s headroom = 25s script timeout
-      expect(cmd).toContain("with timeout of 25 seconds");
+      expect(script).toContain("with timeout of 25 seconds");
     });
 
-    it("passes SIGKILL and a large maxBuffer to execSync", () => {
-      mockExecSync.mockReturnValue("ok");
+    it("passes SIGKILL and a large maxBuffer to execFileSync", () => {
+      mockExecFileSync.mockReturnValue("ok");
       executeAppleScript("get name of notes");
-      const opts = mockExecSync.mock.calls[0][1] as { killSignal?: string; maxBuffer?: number };
+      const opts = execOptions();
       expect(opts.killSignal).toBe("SIGKILL");
       expect(opts.maxBuffer).toBe(64 * 1024 * 1024);
     });
 
     it("honors APPLE_NOTES_MCP_MAX_BUFFER override", () => {
       process.env.APPLE_NOTES_MCP_MAX_BUFFER = "1048576";
-      mockExecSync.mockReturnValue("ok");
+      mockExecFileSync.mockReturnValue("ok");
       executeAppleScript("get name of notes");
-      const opts = mockExecSync.mock.calls[0][1] as { maxBuffer?: number };
-      expect(opts.maxBuffer).toBe(1048576);
+      expect(execOptions().maxBuffer).toBe(1048576);
     });
   });
 
   describe("error handling", () => {
     it("returns error result when execution fails", () => {
       // Arrange: Mock an AppleScript execution failure
-      mockExecSync.mockImplementation(() => {
+      mockExecFileSync.mockImplementation(() => {
         throw new Error("execution error: Can't get note. (-1728)");
       });
 
@@ -117,7 +142,7 @@ describe("executeAppleScript", () => {
     });
 
     it("parses execution error messages cleanly", () => {
-      mockExecSync.mockImplementation(() => {
+      mockExecFileSync.mockImplementation(() => {
         throw new Error("execution error: Note not found (-1728)");
       });
 
@@ -128,7 +153,7 @@ describe("executeAppleScript", () => {
     });
 
     it("handles 'not found' error patterns with user-friendly message", () => {
-      mockExecSync.mockImplementation(() => {
+      mockExecFileSync.mockImplementation(() => {
         throw new Error('Can\'t get note "Missing".');
       });
 
@@ -140,7 +165,7 @@ describe("executeAppleScript", () => {
     });
 
     it("provides helpful message for permission errors", () => {
-      mockExecSync.mockImplementation(() => {
+      mockExecFileSync.mockImplementation(() => {
         throw new Error("execution error: Not authorized to send Apple events (-1743)");
       });
 
@@ -151,7 +176,7 @@ describe("executeAppleScript", () => {
     });
 
     it("provides helpful message for folder not found", () => {
-      mockExecSync.mockImplementation(() => {
+      mockExecFileSync.mockImplementation(() => {
         throw new Error('Can\'t get folder "Work".');
       });
 
@@ -163,7 +188,7 @@ describe("executeAppleScript", () => {
     });
 
     it("provides helpful message for account not found", () => {
-      mockExecSync.mockImplementation(() => {
+      mockExecFileSync.mockImplementation(() => {
         throw new Error('Can\'t get account "Gmail".');
       });
 
@@ -175,7 +200,7 @@ describe("executeAppleScript", () => {
     });
 
     it("handles non-Error exceptions gracefully", () => {
-      mockExecSync.mockImplementation(() => {
+      mockExecFileSync.mockImplementation(() => {
         throw "string error"; // Some code throws strings
       });
 
@@ -186,7 +211,7 @@ describe("executeAppleScript", () => {
     });
 
     it("handles unknown error types", () => {
-      mockExecSync.mockImplementation(() => {
+      mockExecFileSync.mockImplementation(() => {
         throw { weird: "object" }; // Unusual but possible
       });
 
@@ -203,7 +228,7 @@ describe("executeAppleScript", () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBe("Cannot execute empty AppleScript");
-      expect(mockExecSync).not.toHaveBeenCalled();
+      expect(mockExecFileSync).not.toHaveBeenCalled();
     });
 
     it("returns error for whitespace-only script", () => {
@@ -211,62 +236,51 @@ describe("executeAppleScript", () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBe("Cannot execute empty AppleScript");
-      expect(mockExecSync).not.toHaveBeenCalled();
+      expect(mockExecFileSync).not.toHaveBeenCalled();
     });
   });
 
   describe("execution options", () => {
     it("uses default 30 second timeout", () => {
-      mockExecSync.mockReturnValue("ok");
+      mockExecFileSync.mockReturnValue("ok");
 
       executeAppleScript("test");
 
-      const options = mockExecSync.mock.calls[0][1] as { timeout: number };
-      expect(options.timeout).toBe(30000); // 30 second default timeout
+      expect(execOptions().timeout).toBe(30000); // 30 second default timeout
     });
 
     it("allows custom timeout via options", () => {
-      mockExecSync.mockReturnValue("ok");
+      mockExecFileSync.mockReturnValue("ok");
 
       executeAppleScript("test", { timeoutMs: 60000 });
 
-      const options = mockExecSync.mock.calls[0][1] as { timeout: number };
-      expect(options.timeout).toBe(60000); // Custom timeout
+      expect(execOptions().timeout).toBe(60000); // Custom timeout
     });
 
     it("uses UTF-8 encoding for output", () => {
-      mockExecSync.mockReturnValue("日本語テスト");
+      mockExecFileSync.mockReturnValue("日本語テスト");
 
       const result = executeAppleScript("test");
 
       expect(result.output).toBe("日本語テスト");
-      const options = mockExecSync.mock.calls[0][1] as { encoding: string };
-      expect(options.encoding).toBe("utf8");
+      expect(execOptions().encoding).toBe("utf8");
     });
   });
 
   describe("timeout handling", () => {
-    it("returns specific error message on timeout", () => {
-      // Simulate a timeout error (Node.js sets killed=true and signal=SIGTERM)
-      const timeoutError = new Error("Command failed: SIGTERM") as Error & {
-        killed: boolean;
-        signal: string;
-      };
-      timeoutError.killed = true;
-      timeoutError.signal = "SIGTERM";
-
-      mockExecSync.mockImplementation(() => {
-        throw timeoutError;
+    it("detects a real sync-exec timeout (ETIMEDOUT + SIGKILL, no killed flag)", () => {
+      mockExecFileSync.mockImplementation(() => {
+        throw makeTimeoutError();
       });
 
-      const result = executeAppleScript("test");
+      const result = executeAppleScript("test", { maxRetries: 1 });
 
       expect(result.success).toBe(false);
       expect(result.error).toContain("timed out after 30 seconds");
       expect(result.error).toContain("Notes.app may be unresponsive");
     });
 
-    it("includes custom timeout value in error message", () => {
+    it("still detects the async-exec timeout shape (killed=true, SIGTERM)", () => {
       const timeoutError = new Error("Command failed: SIGTERM") as Error & {
         killed: boolean;
         signal: string;
@@ -274,29 +288,33 @@ describe("executeAppleScript", () => {
       timeoutError.killed = true;
       timeoutError.signal = "SIGTERM";
 
-      mockExecSync.mockImplementation(() => {
+      mockExecFileSync.mockImplementation(() => {
         throw timeoutError;
       });
 
-      const result = executeAppleScript("test", { timeoutMs: 60000 });
+      const result = executeAppleScript("test", { maxRetries: 1 });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("timed out after 30 seconds");
+    });
+
+    it("includes custom timeout value in error message", () => {
+      mockExecFileSync.mockImplementation(() => {
+        throw makeTimeoutError();
+      });
+
+      const result = executeAppleScript("test", { timeoutMs: 60000, maxRetries: 1 });
 
       expect(result.error).toContain("timed out after 60 seconds");
     });
 
     it("honors APPLE_NOTES_MCP_TIMEOUT_MS when no per-call timeout is given", () => {
       vi.stubEnv("APPLE_NOTES_MCP_TIMEOUT_MS", "45000");
-      const timeoutError = new Error("Command failed: SIGTERM") as Error & {
-        killed: boolean;
-        signal: string;
-      };
-      timeoutError.killed = true;
-      timeoutError.signal = "SIGTERM";
-
-      mockExecSync.mockImplementation(() => {
-        throw timeoutError;
+      mockExecFileSync.mockImplementation(() => {
+        throw makeTimeoutError();
       });
 
-      const result = executeAppleScript("test");
+      const result = executeAppleScript("test", { maxRetries: 1 });
 
       expect(result.error).toContain("timed out after 45 seconds");
       vi.unstubAllEnvs();
@@ -305,55 +323,58 @@ describe("executeAppleScript", () => {
 
   describe("retry logic", () => {
     it("retries transient errors once by default (maxRetries=2)", () => {
-      mockExecSync.mockImplementation(() => {
+      vi.stubEnv("APPLE_NOTES_MCP_RETRY_DELAY_MS", "1");
+      mockExecFileSync.mockImplementation(() => {
         throw new Error("Notes.app is not responding");
       });
 
       executeAppleScript("test");
 
       // Two attempts with default settings: the initial call plus one retry
-      expect(mockExecSync).toHaveBeenCalledTimes(2);
+      expect(mockExecFileSync).toHaveBeenCalledTimes(2);
+      vi.unstubAllEnvs();
     });
 
     it("APPLE_NOTES_MCP_MAX_RETRIES=1 restores fail-fast behavior", () => {
       vi.stubEnv("APPLE_NOTES_MCP_MAX_RETRIES", "1");
-      mockExecSync.mockImplementation(() => {
+      mockExecFileSync.mockImplementation(() => {
         throw new Error("Notes.app is not responding");
       });
 
       executeAppleScript("test");
 
-      expect(mockExecSync).toHaveBeenCalledTimes(1);
+      expect(mockExecFileSync).toHaveBeenCalledTimes(1);
       vi.unstubAllEnvs();
     });
 
     it("per-call options override the env knobs", () => {
       vi.stubEnv("APPLE_NOTES_MCP_MAX_RETRIES", "5");
-      mockExecSync.mockImplementation(() => {
+      mockExecFileSync.mockImplementation(() => {
         throw new Error("Notes.app is not responding");
       });
 
       executeAppleScript("test", { maxRetries: 1 });
 
-      expect(mockExecSync).toHaveBeenCalledTimes(1);
+      expect(mockExecFileSync).toHaveBeenCalledTimes(1);
       vi.unstubAllEnvs();
     });
 
     it("ignores an invalid APPLE_NOTES_MCP_MAX_RETRIES and uses the default", () => {
       vi.stubEnv("APPLE_NOTES_MCP_MAX_RETRIES", "banana");
-      mockExecSync.mockImplementation(() => {
+      vi.stubEnv("APPLE_NOTES_MCP_RETRY_DELAY_MS", "1");
+      mockExecFileSync.mockImplementation(() => {
         throw new Error("Notes.app is not responding");
       });
 
       executeAppleScript("test");
 
-      expect(mockExecSync).toHaveBeenCalledTimes(2);
+      expect(mockExecFileSync).toHaveBeenCalledTimes(2);
       vi.unstubAllEnvs();
     });
 
     it("retries on transient errors when maxRetries > 1", () => {
       let callCount = 0;
-      mockExecSync.mockImplementation(() => {
+      mockExecFileSync.mockImplementation(() => {
         callCount++;
         if (callCount < 3) {
           throw new Error("Notes.app is not responding");
@@ -365,32 +386,26 @@ describe("executeAppleScript", () => {
 
       expect(result.success).toBe(true);
       expect(result.output).toBe("success");
-      expect(mockExecSync).toHaveBeenCalledTimes(3);
+      expect(mockExecFileSync).toHaveBeenCalledTimes(3);
     });
 
     it("does not retry on non-transient errors", () => {
-      mockExecSync.mockImplementation(() => {
+      mockExecFileSync.mockImplementation(() => {
         throw new Error('Can\'t get note "Missing"');
       });
 
       executeAppleScript("test", { maxRetries: 3, retryDelayMs: 1 });
 
       // Should not retry for "note not found" errors
-      expect(mockExecSync).toHaveBeenCalledTimes(1);
+      expect(mockExecFileSync).toHaveBeenCalledTimes(1);
     });
 
     it("retries on timeout errors", () => {
       let callCount = 0;
-      mockExecSync.mockImplementation(() => {
+      mockExecFileSync.mockImplementation(() => {
         callCount++;
         if (callCount < 2) {
-          const timeoutError = new Error("SIGTERM") as Error & {
-            killed: boolean;
-            signal: string;
-          };
-          timeoutError.killed = true;
-          timeoutError.signal = "SIGTERM";
-          throw timeoutError;
+          throw makeTimeoutError();
         }
         return "success after retry";
       });
@@ -399,12 +414,12 @@ describe("executeAppleScript", () => {
 
       expect(result.success).toBe(true);
       expect(result.output).toBe("success after retry");
-      expect(mockExecSync).toHaveBeenCalledTimes(2);
+      expect(mockExecFileSync).toHaveBeenCalledTimes(2);
     });
 
     it("retries on 'connection invalid' errors", () => {
       let callCount = 0;
-      mockExecSync.mockImplementation(() => {
+      mockExecFileSync.mockImplementation(() => {
         callCount++;
         if (callCount < 2) {
           throw new Error("connection is invalid");
@@ -415,11 +430,11 @@ describe("executeAppleScript", () => {
       const result = executeAppleScript("test", { maxRetries: 3, retryDelayMs: 1 });
 
       expect(result.success).toBe(true);
-      expect(mockExecSync).toHaveBeenCalledTimes(2);
+      expect(mockExecFileSync).toHaveBeenCalledTimes(2);
     });
 
     it("returns last error after all retries exhausted", () => {
-      mockExecSync.mockImplementation(() => {
+      mockExecFileSync.mockImplementation(() => {
         throw new Error("Notes.app is not responding");
       });
 
@@ -427,12 +442,12 @@ describe("executeAppleScript", () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toContain("not responding");
-      expect(mockExecSync).toHaveBeenCalledTimes(3);
+      expect(mockExecFileSync).toHaveBeenCalledTimes(3);
     });
 
     it("retries on 'timed out' errors", () => {
       let callCount = 0;
-      mockExecSync.mockImplementation(() => {
+      mockExecFileSync.mockImplementation(() => {
         callCount++;
         if (callCount < 2) {
           throw new Error("operation timed out");
@@ -443,12 +458,12 @@ describe("executeAppleScript", () => {
       const result = executeAppleScript("test", { maxRetries: 3, retryDelayMs: 1 });
 
       expect(result.success).toBe(true);
-      expect(mockExecSync).toHaveBeenCalledTimes(2);
+      expect(mockExecFileSync).toHaveBeenCalledTimes(2);
     });
 
     it("retries on 'lost connection' errors", () => {
       let callCount = 0;
-      mockExecSync.mockImplementation(() => {
+      mockExecFileSync.mockImplementation(() => {
         callCount++;
         if (callCount < 2) {
           throw new Error("lost connection to Notes.app");
@@ -459,12 +474,12 @@ describe("executeAppleScript", () => {
       const result = executeAppleScript("test", { maxRetries: 3, retryDelayMs: 1 });
 
       expect(result.success).toBe(true);
-      expect(mockExecSync).toHaveBeenCalledTimes(2);
+      expect(mockExecFileSync).toHaveBeenCalledTimes(2);
     });
 
     it("retries on 'busy' errors", () => {
       let callCount = 0;
-      mockExecSync.mockImplementation(() => {
+      mockExecFileSync.mockImplementation(() => {
         callCount++;
         if (callCount < 2) {
           throw new Error("Notes.app is busy");
@@ -475,14 +490,14 @@ describe("executeAppleScript", () => {
       const result = executeAppleScript("test", { maxRetries: 3, retryDelayMs: 1 });
 
       expect(result.success).toBe(true);
-      expect(mockExecSync).toHaveBeenCalledTimes(2);
+      expect(mockExecFileSync).toHaveBeenCalledTimes(2);
     });
 
     it("uses exponential backoff between retries", () => {
       let execCallCount = 0;
 
       // Fails first 3 times, succeeds on 4th attempt
-      mockExecSync.mockImplementation(() => {
+      mockExecFileSync.mockImplementation(() => {
         execCallCount++;
         if (execCallCount <= 3) {
           throw new Error("Notes.app is not responding");
@@ -490,11 +505,11 @@ describe("executeAppleScript", () => {
         return "success";
       });
 
-      // With retryDelayMs=100, delays should be: 100ms, 200ms, 400ms
-      const result = executeAppleScript("test", { maxRetries: 4, retryDelayMs: 100 });
+      // With retryDelayMs=1, delays should be: 1ms, 2ms, 4ms
+      const result = executeAppleScript("test", { maxRetries: 4, retryDelayMs: 1 });
 
       expect(result.success).toBe(true);
-      expect(mockExecSync).toHaveBeenCalledTimes(4);
+      expect(mockExecFileSync).toHaveBeenCalledTimes(4);
     });
   });
 });

--- a/src/utils/applescript.ts
+++ b/src/utils/applescript.ts
@@ -7,7 +7,7 @@
  * @module utils/applescript
  */
 
-import { execSync, spawnSync } from "child_process";
+import { execFileSync } from "child_process";
 import type { AppleScriptResult, AppleScriptOptions } from "@/types.js";
 
 /**
@@ -108,39 +108,26 @@ function debugLog(message: string, data?: unknown): void {
 }
 
 /**
- * Escapes a string for safe inclusion in a shell command.
+ * Checks if an error is a timeout error from a sync child_process call.
  *
- * When passing AppleScript to osascript via shell, we need to handle
- * the interaction between shell quoting and AppleScript string literals.
- * This function escapes single quotes since we wrap the script in single quotes.
- *
- * @param script - The raw AppleScript code
- * @returns Shell-safe version of the script
- *
- * @example
- * // Input: tell app "Notes" to get note "Rob's Note"
- * // Output: tell app "Notes" to get note "Rob'\''s Note"
- */
-function escapeForShell(script: string): string {
-  // Replace single quotes with: end quote, escaped quote, start quote
-  // This is the standard shell escaping pattern for single-quoted strings
-  return script.replace(/'/g, "'\\''");
-}
-
-/**
- * Checks if an error is a timeout error from execSync.
- *
- * Node.js throws errors with specific properties when a child process
- * is killed due to timeout.
+ * A timed-out execFileSync/execSync throws the underlying spawnSync error:
+ * `code` is "ETIMEDOUT" and `signal` is the configured killSignal (SIGKILL
+ * here, per #17). There is no `killed: true` on the sync API's error — that
+ * shape belongs to async exec — but it is kept as a fallback so any caller
+ * that wraps this with the async API still gets timeout semantics.
  *
  * @param error - The caught error object
  * @returns True if this was a timeout error
  */
 function isTimeoutError(error: unknown): boolean {
   if (error instanceof Error) {
-    const execError = error as Error & { killed?: boolean; signal?: string };
-    // execSync kills the process with SIGTERM on timeout
-    return execError.killed === true || execError.signal === "SIGTERM";
+    const execError = error as Error & { code?: string; killed?: boolean; signal?: string };
+    return (
+      execError.code === "ETIMEDOUT" ||
+      execError.killed === true ||
+      execError.signal === "SIGKILL" ||
+      execError.signal === "SIGTERM"
+    );
   }
   return false;
 }
@@ -168,29 +155,17 @@ function isRetryableError(errorMessage: string): boolean {
 }
 
 /**
- * Synchronous sleep using the system's sleep command.
- * Used between retry attempts for exponential backoff.
+ * Synchronous sleep between retry attempts, without spawning a subprocess.
  *
- * This is more efficient than a busy-wait loop as it doesn't
- * consume CPU cycles during the delay.
- *
- * Uses spawnSync instead of execSync to avoid interference with
- * execSync mocks in tests.
+ * Atomics.wait blocks the thread until the timeout expires (the int32 never
+ * changes, so the wait always runs to its timeout). It consumes no CPU while
+ * waiting and, unlike the previous `spawnSync("sleep", ...)`, costs no
+ * process fork per retry and cannot fail into a busy-wait.
  *
  * @param ms - Milliseconds to sleep
  */
 function sleep(ms: number): void {
-  // Use system sleep command with fractional seconds support
-  // This avoids CPU-spinning busy wait while keeping the code synchronous
-  const seconds = ms / 1000;
-  const result = spawnSync("sleep", [seconds.toString()], { stdio: "ignore" });
-  if (result.error) {
-    // Fallback to busy-wait if sleep command fails (shouldn't happen on macOS)
-    const end = Date.now() + ms;
-    while (Date.now() < end) {
-      // Busy wait fallback
-    }
-  }
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 
 /**
@@ -303,7 +278,7 @@ function parseErrorMessage(errorOutput: string): string {
  * Executes an AppleScript command and returns a structured result.
  *
  * This function serves as the bridge between TypeScript and macOS AppleScript.
- * It handles the complexity of shell escaping, execution, and error handling
+ * It handles the complexity of execution and error handling
  * so that calling code can work with clean TypeScript interfaces.
  *
  * The script is executed synchronously via the `osascript` command-line tool.
@@ -361,13 +336,9 @@ export function executeAppleScript(
   // 2. Wrap in `with timeout` so Notes.app aborts cleanly from inside its own
   //    dispatch before the outer process SIGKILL (#17)
   // 3. Preserve internal newlines (required for AppleScript syntax)
-  // 4. Escape for shell execution
-  const preparedScript = escapeForShell(wrapWithTimeout(script.trim(), timeoutMs));
-
-  // Build the osascript command
-  // We use single quotes to wrap the script, which is why we escape
-  // single quotes within the script itself
-  const command = `osascript -e '${preparedScript}'`;
+  // The script is fed to `osascript -` over stdin, so no shell and no shell
+  // escaping are involved, and script size is not bounded by ARG_MAX.
+  const preparedScript = wrapWithTimeout(script.trim(), timeoutMs);
 
   // Debug: Log the script being executed
   debugLog("Executing AppleScript", {
@@ -383,8 +354,13 @@ export function executeAppleScript(
     const attemptStart = Date.now();
     try {
       // Execute synchronously - MCP tools are inherently synchronous
-      // and Apple Notes operations are fast enough that async isn't needed
-      const output = execSync(command, {
+      // and Apple Notes operations are fast enough that async isn't needed.
+      // osascript is invoked directly (no /bin/sh in between) and reads the
+      // script from stdin: a shell-escaping bug can never become shell
+      // execution, and a huge generated script (large note bodies) can't
+      // blow the kernel's argv size limit the old `-e '<script>'` form had.
+      const output = execFileSync("osascript", ["-"], {
+        input: preparedScript,
         encoding: "utf8",
         timeout: timeoutMs,
         // SIGKILL (not the default SIGTERM): a wedged osascript blocked on an
@@ -394,8 +370,6 @@ export function executeAppleScript(
         // Raise the output cap above Node's 1 MB default so large exports /
         // long notes aren't truncated into an ENOBUFS failure. (#16)
         maxBuffer: getMaxBuffer(),
-        // Capture stderr separately to get error details
-        stdio: ["pipe", "pipe", "pipe"],
       });
 
       const duration = Date.now() - attemptStart;

--- a/src/utils/jxa.test.ts
+++ b/src/utils/jxa.test.ts
@@ -7,13 +7,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { executeJXA, escapeForJXA, buildNotesJXA } from "./jxa.js";
 
-// Mock execSync to avoid actual osascript calls
+// Mock execFileSync to avoid actual osascript calls
 vi.mock("child_process", () => ({
-  execSync: vi.fn(),
+  execFileSync: vi.fn(),
 }));
 
-import { execSync } from "child_process";
-const mockExecSync = vi.mocked(execSync);
+import { execFileSync } from "child_process";
+const mockExecFileSync = vi.mocked(execFileSync);
 
 describe("escapeForJXA", () => {
   beforeEach(() => {
@@ -69,20 +69,21 @@ describe("executeJXA", () => {
   });
 
   it("executes JXA script via osascript", () => {
-    mockExecSync.mockReturnValue("test output\n");
+    mockExecFileSync.mockReturnValue("test output\n");
 
     const result = executeJXA("JSON.stringify({test: true})");
 
     expect(result.success).toBe(true);
     expect(result.output).toBe("test output");
-    expect(mockExecSync).toHaveBeenCalledWith(
-      expect.stringContaining("-l JavaScript"),
-      expect.any(Object)
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "osascript",
+      ["-l", "JavaScript", "-"],
+      expect.objectContaining({ input: "JSON.stringify({test: true})" })
     );
   });
 
   it("handles execution errors", () => {
-    mockExecSync.mockImplementation(() => {
+    mockExecFileSync.mockImplementation(() => {
       throw new Error("Error: Cannot find note");
     });
 
@@ -97,27 +98,31 @@ describe("executeJXA", () => {
       delete process.env.APPLE_NOTES_MCP_MAX_BUFFER;
     });
 
-    it("passes SIGKILL and a large maxBuffer to execSync", () => {
-      mockExecSync.mockReturnValue("ok");
+    it("passes SIGKILL and a large maxBuffer to execFileSync", () => {
+      mockExecFileSync.mockReturnValue("ok");
       executeJXA("JSON.stringify({})");
-      const opts = mockExecSync.mock.calls[0][1] as { killSignal?: string; maxBuffer?: number };
+      const opts = mockExecFileSync.mock.calls[0][2] as { killSignal?: string; maxBuffer?: number };
       expect(opts.killSignal).toBe("SIGKILL");
       expect(opts.maxBuffer).toBe(64 * 1024 * 1024);
     });
 
     it("honors APPLE_NOTES_MCP_MAX_BUFFER override", () => {
       process.env.APPLE_NOTES_MCP_MAX_BUFFER = "2097152";
-      mockExecSync.mockReturnValue("ok");
+      mockExecFileSync.mockReturnValue("ok");
       executeJXA("JSON.stringify({})");
-      const opts = mockExecSync.mock.calls[0][1] as { maxBuffer?: number };
+      const opts = mockExecFileSync.mock.calls[0][2] as { maxBuffer?: number };
       expect(opts.maxBuffer).toBe(2097152);
     });
   });
 
-  it("handles timeout errors", () => {
-    const error = new Error("Command failed") as Error & { killed: boolean };
-    error.killed = true;
-    mockExecSync.mockImplementation(() => {
+  it("handles timeout errors (ETIMEDOUT + SIGKILL, the real sync-exec shape)", () => {
+    const error = new Error("spawnSync osascript ETIMEDOUT") as Error & {
+      code: string;
+      signal: string;
+    };
+    error.code = "ETIMEDOUT";
+    error.signal = "SIGKILL";
+    mockExecFileSync.mockImplementation(() => {
       throw error;
     });
 

--- a/src/utils/jxa.ts
+++ b/src/utils/jxa.ts
@@ -14,7 +14,7 @@
  * @module utils/jxa
  */
 
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 
 /**
  * Output cap for osascript (JXA). Mirrors the AppleScript executor — Node's 1 MB
@@ -71,12 +71,19 @@ export function escapeForJXA(str: string): string {
 }
 
 /**
- * Checks if an error is a timeout error.
+ * Checks if an error is a timeout error. A timed-out sync exec call throws
+ * with code "ETIMEDOUT" and the configured killSignal (SIGKILL, per #17);
+ * the killed/SIGTERM checks are kept as a fallback for the async exec shape.
  */
 function isTimeoutError(error: unknown): boolean {
   if (error instanceof Error) {
-    const execError = error as Error & { killed?: boolean; signal?: string };
-    return execError.killed === true || execError.signal === "SIGTERM";
+    const execError = error as Error & { code?: string; killed?: boolean; signal?: string };
+    return (
+      execError.code === "ETIMEDOUT" ||
+      execError.killed === true ||
+      execError.signal === "SIGKILL" ||
+      execError.signal === "SIGTERM"
+    );
   }
   return false;
 }
@@ -109,18 +116,16 @@ export function executeJXA(script: string, options: JXAOptions = {}): JXAResult 
     };
   }
 
-  // Escape the script for shell embedding
-  // We use single quotes to wrap, so escape single quotes within
-  const escapedScript = script.trim().replace(/'/g, "'\\''");
-  const command = `osascript -l JavaScript -e '${escapedScript}'`;
-
   try {
-    const output = execSync(command, {
+    // osascript is invoked directly (no /bin/sh) and reads the script from
+    // stdin, so no shell escaping is needed and script size isn't bounded by
+    // the kernel's argv limit.
+    const output = execFileSync("osascript", ["-l", "JavaScript", "-"], {
+      input: script.trim(),
       encoding: "utf8",
       timeout: timeoutMs,
       killSignal: "SIGKILL", // reap a wedged osascript reliably (#17)
       maxBuffer: getMaxBuffer(), // avoid ENOBUFS truncation on large output (#16)
-      stdio: ["pipe", "pipe", "pipe"],
     });
 
     return {


### PR DESCRIPTION
## What this fixes

While reviewing the execution layer I found two related problems, both in how `executeAppleScript` and `executeJXA` shell out.

**Timeouts were never detected in production.** `isTimeoutError` checks `killed === true || signal === "SIGTERM"`, which is the error shape of the async `exec` API. A timed-out `execSync` call actually throws the underlying spawnSync error: `code: "ETIMEDOUT"` with the configured kill signal (`SIGKILL`, from #17). So a real timeout fell through to generic error parsing and surfaced as the raw `spawnSync /bin/sh ETIMEDOUT`. Worse, the retry gate keys off that detection, and `ETIMEDOUT` does not match the `/timed? out/i` transient pattern, so the retry-on-timeout behavior from #70 never actually ran. The unit tests passed because their mocked errors used the async shape. Detection now checks `ETIMEDOUT`/`SIGKILL` first (the old checks stay as a fallback for anyone wrapping this with async exec), and the tests throw the real error shape.

**Both executors composed `osascript -e '<script>'` as a shell string.** That made single-quote escaping the only barrier between note content and arbitrary shell execution, and it capped generated script size at the kernel argv limit, so a large enough note body could fail with E2BIG. They now call `execFileSync("osascript", ["-"], ...)` with the script delivered over stdin. No shell is involved at all, so the injection class of bug is structurally impossible, script size is unbounded, and each call saves a `/bin/sh` fork. `escapeForShell` and the JXA equivalent are gone. As a small bonus the retry sleep now blocks in-process via `Atomics.wait` instead of forking `/bin/sleep` per attempt.

## The honest caveat

The timeout bug survived this long because the tests encoded the wrong error shape, so the mocks agreed with the bug. I rewrote the affected tests to use the shape Node actually throws, and I verified against the real thing before trusting them: probed Node's sync-exec timeout error directly, confirmed `osascript -` reads both AppleScript and JXA from stdin, then ran a live check against Notes.app. A real `count of notes` call succeeds over stdin, and a forced 3-second timeout now returns the friendly timeout message instead of the raw spawnSync error.

## Out of scope

I did not touch the AppleScript-literal escaping in `appleNotesManager` (that layer is correct and unrelated), and I left the `with timeout` wrapping and SIGKILL semantics from #17 exactly as they were. No behavior changes for callers beyond timeouts now being reported and retried as #70 intended.

`lint`, `typecheck`, `test` (468 passing), and `build` are all green.