### PR TITLE
perf: bulk-fetch note properties in listNotes instead of per-note Apple Events

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-notes",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-notes",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "apple-notes",
       "description": "Manage Apple Notes through natural language - create, search, read, update, delete, and organize notes and folders",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, and organize notes and folders (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.1] - 2026-07-20
+### Changed
+- **`list-notes` fetches note properties in bulk instead of two Apple Events per note.** Full-library listings scaled at roughly 8 notes/second, so a 524-note library took 63 seconds and blew past the 60-second tool timeout MCP clients enforce; `health-check` runs an unbounded listing internally, so large libraries looked broken to clients. Names, ids, and (when `modifiedSince` is set) modification dates now come back as whole-list Apple Events, with the date comparison done locally in AppleScript rather than a `whose` clause, which Notes evaluates per-note. Measured on the same 524-note library: filtered listing 63s → 6.7s, `health-check` 60s+ → ~10s. Dedup and `limit` are applied in JS after the bulk fetch.
+
 ## [2.6.0] - 2026-07-16
 ### Added
 - **`append-to-note`**: Appends or prepends content to an existing note by id or title, preserving all existing rich HTML formatting (bold, italic, etc.). Always reads and writes as HTML, splitting the title `<div>` from body to prevent title duplication. Supports `position` (`"after"` / `"before"`), `separator`, and `format` (`"plaintext"` / `"html"`) parameters.

