### PR TITLE
docs(skills): re-sync codex/antigravity SKILL.md copies; add sync-skills drift guard

### DIFF
--- a/.antigravity-plugin/skills/apple-notes/SKILL.md
+++ b/.antigravity-plugin/skills/apple-notes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: apple-notes
-description: Use this skill when the user wants to interact with Apple Notes on macOS - creating, searching, reading, updating, deleting, or organizing notes and folders. This skill provides access to the full Apple Notes app through MCP tools.
+description: Use this skill when the user wants to interact with Apple Notes on macOS - creating, searching, reading, updating, deleting, organizing, or formatting notes and folders. This skill provides access to Apple Notes through MCP tools and includes safe formatting guidance.
 ---
 
 # Apple Notes Skill
@@ -28,11 +28,17 @@ Use this skill when the user:
 | `create-note` | Create a new note with title and content |
 | `search-notes` | Find notes by title or content |
 | `get-note-content` | Read the full content of a note |
+| `get-note-plaintext` | Read a note's body as plain text (no HTML) |
+| `get-note-markdown` | Read note content as Markdown |
+| `get-note-by-id` | Get note metadata by ID |
 | `get-note-details` | Get metadata (created, modified, account) |
 | `update-note` | Modify a note's title or content |
 | `delete-note` | Remove a note (moves to Recently Deleted) |
+| `batch-delete-notes` | Delete multiple notes by ID |
 | `move-note` | Move a note to a different folder |
+| `batch-move-notes` | Move multiple notes by ID |
 | `list-notes` | List all notes or notes in a folder |
+| `export-notes-json` | Export all accounts, folders, and notes as JSON |
 
 ### Folder Operations
 
@@ -41,12 +47,30 @@ Use this skill when the user:
 | `list-folders` | List all folders in an account |
 | `create-folder` | Create a new folder |
 | `delete-folder` | Delete an empty folder |
+| `show-folder` | Reveal a folder in the Notes.app UI by ID |
 
 ### Account Operations
 
 | Tool | Purpose |
 |------|---------|
 | `list-accounts` | List configured accounts (iCloud, Gmail, etc.) |
+| `show-account` | Reveal an account in the Notes.app UI by ID |
+
+### Attachments, Checklists, Collaboration, and Diagnostics
+
+| Tool | Purpose |
+|------|---------|
+| `list-attachments` | List attachments in a note |
+| `save-attachment` | Save an attachment to disk |
+| `fetch-attachment` | Fetch attachment bytes as base64 |
+| `show-attachment` | Reveal an attachment in the Notes.app UI |
+| `get-checklist-state` | Read checked/unchecked state for existing checklists |
+| `get-note-metadata` | [BETA] Read pinned/trash/snippet metadata from the NoteStore DB |
+| `list-shared-notes` | List notes shared with collaborators |
+| `get-sync-status` | Check whether iCloud sync is active |
+| `health-check` | Quickly verify Notes.app access |
+| `doctor` | Run detailed setup diagnostics |
+| `get-notes-stats` | Summarize note counts and recent activity |
 
 ## Usage Patterns
 
@@ -56,13 +80,17 @@ When the user wants to save information:
 
 ```
 User: "Save this meeting summary as a note"
-Action: Use create-note with appropriate title and the content
+Action: Use create-note with an appropriate title and the content
 ```
 
 ```
 User: "Create a shopping list note"
 Action: Use create-note with title="Shopping List" and formatted content
 ```
+
+For structured notes, pass `format="html"` and use simple Apple Notes-friendly HTML. The server automatically prepends the `title` as an `<h1>` in both plaintext and HTML modes, so do not include the same `<h1>` title in `content` when creating a note.
+
+**Optional: full control of the title without a duplicate line.** The default approach (pass only `title`, let the server add the `<h1>`) is simplest and is what most notes need. If you instead want to control the title's HTML yourself and find the metadata title rendering as a small duplicate line above your styled `<h1>`, you can put the styled `<h1>Title</h1>` in `content`, then immediately `update-note` on the returned id with `newTitle: " "` (a single space) and the same HTML. Notes then uses the first body line as the sidebar title. Caveat: after blanking the metadata title this way, the note's CoreData id can stop resolving for follow-up calls, so address the note by its display title afterward. Prefer the default title-only approach unless you specifically need this.
 
 ### Finding Notes
 
