### PR TITLE
docs: modernize contributor docs for the pnpm toolchain

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,12 +12,14 @@ Brief description of the changes.
 
 ## Testing
 
-- [ ] Tests pass locally (`npm test`)
-- [ ] Linting passes (`npm run lint`)
-- [ ] Build succeeds (`npm run build`)
+- [ ] Tests pass locally (`pnpm test`)
+- [ ] Linting passes (`pnpm run lint`)
+- [ ] Typecheck and formatting pass (`pnpm run typecheck && pnpm run format:check`)
+- [ ] Build succeeds (`pnpm run build`)
 
 ## Checklist
 
 - [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
 - [ ] My code follows the project's style
 - [ ] I have updated documentation if needed
+- [ ] If this PR changes shipped code (`src/**` excluding tests, or the runtime `dependencies` in `package.json`): version bumped at least a patch (`pnpm version patch --no-git-tag-version`) + a CHANGELOG.md entry — the `require-version-bump` CI check enforces this (docs-only and test-only PRs are exempt)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,23 +6,25 @@ Thank you for your interest in contributing! This document provides guidelines f
 
 1. **Clone the repository**
    ```bash
-   git clone https://github.com/sweetrb/mcp-apple-notes.git
-   cd mcp-apple-notes
+   git clone https://github.com/sweetrb/apple-notes-mcp.git
+   cd apple-notes-mcp
    ```
 
 2. **Install dependencies**
    ```bash
-   npm install
+   pnpm install
    ```
+
+   This repo pins pnpm via `packageManager` in `package.json` — `corepack enable` provides it. Development needs Node >= 22.13 (CI tests on Node 22 and 24); the published server itself runs on Node >= 20.
 
 3. **Build the project**
    ```bash
-   npm run build
+   pnpm run build
    ```
 
 4. **Run tests**
    ```bash
-   npm test
+   pnpm test
    ```
 
 ## Code Style
@@ -31,16 +33,16 @@ This project uses ESLint and Prettier for code quality and formatting.
 
 ```bash
 # Check for linting issues
-npm run lint
+pnpm run lint
 
 # Auto-fix linting issues
-npm run lint:fix
+pnpm run lint:fix
 
 # Format code
-npm run format
+pnpm run format
 
 # Check formatting
-npm run format:check
+pnpm run format:check
 ```
 
 ## Testing
@@ -49,10 +51,10 @@ All new features should include tests. We use Vitest for testing.
 
 ```bash
 # Run tests once
-npm test
+pnpm test
 
 # Run tests in watch mode
-npm run test:watch
+pnpm run test:watch
 ```
 
 ### Testing Guidelines
@@ -75,17 +77,22 @@ npm run test:watch
 
 3. **Run all checks**
    ```bash
-   npm run lint
-   npm run typecheck
-   npm test
-   npm run build
+   pnpm run lint
+   pnpm run typecheck
+   pnpm run format:check
+   pnpm test
+   pnpm run build
    ```
 
-4. **Commit your changes**
+4. **Version bump & committed bundle** (shipped-code changes only)
+   - Any change to shipped code (`src/**` excluding tests, or the runtime `dependencies` in `package.json`) must bump `package.json` at least a patch (`pnpm version patch --no-git-tag-version`) and add a CHANGELOG.md entry in the same PR — the `require-version-bump` CI check fails the PR otherwise. Docs-only and test-only PRs are exempt.
+   - The bundled `build/index.js` is committed to git: after source changes, rebuild (`pnpm run build`) and commit the updated bundle alongside `src/` — CI verifies the committed bundle matches the source.
+
+5. **Commit your changes**
    - Use clear, descriptive commit messages
    - Reference any related issues
 
-5. **Push and create a PR**
+6. **Push and create a PR**
    - Describe what your PR does
    - Link any related issues
 
@@ -93,7 +100,7 @@ npm run test:watch
 
 When adding a new MCP tool:
 
-1. **Add the schema** in `src/index.ts`
+1. **Add the schema** in `src/index.ts` (with a structured `Use when: / Returns: / Do not use when:` description, plus `Safety:` for any write/destructive tool)
 2. **Implement the method** in `src/services/appleNotesManager.ts`
 3. **Add type definitions** in `src/types.ts`
 4. **Write tests** in `src/services/appleNotesManager.test.ts`


### PR DESCRIPTION
The repos migrated from npm to pnpm in June 2026, but the contributor docs still taught npm dev commands — this refreshes CONTRIBUTING.md and the PR template to match the actual toolchain.

**CONTRIBUTING.md**
- All npm dev commands converted to pnpm (`pnpm install`, `pnpm test`, `pnpm run lint`/`lint:fix`/`format`/`format:check`/`typecheck`/`build`/`test:watch`)
- Fixed the clone URL: `sweetrb/mcp-apple-notes` → `sweetrb/apple-notes-mcp` (and the matching `cd`)
- Added a note that pnpm is pinned via `packageManager` (`corepack enable` provides it) and that development needs Node >= 22.13 (CI tests on 22 + 24) while the published server runs on Node >= 20
- "Run all checks" now includes `pnpm run format:check` (CI gates it separately)
- New "Version bump & committed bundle" step in the Pull Request Process: shipped-code changes must bump at least a patch + CHANGELOG entry (`require-version-bump` enforces it), and the committed `build/index.js` must be rebuilt alongside `src/` changes
- "Adding New Tools" step 1 now asks for the structured `Use when: / Returns: / Do not use when:` (+ `Safety:`) tool description, matching the numbers/photos repos

**.github/PULL_REQUEST_TEMPLATE.md**
- Testing checkboxes use pnpm and add typecheck/format:check + build
- Checklist adds the version-bump + CHANGELOG item for shipped-code PRs

Docs-only — no version bump (version-guard exempts docs-only PRs).