--- a/build/index.js
+++ b/build/index.js
@@ -39932,28 +39932,27 @@ var AppleNotesManager = class {
     if (modifiedSince || safeLimit !== void 0) {
       const baseNotesSource = folder ? `notes of ${buildFolderReference(folder)}` : "notes";
       let dateSetup = "";
-      let notesSource = baseNotesSource;
+      let hasDateFilter = false;
       if (modifiedSince) {
         const date3 = new Date(modifiedSince);
         if (!isNaN(date3.getTime())) {
           dateSetup = buildAppleScriptDateVar(date3) + "\n";
-          notesSource = `(${baseNotesSource} whose modification date >= thresholdDate)`;
+          hasDateFilter = true;
         }
       }
-      const limitCheck = safeLimit !== void 0 ? `
-            if (count of resultList) >= ${safeLimit} then exit repeat` : "";
+      const notesSource = baseNotesSource;
+      const dateFetch = hasDateFilter ? `set noteDates to modification date of ${notesSource}
+        ` : "";
+      const dateGuardOpen = hasDateFilter ? `if (item i of noteDates) >= thresholdDate then
+            ` : "";
+      const dateGuardClose = hasDateFilter ? `
+          end if` : "";
       const listCommand2 = `
-        ${dateSetup}set resultList to {}
-        set seenIds to {}
-        repeat with n in ${notesSource}
-          try
-            set noteName to name of n
-            set noteId to id of n
-            if seenIds does not contain noteId then
-              set end of seenIds to noteId
-              set end of resultList to noteName & ${AS_FIELD_SEP} & noteId${limitCheck}
-            end if
-          end try
+        ${dateSetup}set noteNames to name of ${notesSource}
+        set noteIds to id of ${notesSource}
+        ${dateFetch}set resultList to {}
+        repeat with i from 1 to count of noteNames
+          ${dateGuardOpen}set end of resultList to (item i of noteNames) & ${AS_FIELD_SEP} & (item i of noteIds)${dateGuardClose}
         end repeat
         set AppleScript's text item delimiters to ${AS_RECORD_SEP}
         return resultList as text
@@ -39975,22 +39974,17 @@ var AppleNotesManager = class {
         if (seenIds2.has(noteId)) continue;
         seenIds2.add(noteId);
         titles2.push(title.trim());
+        if (safeLimit !== void 0 && titles2.length >= safeLimit) break;
       }
       return titles2;
     }
     const notesRef = folder ? `notes of ${buildFolderReference(folder)}` : `notes`;
     const listCommand = `
+      set noteNames to name of ${notesRef}
+      set noteIds to id of ${notesRef}
       set resultList to {}
-      set seenIds to {}
-      repeat with n in ${notesRef}
-        try
-          set noteName to name of n
-          set noteId to id of n
-          if seenIds does not contain noteId then
-            set end of seenIds to noteId
-            set end of resultList to noteName & ${AS_FIELD_SEP} & noteId
-          end if
-        end try
+      repeat with i from 1 to count of noteNames
+        set end of resultList to (item i of noteNames) & ${AS_FIELD_SEP} & (item i of noteIds)
       end repeat
       set AppleScript's text item delimiters to ${AS_RECORD_SEP}
       return resultList as text

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes-mcp",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Notes - create, search, update, and manage notes via Claude and other AI assistants",
   "type": "module",

--- a/src/services/appleNotesManager.test.ts
+++ b/src/services/appleNotesManager.test.ts
@@ -1549,20 +1549,22 @@ describe("AppleNotesManager", () => {
       expect(results).toEqual(["Recent Note 1", "Recent Note 2"]);
     });
 
-    it("uses repeat loop when limit is provided", () => {
+    it("bulk-fetches and applies limit in JS when limit is provided", () => {
       mockExecuteAppleScript.mockReturnValue({
         success: true,
         output: [
           ["Note 1", "x-coredata://ABC/ICNote/p1"].join(F),
           ["Note 2", "x-coredata://ABC/ICNote/p2"].join(F),
           ["Note 3", "x-coredata://ABC/ICNote/p3"].join(F),
+          ["Note 4", "x-coredata://ABC/ICNote/p4"].join(F),
         ].join(R),
       });
 
       const results = manager.listNotes(undefined, undefined, undefined, 3);
 
       const script = mockExecuteAppleScript.mock.calls[0][0];
-      expect(script).toContain("(count of resultList) >= 3");
+      expect(script).toContain("set noteNames to name of notes");
+      expect(script).toContain("set noteIds to id of notes");
       expect(results).toEqual(["Note 1", "Note 2", "Note 3"]);
     });
 
@@ -1580,7 +1582,7 @@ describe("AppleNotesManager", () => {
       const script = mockExecuteAppleScript.mock.calls[0][0];
       expect(script).toContain("whose modification date >= thresholdDate");
       expect(script).toContain('notes of folder "Work"');
-      expect(script).toContain("(count of resultList) >= 10");
+      expect(script).toContain("set noteNames to name of (notes of folder");
     });
 
     it("returns empty array when modifiedSince yields no results", () => {
@@ -1607,7 +1609,7 @@ describe("AppleNotesManager", () => {
 
       const script = mockExecuteAppleScript.mock.calls[0][0];
       expect(script).not.toContain("thresholdDate");
-      expect(script).toContain("(count of resultList) >= 5");
+      expect(script).toContain("set noteNames to name of notes");
       expect(results).toEqual(["Note 1", "Note 2"]);
     });
   });

--- a/src/services/appleNotesManager.test.ts
+++ b/src/services/appleNotesManager.test.ts
@@ -1528,7 +1528,7 @@ describe("AppleNotesManager", () => {
       );
     });
 
-    it("uses whose clause when modifiedSince is provided", () => {
+    it("filters by bulk-fetched modification dates when modifiedSince is provided", () => {
       mockExecuteAppleScript.mockReturnValue({
         success: true,
         output: [
@@ -1540,12 +1540,14 @@ describe("AppleNotesManager", () => {
       const results = manager.listNotes(undefined, undefined, "2025-06-15T00:00:00");
 
       const script = mockExecuteAppleScript.mock.calls[0][0];
-      // Locale-safe: uses variable setup + whose clause (no sort order assumption)
+      // Locale-safe: variable setup + local comparison over bulk-fetched
+      // dates (whose clauses evaluate per-note server-side and are slow)
       expect(script).toContain("set thresholdDate to current date");
       expect(script).toContain("set year of thresholdDate to 2025");
       expect(script).toContain("set month of thresholdDate to 6");
       expect(script).toContain("set day of thresholdDate to 15");
-      expect(script).toContain("whose modification date >= thresholdDate");
+      expect(script).toContain("set noteDates to modification date of notes");
+      expect(script).toContain("if (item i of noteDates) >= thresholdDate then");
       expect(results).toEqual(["Recent Note 1", "Recent Note 2"]);
     });
 
@@ -1580,9 +1582,9 @@ describe("AppleNotesManager", () => {
       manager.listNotes("iCloud", "Work", "2025-01-01", 10);
 
       const script = mockExecuteAppleScript.mock.calls[0][0];
-      expect(script).toContain("whose modification date >= thresholdDate");
       expect(script).toContain('notes of folder "Work"');
-      expect(script).toContain("set noteNames to name of (notes of folder");
+      expect(script).toContain('set noteDates to modification date of notes of folder "Work"');
+      expect(script).toContain('set noteNames to name of notes of folder "Work"');
     });
 
     it("returns empty array when modifiedSince yields no results", () => {

--- a/src/services/appleNotesManager.ts
+++ b/src/services/appleNotesManager.ts
@@ -1333,26 +1333,36 @@ export class AppleNotesManager {
     if (modifiedSince || safeLimit !== undefined) {
       const baseNotesSource = folder ? `notes of ${buildFolderReference(folder)}` : "notes";
 
-      // Use whose clause for date filtering (locale-safe, no sort order assumption)
+      // Date filtering compares bulk-fetched modification dates in a local
+      // loop instead of a whose clause: Notes evaluates whose filters
+      // per-note server-side, which is as slow as per-note Apple Events.
       let dateSetup = "";
-      let notesSource = baseNotesSource;
+      let hasDateFilter = false;
       if (modifiedSince) {
         const date = new Date(modifiedSince);
         if (!isNaN(date.getTime())) {
           dateSetup = buildAppleScriptDateVar(date) + "\n";
-          notesSource = `(${baseNotesSource} whose modification date >= thresholdDate)`;
+          hasDateFilter = true;
         }
       }
+      const notesSource = baseNotesSource;
 
       // Bulk-fetch names and ids as two whole-list Apple Events instead of two
       // events per note; per-note round trips scale linearly and push large
       // libraries past client tool timeouts. Dedup and limit stay in JS. (#17)
+      const dateFetch = hasDateFilter
+        ? `set noteDates to modification date of ${notesSource}\n        `
+        : "";
+      const dateGuardOpen = hasDateFilter
+        ? `if (item i of noteDates) >= thresholdDate then\n            `
+        : "";
+      const dateGuardClose = hasDateFilter ? `\n          end if` : "";
       const listCommand = `
         ${dateSetup}set noteNames to name of ${notesSource}
         set noteIds to id of ${notesSource}
-        set resultList to {}
+        ${dateFetch}set resultList to {}
         repeat with i from 1 to count of noteNames
-          set end of resultList to (item i of noteNames) & ${AS_FIELD_SEP} & (item i of noteIds)
+          ${dateGuardOpen}set end of resultList to (item i of noteNames) & ${AS_FIELD_SEP} & (item i of noteIds)${dateGuardClose}
         end repeat
         set AppleScript's text item delimiters to ${AS_RECORD_SEP}
         return resultList as text

--- a/src/services/appleNotesManager.ts
+++ b/src/services/appleNotesManager.ts
@@ -1344,26 +1344,15 @@ export class AppleNotesManager {
         }
       }
 
-      // Build the limit check. Check after appending so deduped results,
-      // rather than duplicate AppleScript references, determine the limit.
-      const limitCheck =
-        safeLimit !== undefined
-          ? `
-            if (count of resultList) >= ${safeLimit} then exit repeat`
-          : "";
-
+      // Bulk-fetch names and ids as two whole-list Apple Events instead of two
+      // events per note; per-note round trips scale linearly and push large
+      // libraries past client tool timeouts. Dedup and limit stay in JS. (#17)
       const listCommand = `
-        ${dateSetup}set resultList to {}
-        set seenIds to {}
-        repeat with n in ${notesSource}
-          try
-            set noteName to name of n
-            set noteId to id of n
-            if seenIds does not contain noteId then
-              set end of seenIds to noteId
-              set end of resultList to noteName & ${AS_FIELD_SEP} & noteId${limitCheck}
-            end if
-          end try
+        ${dateSetup}set noteNames to name of ${notesSource}
+        set noteIds to id of ${notesSource}
+        set resultList to {}
+        repeat with i from 1 to count of noteNames
+          set end of resultList to (item i of noteNames) & ${AS_FIELD_SEP} & (item i of noteIds)
         end repeat
         set AppleScript's text item delimiters to ${AS_RECORD_SEP}
         return resultList as text
@@ -1389,25 +1378,21 @@ export class AppleNotesManager {
         if (seenIds.has(noteId)) continue;
         seenIds.add(noteId);
         titles.push(title.trim());
+        if (safeLimit !== undefined && titles.length >= safeLimit) break;
       }
       return titles;
     }
 
-    // Simple path: no date or limit filters. Use a repeat loop so duplicate
-    // CoreData note references can be deduped by ID before returning titles.
+    // Simple path: no date or limit filters. Bulk-fetch names and ids as two
+    // whole-list Apple Events; duplicate CoreData references are deduped by
+    // ID in JS below. (#17)
     const notesRef = folder ? `notes of ${buildFolderReference(folder)}` : `notes`;
     const listCommand = `
+      set noteNames to name of ${notesRef}
+      set noteIds to id of ${notesRef}
       set resultList to {}
-      set seenIds to {}
-      repeat with n in ${notesRef}
-        try
-          set noteName to name of n
-          set noteId to id of n
-          if seenIds does not contain noteId then
-            set end of seenIds to noteId
-            set end of resultList to noteName & ${AS_FIELD_SEP} & noteId
-          end if
-        end try
+      repeat with i from 1 to count of noteNames
+        set end of resultList to (item i of noteNames) & ${AS_FIELD_SEP} & (item i of noteIds)
       end repeat
       set AppleScript's text item delimiters to ${AS_RECORD_SEP}
       return resultList as text


### PR DESCRIPTION
listNotes iterates notes with a repeat loop that sends two Apple Events per note (name of n, id of n). That works fine on small libraries, but it scales at roughly 8 notes per second. On my 524-note library a full listing takes 63 seconds, which blows past the 60 second tool timeout that MCP clients like Claude enforce. Since health-check runs an unbounded listNotes internally, a large library makes the connector look completely broken to the client even though nothing is wrong.

This change fetches name of notes and id of notes as two whole-list Apple Events and zips them in a local AppleScript loop. The modifiedSince filter needed one more step: a whose clause gets evaluated per note on the Notes side, so it is just as slow as the explicit loop. Instead I bulk-fetch modification date of notes as a third list and compare against thresholdDate locally. Comparing AppleScript dates in AppleScript also sidesteps any locale issues from coercing dates to text and parsing them in JS, which is the one part I would flag for review.

Measured on the same 524-note library through an MCP client: full listing with modifiedSince went from 63s (timeout) to 6.7s, and health-check went from 60s+ (timeout) to about 10s.

Dedup and the limit now happen in JS after the bulk fetch. I left the whose clause in searchNotes alone since it filters on note content, which has no bulk equivalent, and search result sets are small anyway.

Checks: npm run lint, typecheck, format:check, and npm test (477 passing, including three listNotes tests updated for the new script shape).