@@ -87,6 +115,8 @@ User: "Show me my shopping list"
 Action: Use get-note-content with title="Shopping List"
 ```
 
+When search results include an ID, prefer that ID for all follow-up reads, edits, moves, or deletes. Titles can be duplicated, truncated, or contain characters that make title lookup fragile.
+
 ### Updating Notes
 
 When the user wants to modify a note:
@@ -94,9 +124,13 @@ When the user wants to modify a note:
 ```
 User: "Add milk to my shopping list"
 Action:
-1. Use get-note-content to read current content
-2. Use update-note with the updated content including "milk"
+1. Use search-notes if needed to get the note ID
+2. Use get-note-content or get-note-markdown to read current content
+3. Use list-attachments if the note may contain files, scans, images, audio, or PDFs
+4. Use update-note by ID with the complete updated body
 ```
+
+`update-note` replaces the entire note body. It is not an append operation. If `format="html"`, `newTitle` is ignored and the first element in `newContent` becomes the visible title.
 
 ### Organizing Notes
 
@@ -112,25 +146,69 @@ User: "Create a Work folder"
 Action: Use create-folder with name="Work"
 ```
 
+## Formatting Guidance
+
+Use HTML for predictable rich notes. Apple Notes normalizes HTML internally, but these tags are reliable for most API-created content:
+
+- Use `<div>` for body blocks and `<div><br></div>` for blank spacing.
+- Use `<h2>` and `<h3>` for section headings inside newly created notes. `create-note` already creates the top `<h1>` from the `title`.
+- Use `<ul><li>` and `<ol><li>` for native bullet and numbered lists. Add `<div><br></div>` after closing `</ul>` or `</ol>` so the next section has spacing.
+- Use `<b>`, `<i>`, `<u>`, and `<s>` for inline emphasis.
+- Use `<tt>` for commands, code, paths, API keys, and other technical strings.
+- Escape literal `&`, `<`, and `>` in user content as `&amp;`, `&lt;`, and `&gt;`.
+- Avoid nested lists when possible. Apple Notes can flatten or misplace nested list markup.
+- Use bare URLs when updating existing notes if anchor tags are stripped by Notes on save.
+- Do not use decorative separators between sections (horizontal rules, repeated dashes, or box-drawing characters). They render inconsistently in Notes; use an empty `<div><br></div>` spacer instead.
+
+Do not use CDATA sections. They can render literally in Apple Notes.
+
+## Attachment-Safe Updates
+
+Before updating an existing note, check whether it contains attachments when the user mentions or the note likely includes images, PDFs, scans, audio, files, or other embedded objects.
+
+- Use `list-attachments` before rewriting attachment-risk notes.
+- Treat empty body output, very large content, a `stdout maxBuffer length exceeded` error, or a non-empty `list-attachments` result as a warning that a full-body update may remove embedded objects.
+- If preserving attachments matters, create a new formatted note instead of overwriting the existing one, or save/fetch the attachments first and explain the limitation to the user.
+
+## Formatting Limits
+
+Some Notes UI features cannot be created by the current AppleScript-backed create/update tools:
+
+- Interactive checklists: create a plain list instead. Use `get-checklist-state` only to read existing checklist state.
+- Collapsible headings: API-created headings look like headings, but may not get Notes' native collapse controls.
+- Block quotes, dashed lists, and background highlights: these require manual Notes UI formatting.
+
+If the user specifically requires those features, create all API-supported content first, then explain which remaining formatting must be applied in Notes.app.
+
 ## Important Guidelines
 
-1. **Title Matching**: Note operations require exact title matches. If a note isn't found, suggest using `search-notes` first.
+1. **Prefer IDs**: Use note IDs for follow-up operations whenever available. If only a title is known, use `search-notes` first and then operate on the returned ID.
 
 2. **Default Account**: Operations default to iCloud. Use the `account` parameter for other accounts (Gmail, Exchange).
 
-3. **Content Format**: Notes store content as HTML. Plain text works fine for creation, but retrieved content may include HTML tags.
+3. **Content Format**: Notes store content as HTML. Use `format="html"` for structured content. Retrieved HTML is normalized by Notes and may not match the submitted HTML byte-for-byte.
 
 4. **Backslash Escaping**: When content contains backslashes, escape them as `\\` in the JSON.
 
 5. **Password-Protected Notes**: Cannot be accessed via this skill. Inform the user if they try.
 
