### PR TITLE
Fix stale sync warnings from orphaned cloud-state rows

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-notes",
-      "version": "2.5.11",
+      "version": "2.5.12",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-notes",
-      "version": "2.5.11",
+      "version": "2.5.12",
       "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.5.11",
+  "version": "2.5.12",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "apple-notes",
       "description": "Manage Apple Notes through natural language - create, search, read, update, delete, and organize notes and folders",
-      "version": "2.5.11",
+      "version": "2.5.12",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.5.11",
+  "version": "2.5.12",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, and organize notes and folders (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.12] - 2026-07-13
+### Fixed
+- **`get-sync-status` no longer reports orphaned Core Data rows as pending uploads.** The detector counted every `ZICCLOUDSTATE` version gap, including historical rows whose Notes syncing object no longer exists. It now requires a matching live `ZICCLOUDSYNCINGOBJECT` reference before treating a row as pending, preventing a permanent false active-sync warning while preserving detection for live unsynced objects.
+
 ## [2.5.11] - 2026-07-09
 ### Changed
 - **Setup errors are now actionable for end users** (end-user docs audit). Every Full Disk Access failure message (`get-checklist-state`, `get-note-metadata`, `health-check`, `doctor`) now says exactly what to do — grant Full Disk Access to the app that launches the server (Claude Desktop / Terminal / iTerm2), then fully quit and relaunch it — and links the absolute [Full Disk Access Setup Guide](https://github.com/sweetrb/apple-notes-mcp/blob/main/docs/FULL-DISK-ACCESS.md) URL instead of a repo-relative path that no-clone (npm / marketplace) installs can't resolve. The `doctor` ad-hoc-Node warning likewise links the absolute [Node runtime / TCC guide](https://github.com/sweetrb/apple-notes-mcp/blob/main/docs/NODE-RUNTIME-AND-TCC-PERMISSIONS.md). The shared URLs live in a new `src/utils/docsUrls.ts`. Automation-permission errors now point at **System Settings** > Privacy & Security > Automation (macOS renamed System Preferences in Ventura).

--- a/build/index.js
+++ b/build/index.js
@@ -41396,9 +41396,13 @@ function getSyncStatus(useCache = true) {
       status.recentActivity = secondsAgo < RECENT_ACTIVITY_THRESHOLD_SECONDS;
     }
     const query = `
-      SELECT COUNT(*) FROM ZICCLOUDSTATE
-      WHERE ZCURRENTLOCALVERSION > ZLATESTVERSIONSYNCEDTOCLOUD
-      AND ZLATESTVERSIONSYNCEDTOCLOUD IS NOT NULL;
+      SELECT COUNT(*) FROM ZICCLOUDSTATE state
+      WHERE state.ZCURRENTLOCALVERSION > state.ZLATESTVERSIONSYNCEDTOCLOUD
+      AND state.ZLATESTVERSIONSYNCEDTOCLOUD IS NOT NULL
+      AND EXISTS (
+        SELECT 1 FROM ZICCLOUDSYNCINGOBJECT object
+        WHERE object.ZCLOUDSTATE = state.Z_PK
+      );
     `;
     const result = execFileSync3(
       "sqlite3",

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.5.11",
+  "version": "2.5.12",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes-mcp",
-  "version": "2.5.11",
+  "version": "2.5.12",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Notes - create, search, update, and manage notes via Claude and other AI assistants",
   "type": "module",

--- a/src/utils/syncDetection.test.ts
+++ b/src/utils/syncDetection.test.ts
@@ -62,6 +62,25 @@ describe("getSyncStatus", () => {
     expect(status.warning).toBeUndefined();
   });
 
+  it("counts only cloud state rows referenced by live syncing objects", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockStatSync.mockReturnValue({
+      mtimeMs: Date.now() - 60000,
+    } as fs.Stats);
+    mockExecSync.mockReturnValue("0\n");
+
+    getSyncStatus();
+
+    const sqliteArgs = mockExecSync.mock.calls[0]?.[1];
+    expect(sqliteArgs).toEqual(
+      expect.arrayContaining([expect.stringContaining("ZICCLOUDSYNCINGOBJECT")])
+    );
+    expect(sqliteArgs).toEqual(expect.arrayContaining([expect.stringContaining("ZCLOUDSTATE")]));
+    expect(sqliteArgs).toEqual(
+      expect.arrayContaining([expect.stringContaining("object.ZCLOUDSTATE = state.Z_PK")])
+    );
+  });
+
   it("detects pending uploads", () => {
     mockExistsSync.mockReturnValue(true);
     mockStatSync.mockReturnValue({

--- a/src/utils/syncDetection.ts
+++ b/src/utils/syncDetection.ts
@@ -118,12 +118,18 @@ export function getSyncStatus(useCache = true): SyncStatus {
       status.recentActivity = secondsAgo < RECENT_ACTIVITY_THRESHOLD_SECONDS;
     }
 
-    // Query for pending sync changes
+    // Query for pending sync changes. Core Data can retain orphaned cloud-state
+    // rows after their syncing objects are gone, so count only states still
+    // referenced by a live ZICCLOUDSYNCINGOBJECT row.
     // Use a read-only connection and timeout to avoid blocking
     const query = `
-      SELECT COUNT(*) FROM ZICCLOUDSTATE
-      WHERE ZCURRENTLOCALVERSION > ZLATESTVERSIONSYNCEDTOCLOUD
-      AND ZLATESTVERSIONSYNCEDTOCLOUD IS NOT NULL;
+      SELECT COUNT(*) FROM ZICCLOUDSTATE state
+      WHERE state.ZCURRENTLOCALVERSION > state.ZLATESTVERSIONSYNCEDTOCLOUD
+      AND state.ZLATESTVERSIONSYNCEDTOCLOUD IS NOT NULL
+      AND EXISTS (
+        SELECT 1 FROM ZICCLOUDSYNCINGOBJECT object
+        WHERE object.ZCLOUDSTATE = state.Z_PK
+      );
     `;
 
     // Use execFileSync (argv array, no shell) to match the sibling sqlite callers


### PR DESCRIPTION
## What changed

`get-sync-status` was reporting 158 pending uploads on my Mac even though Notes was healthy and the count never changed. I traced those rows through `NoteStore.sqlite`. All 158 were orphaned `ZICCLOUDSTATE` rows, and none were referenced by a live `ZICCLOUDSYNCINGOBJECT`.

This change requires that live reference before a version gap counts as pending. Real gaps on live objects still count; historical orphan rows do not.

## Verification

- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test` (469 tests)
- `pnpm run build`
- Live MCP handshake and `get-sync-status`: 34 tools, `pendingUpload: 0`, idle

I kept this scoped to sync detection and its regression. It does not change Notes data or write behavior.