-6. **macOS Only**: This skill only works on macOS systems.
+6. **Shared Notes**: Use extra care before edits or deletes. Changes to shared notes are visible to collaborators.
+
+7. **macOS Only**: This skill only works on macOS systems.
+
+## Verification
+
+`get-note-content` returns Apple Notes' stored HTML, which may differ from the original HTML while still rendering correctly. Use `get-note-markdown`, `get-note-content`, or a quick reread of the note after create/update to verify the title, line breaks, list spacing, and important content. Do not rewrite normalized HTML just because Notes transformed tags such as headings or monostyled text.
+
+When the stored HTML looks suspicious, `get-note-plaintext` is the quickest check: it returns the note's plain-text body (what Notes itself shows) with no markup, so you can confirm the title, line breaks, and text survived without reading through normalized HTML.
 
 ## Error Handling
 
 - **"Note not found"**: Use search-notes to find similar titles
-- **"Permission denied"**: User needs to grant automation permission in System Preferences
+- **"Permission denied"**: User needs to grant automation permission in System Settings > Privacy & Security > Automation
 - **"Folder not empty"**: Cannot delete folders with notes; move notes first
+- **Attachment-risk update**: Use list-attachments and avoid full-body updates unless the user accepts that embedded objects may be lost
+- **Notes accumulate blank lines after repeated updates**: Apple Notes' internal HTML processing preserves empty `<div><br></div>` artifacts from previous edits, and they persist even when you update with clean content. Fix: delete the note with delete-note and create a fresh one with create-note — the artifacts are baked into the note's internal representation, so this is more reliable than trying to fix the whitespace through updates
 
 ## Examples
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Root skills/ is canonical; codex/skills/ and .antigravity-plugin/skills/
+      # are generated copies. Fails when they drift (fix: pnpm run sync:skills).
+      - name: Verify skill copies match skills/
+        run: node scripts/sync-skills.mjs --check
+
       - name: Run linter
         run: pnpm run lint
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ When adding a new MCP tool:
 2. **Implement the method** in `src/services/appleNotesManager.ts`
 3. **Add type definitions** in `src/types.ts`
 4. **Write tests** in `src/services/appleNotesManager.test.ts`
-5. **Update documentation** in README.md and CHANGELOG.md
+5. **Update documentation** in README.md and CHANGELOG.md. If the skill guidance changed, edit `skills/apple-notes/SKILL.md` (the canonical copy) and run `pnpm run sync:skills` — the `codex/` and `.antigravity-plugin/` copies are generated from it and CI fails if they drift
 
 ## AppleScript Guidelines
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,4 +30,4 @@ This MCP server:
 - Does not store credentials or passwords
 - Cannot access password-protected notes
 
-The server requires macOS automation permissions to function. These permissions are managed by macOS and can be revoked at any time in System Preferences > Privacy & Security > Automation.
+The server requires macOS automation permissions to function. These permissions are managed by macOS and can be revoked at any time in System Settings > Privacy & Security > Automation.

--- a/codex/skills/apple-notes/SKILL.md
+++ b/codex/skills/apple-notes/SKILL.md
@@ -205,9 +205,10 @@ When the stored HTML looks suspicious, `get-note-plaintext` is the quickest chec
 ## Error Handling
 
 - **"Note not found"**: Use search-notes to find similar titles
-- **"Permission denied"**: User needs to grant automation permission in System Preferences
+- **"Permission denied"**: User needs to grant automation permission in System Settings > Privacy & Security > Automation
 - **"Folder not empty"**: Cannot delete folders with notes; move notes first
 - **Attachment-risk update**: Use list-attachments and avoid full-body updates unless the user accepts that embedded objects may be lost
+- **Notes accumulate blank lines after repeated updates**: Apple Notes' internal HTML processing preserves empty `<div><br></div>` artifacts from previous edits, and they persist even when you update with clean content. Fix: delete the note with delete-note and create a fresh one with create-note — the artifacts are baked into the note's internal representation, so this is more reliable than trying to fix the whitespace through updates
 
 ## Examples
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "format": "prettier --write src",
     "format:check": "prettier --check src",
     "typecheck": "tsc --noEmit",
+    "sync:skills": "node scripts/sync-skills.mjs",
     "version": "node scripts/sync-plugin-version.mjs && git add .claude-plugin .agents/plugins codex .hermes-plugin .antigravity-plugin",
     "prepublishOnly": "pnpm run lint && pnpm test && pnpm run build",
     "prepare": "husky; pnpm run build"

--- a/scripts/sync-skills.mjs
+++ b/scripts/sync-skills.mjs
@@ -1,0 +1,69 @@
+// Root skills/ is the canonical copy; the per-surface duplicates
+// (codex/skills/, .antigravity-plugin/skills/) are generated from it and must
+// never be edited directly. (.agents/plugins/marketplace.json sources ./codex,
+// and .hermes-plugin carries no skill copy — syncing codex covers every other
+// surface.)
+//
+//   node scripts/sync-skills.mjs          overwrite the copies from skills/
+//   node scripts/sync-skills.mjs --check  exit 1 on any drift (CI gate)
+//
+// Edit skills/**, run `pnpm run sync:skills`, and commit all three trees.
+
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const CANONICAL = "skills";
+const TARGETS = ["codex/skills", ".antigravity-plugin/skills"];
+
+const check = process.argv.includes("--check");
+const canonicalFiles = listFiles(path.join(root, CANONICAL));
+const drifted = [];
+
+for (const target of TARGETS) {
+  const targetRoot = path.join(root, target);
+  // Files present in a target but absent from skills/ are orphans from a
+  // removed or renamed skill — stale content, so they count as drift too.
+  for (const rel of listFiles(targetRoot)) {
+    if (!canonicalFiles.includes(rel)) {
+      drifted.push(`${path.join(target, rel)} (orphan; not in ${CANONICAL}/)`);
+      if (!check) fs.rmSync(path.join(targetRoot, rel));
+    }
+  }
+  for (const rel of canonicalFiles) {
+    const source = path.join(root, CANONICAL, rel);
+    const dest = path.join(targetRoot, rel);
+    if (
+      fs.existsSync(dest) &&
+      fs.readFileSync(source).equals(fs.readFileSync(dest))
+    ) {
+      continue;
+    }
+    drifted.push(path.join(target, rel));
+    if (!check) {
+      fs.mkdirSync(path.dirname(dest), { recursive: true });
+      fs.copyFileSync(source, dest);
+    }
+  }
+}
+
+if (drifted.length === 0) {
+  console.log(`skill copies in sync with ${CANONICAL}/: ${TARGETS.join(", ")}`);
+} else if (check) {
+  console.error(`skill copies have drifted from ${CANONICAL}/:`);
+  for (const file of drifted) console.error(`  ${file}`);
+  console.error("Run 'pnpm run sync:skills' and commit the result.");
+  process.exit(1);
+} else {
+  console.log(`synced from ${CANONICAL}/:`);
+  for (const file of drifted) console.log(`  ${file}`);
+}
+
+function listFiles(dir) {
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir, { recursive: true, withFileTypes: true })
+    .filter((entry) => entry.isFile())
+    .map((entry) => path.relative(dir, path.join(entry.parentPath, entry.name)))
+    .sort();
+}


### PR DESCRIPTION
## Description

The `codex/` and `.antigravity-plugin/` SKILL.md copies had drifted from the canonical root `skills/apple-notes/SKILL.md`, violating the end-user docs invariants (#2 banned "System Preferences" phrasing, #6 copies-in-sync):

- **`.antigravity-plugin/skills/apple-notes/SKILL.md`** was a pre-2.x snapshot (155 lines vs 233): tool table missing ~15 shipped tools (`get-note-plaintext`/`-markdown`/`-by-id`, `batch-delete-notes`, `batch-move-notes`, `export-notes-json`, `show-folder`/`show-account`, and the entire attachments/checklists/collaboration/diagnostics section), plus no Formatting Guidance, Attachment-Safe Updates, Formatting Limits, or Verification sections, and a stale frontmatter description.
- **`codex/skills/apple-notes/SKILL.md`** said "grant automation permission in System Preferences" and omitted the blank-lines-artifact troubleshooting entry.

Both are now byte-identical to root. The same System Preferences → System Settings fix is applied to `SECURITY.md`. (`.agents/plugins/marketplace.json` sources `./codex`, and `.hermes-plugin/` carries no skill copy — syncing codex covers those surfaces.)

**Re-drift prevention (fix at the root):** new `scripts/sync-skills.mjs` (`pnpm run sync:skills`) owns the copies — regenerates them from `skills/` and removes orphan files — and a new CI step in `ci.yml`'s test job runs it with `--check`, failing any PR whose copies drift (same pattern as the committed-`build/` verify step). `CONTRIBUTING.md`'s "Adding New Tools" checklist now documents the flow.

## Type of Change

- [x] Documentation update
- [x] Other (describe): CI drift guard + sync script (tooling)

## Testing

- [x] Tests pass locally (`pnpm test` — 477/477)
- [x] Linting passes (`pnpm run lint`, `pnpm run typecheck`, `pnpm run format:check`)
- [x] `sync-skills.mjs --check` verified: passes in-sync, exits 1 on content drift and on orphan files, sync mode repairs both

No version bump: docs/tooling only — no `src/**` change, and the `package.json` edit is scripts-map only (`dependencies` untouched), so version-guard's exemptions apply.

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the project's style
- [x] I have updated documentation if needed
