### PR TITLE
ci: bulletproof hardening (audit 2026-07-20)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-notes",
-      "version": "2.6.1",
+      "version": "2.6.2",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-notes",
-      "version": "2.6.1",
+      "version": "2.6.2",
       "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "apple-notes",
       "description": "Manage Apple Notes through natural language - create, search, read, update, delete, and organize notes and folders",
-      "version": "2.6.1",
+      "version": "2.6.2",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, and organize notes and folders (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,3 @@ updates:
     groups:
       github-actions:
         patterns: ["*"]
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,6 @@
+# RENAME HAZARD: `name: CI` is publish.yml's workflow_run trigger key, and the
+# `test` job's matrix produces required branch-protection contexts
+# `test (22)` / `test (24)`. Renaming either silently severs publishing/merging.
 name: CI
 
 on:
@@ -30,13 +33,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: "pnpm"
@@ -52,6 +55,12 @@ jobs:
       - name: Run linter
         run: pnpm run lint
 
+      - name: Check formatting
+        run: pnpm run format:check
+
+      - name: Verify plugin manifests match package.json version
+        run: node scripts/sync-plugin-version.mjs --check
+
       - name: Type check
         run: pnpm run typecheck
 
@@ -60,7 +69,7 @@ jobs:
 
       - name: Upload coverage reports
         if: matrix.node-version == 22
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./coverage/lcov.info
           fail_ci_if_error: false
@@ -71,11 +80,45 @@ jobs:
 
       - name: Verify committed build/ matches source
         run: |
+          UNTRACKED=$(git status --porcelain --ignored -- build/ | grep -E '^(\?\?|!!)' || true)
+          if [ -n "$UNTRACKED" ]; then
+            echo "::error::Build emitted files into build/ that are not tracked:"; echo "$UNTRACKED"
+            exit 1
+          fi
           if ! git diff --quiet build/; then
             echo "::error::build/ is out of date. Run 'pnpm run build' locally and commit the changes."
             git --no-pager diff --stat build/
             exit 1
           fi
+
+  # The committed bundle is what npm and marketplace users actually run — prove
+  # every push that it boots standalone (no node_modules) on the engines floor.
+  bundle-boots:
+    name: bundle-boots (standalone, Node 20)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "20"
+      - name: Boot the committed bundle standalone (no node_modules, Node 20)
+        # macOS runners have no `timeout` binary; the perl alarm+exec wrapper is
+        # the always-present equivalent (the alarm survives exec).
+        run: |
+          set -euo pipefail
+          DIR=$(mktemp -d)
+          cp package.json "$DIR/"
+          cp -R build "$DIR/build"
+          cd "$DIR"
+          RESP=$(printf '%s\n' \
+            '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"ci-boot","version":"0"}}}' \
+            | perl -e 'alarm 30; exec @ARGV' node build/index.js | head -1)
+          echo "$RESP" | node -e '
+            let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{
+              const j=JSON.parse(s);
+              if(!j.result||!j.result.serverInfo||!j.result.serverInfo.version){console.error("no serverInfo in initialize response");process.exit(1)}
+              console.log("bundle boots standalone on Node 20: v"+j.result.serverInfo.version);
+            })'
 
   # Integration suite (opt-in, real Notes.app). On CI the runner's Notes.app has
   # no signed-in account, so the live tests self-skip; the path-safety and
@@ -86,13 +129,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       - name: Setup Node.js 22
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: "pnpm"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,11 +17,11 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           languages: javascript-typescript
           queries: security-extended
       - name: Analyze
-        uses: github/codeql-action/analyze@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
       - name: Enable auto-merge for dev-deps and github-actions
         if: ${{ steps.meta.outputs.package-ecosystem == 'github_actions' || steps.meta.outputs.dependency-type == 'direct:development' }}
         run: gh pr merge --auto --squash "${{ github.event.pull_request.html_url }}"

--- a/.github/workflows/dependabot-rebuild.yml
+++ b/.github/workflows/dependabot-rebuild.yml
@@ -76,7 +76,7 @@ jobs:
       built_from: ${{ steps.head.outputs.sha }}
     steps:
       - name: Checkout PR head branch
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.head_ref || github.ref_name }}
           persist-credentials: false
@@ -105,7 +105,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.guard.outputs.skip != 'true'
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: "pnpm"
@@ -158,9 +158,12 @@ jobs:
     steps:
       - name: Checkout PR head branch
         if: needs.rebuild.outputs.changed == 'true'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.head_ref || github.ref_name }}
+          # Full history so the auto-bump step can compute the fork point
+          # (merge-base with origin/main) the same way version-guard does.
+          fetch-depth: 0
 
       - name: Abort if the branch moved since the rebuild
         if: needs.rebuild.outputs.changed == 'true'
@@ -191,6 +194,53 @@ jobs:
         with:
           name: rebuilt-bundle
           path: build/
+
+      - name: Auto-bump patch version for shipped-byte change
+        # version-guard now treats build/** as shipped bytes; without this
+        # auto-bump, every bundle-changing Dependabot PR would fail that
+        # required check (the rebuilt bundle changes what users receive, but
+        # the bot never bumps package.json). Token-split invariant: NO pnpm
+        # and NO install in this job — dependency lifecycle code must never
+        # run with the write token — so the edits below are plain `node -e`
+        # plus the repo-owned, dependency-free sync script.
+        if: needs.rebuild.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          # Same fork-point semantics as version-guard: compare package.json's
+          # version field between the merge-base with origin/main and HEAD.
+          git fetch --no-tags --quiet origin +refs/heads/main:refs/remotes/origin/main
+          BASE="$(git merge-base origin/main HEAD)"
+          OLDV="$(git show "${BASE}:package.json" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(JSON.parse(s).version))')"
+          NEWV="$(node -p "require('./package.json').version")"
+          if [ "$OLDV" != "$NEWV" ]; then
+            echo "Version already bumped vs fork point (${OLDV} -> ${NEWV}) — skipping auto-bump."
+            exit 0
+          fi
+          node -e '
+            const fs = require("fs");
+            const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+            const p = pkg.version.split(".");
+            p[2] = String(Number(p[2]) + 1);
+            pkg.version = p.join(".");
+            fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n");
+            console.log("Auto-bumped version to " + pkg.version);
+          '
+          node scripts/sync-plugin-version.mjs
+          NEWV="$(node -p "require('./package.json').version")" node -e '
+            const fs = require("fs");
+            const v = process.env.NEWV;
+            const date = new Date().toISOString().slice(0, 10);
+            const entry = "## [" + v + "] - " + date + "\n### Changed\n- Dependency bump via Dependabot; committed bundle rebuilt. (automated)\n";
+            const cl = fs.readFileSync("CHANGELOG.md", "utf8");
+            const marker = "## [Unreleased]";
+            const i = cl.indexOf(marker);
+            if (i === -1) { console.error("no [Unreleased] section in CHANGELOG.md"); process.exit(1); }
+            const at = i + marker.length;
+            const rest = cl.slice(at).replace(/^\n*/, "");
+            fs.writeFileSync("CHANGELOG.md", cl.slice(0, at) + "\n\n" + entry + "\n" + rest);
+            console.log("Prepended CHANGELOG entry for " + v);
+          '
+          git add package.json CHANGELOG.md build .claude-plugin .agents codex .hermes-plugin .antigravity-plugin 2>/dev/null || true
 
       - name: Commit and push the rebuilt bundle
         if: needs.rebuild.outputs.changed == 'true'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,3 +1,15 @@
+# ┌─────────────────────────── RENAME HAZARD ───────────────────────────┐
+# │ Three names in this pipeline are LOAD-BEARING COUPLINGS:            │
+# │  1. This FILE's name (publish.yml) is the npm Trusted Publisher     │
+# │     key — rename it and OIDC publishing breaks (photos hit this:    │
+# │     auto-release.yml had to be renamed to match).                   │
+# │  2. `workflows: [CI]` below matches ci.yml's `name:` — retitle CI   │
+# │     and this workflow never fires again (the daily schedule below   │
+# │     is the safety net that turns that silent break into a loud one).│
+# │  3. ci.yml's `test` job + matrix [22, 24] produce the required      │
+# │     branch-protection contexts `test (22)` / `test (24)` — rename   │
+# │     the job or matrix and merges block on phantom checks.           │
+# └─────────────────────────────────────────────────────────────────────┘
 name: Publish to npm
 
 on:
@@ -7,12 +19,24 @@ on:
     workflows: [CI]
     types: [completed]
     branches: [main]
+  # Manual retry for a stranded publish (e.g. CI flake recovered by
+  # re-dispatching CI, whose green run a workflow_run trigger would
+  # otherwise accept only for `push` events).
+  workflow_dispatch:
+  # Daily watchdog: retries any pending publish (version on main absent from
+  # npm) and self-heals a missed GitHub Release. Converts every silent
+  # never-publish variant — severed trigger coupling, race, transient npm or
+  # gh failure — into automatic recovery within 24h, or a RED run (email)
+  # when recovery fails. Runs read-only when nothing is pending.
+  schedule:
+    - cron: "17 9 * * *"
 
-# A release lands two pushes on main (PR merge + chore(release) bump), so two CI
-# runs complete and each triggers a publish. Without serialization they race —
-# both read the pre-publish version and the loser fails with a 403 "cannot
-# publish over existing version". This group serializes them; the second then
-# sees the version already published and skips cleanly.
+# Each release can land multiple pushes on main in quick succession, so
+# multiple CI runs complete and each triggers a publish. Without
+# serialization they race: both read the pre-publish version, both attempt
+# publish, and the loser fails with a 403 "cannot publish over existing
+# version" (noisy failure emails). A concurrency group serializes them; the
+# later run then sees the version already published and skips cleanly.
 concurrency:
   group: publish-to-npm
   cancel-in-progress: false
@@ -22,36 +46,53 @@ jobs:
     runs-on: macos-latest
     if: >
       (github.event_name == 'release') ||
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push')
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event_name == 'schedule') ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' &&
+        (github.event.workflow_run.event == 'push' || github.event.workflow_run.event == 'workflow_dispatch'))
     permissions:
       id-token: write
       contents: write
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Checkout repository (the CI-validated commit, not a moving ref)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # For workflow_run, check out exactly the commit CI validated —
+          # otherwise a push landing between CI completion and this checkout
+          # publishes bytes (and provenance, and a Release tag) that no CI
+          # run ever saw. Other events check out their natural ref
+          # (main for schedule/dispatch, the tag for release).
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || '' }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
 
-      - name: Check if version is already published
+      - name: Check if this exact version is already published
         id: check
+        # Exact-version existence (`npm view pkg@version`), NOT latest-equality:
+        # immune to the registry's `latest` CDN lag, and a manual Release
+        # created for an old version is a clean no-op instead of a re-publish
+        # attempt.
         run: |
+          PKG=$(node -p "require('./package.json').name")
           LOCAL_VERSION=$(node -p "require('./package.json').version")
-          PUBLISHED_VERSION=$(npm view apple-notes-mcp version 2>/dev/null || echo "0.0.0")
+          EXISTS=$(npm view "${PKG}@${LOCAL_VERSION}" version 2>/dev/null || echo "")
+          echo "pkg=$PKG" >> "$GITHUB_OUTPUT"
           echo "local=$LOCAL_VERSION" >> "$GITHUB_OUTPUT"
-          echo "published=$PUBLISHED_VERSION" >> "$GITHUB_OUTPUT"
-          if [ "$LOCAL_VERSION" = "$PUBLISHED_VERSION" ]; then
+          if [ -n "$EXISTS" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "${PKG}@${LOCAL_VERSION} is already on npm — nothing to publish."
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "${PKG}@${LOCAL_VERSION} is not on npm — publishing."
           fi
 
       - name: Install dependencies
@@ -72,34 +113,34 @@ jobs:
 
       - name: Publish to npm (pnpm + OIDC trusted publishing)
         if: steps.check.outputs.skip == 'false'
-        # Phase 2: publish via `pnpm publish` over OIDC trusted publishing
-        # (tokenless — no NPM_TOKEN). pnpm 11 supports npm's OIDC flow; the npm
-        # trusted-publisher config is keyed to repo + workflow file, not the CLI,
-        # so it still matches after the npm→pnpm switch. `--provenance` emits the
-        # attestation; `--no-git-checks` because CI publishes from a clean but
-        # detached checkout (pnpm otherwise refuses to publish off a branch).
-        # Tolerate the publish race: a release lands two pushes on main, so two CI
-        # runs complete and each triggers a publish. The concurrency group
-        # serializes them, but the registry read (`npm view`, CDN-cached) lags the
-        # write, so the second run can still see the old version, attempt to
-        # publish, and get a 403 for the version the first run just pushed. Treat
-        # that specific case as success.
+        # `pnpm publish` does the OIDC exchange + provenance (no token).
+        # `--no-git-checks` skips pnpm's clean-tree/branch guard, which CI
+        # does not satisfy.
+        #
+        # Tolerate the publish race: the concurrency group serializes runs,
+        # but npm's registry read lags the write, so a later run's existence
+        # check can miss the version a concurrent run just pushed, attempt to
+        # publish, and get a 403. Re-check and treat that case as success.
         run: |
           if pnpm publish --provenance --no-git-checks; then
             echo "Published."
           else
-            LOCAL=$(node -p "require('./package.json').version")
-            PUBLISHED=$(npm view apple-notes-mcp version 2>/dev/null || echo "")
-            if [ "$PUBLISHED" = "$LOCAL" ]; then
-              echo "Version $LOCAL is already on npm (published by a concurrent run); treating as success."
+            PKG="${{ steps.check.outputs.pkg }}"
+            LOCAL="${{ steps.check.outputs.local }}"
+            NOW_EXISTS=$(npm view "${PKG}@${LOCAL}" version 2>/dev/null || echo "")
+            if [ -n "$NOW_EXISTS" ]; then
+              echo "${PKG}@${LOCAL} is already on npm (published by a concurrent run); treating as success."
             else
-              echo "::error::pnpm publish failed and $LOCAL is not on npm."
+              echo "::error::pnpm publish failed and ${PKG}@${LOCAL} is not on npm."
               exit 1
             fi
           fi
 
-      - name: Create GitHub Release (keep Releases in sync with npm)
-        if: steps.check.outputs.skip == 'false'
+      - name: Sync GitHub Release (self-healing — runs on every trigger)
+        # Deliberately NOT gated on the skip flag: idempotent via
+        # `gh release view`, so a Release missed by a transient failure in an
+        # earlier run is healed by ANY later run, including the daily
+        # schedule.
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -110,7 +151,7 @@ jobs:
             NOTES=$(awk -v v="## [$VERSION]" 'index($0,v)==1{p=1;next} p&&/^## \[/{exit} p' CHANGELOG.md)
             [ -z "$NOTES" ] && NOTES="Published to npm as v$VERSION."
             gh release create "v$VERSION" --target "$(git rev-parse HEAD)" --title "v$VERSION" --notes "$NOTES" \
-              || echo "::warning::Failed to create GitHub Release v$VERSION (npm publish still succeeded)"
+              || echo "::warning::Failed to create GitHub Release v$VERSION (will self-heal on the next run)"
           fi
 
       - name: Skip publish (version already published)

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -21,7 +21,7 @@ jobs:
       id-token: write # publish results to the OpenSSF API (badge)
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -33,13 +33,13 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       - name: Upload SARIF to code scanning
-        uses: github/codeql-action/upload-sarif@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           sarif_file: results.sarif

--- a/.github/workflows/version-guard.yml
+++ b/.github/workflows/version-guard.yml
@@ -1,15 +1,21 @@
 name: version-guard
 
-# Fail any PR to main that changes SHIPPED CODE without bumping package.json's
-# version. Shipped code = src/** (non-test), requirements.txt, and the RUNTIME
-# `dependencies` map in package.json — runtime deps are inlined into the
-# committed esbuild bundle, so bumping one changes shipped bytes too (rule
-# added 2026-07-15 alongside dependabot-rebuild.yml; previously a merged
-# runtime-dep bump silently never reached npm). Docs-only, test-only, dev-dep
-# and github-actions bumps stay exempt. Rationale: publish.yml only runs
-# `pnpm publish` when the version differs from npm, so an un-bumped code
-# change would silently never release. This makes the bump mandatory. The
-# guard file itself lives in .github/ (doesn't ship), so it needs no bump.
+# Fail any PR to main that changes SHIPPED BYTES without bumping package.json's
+# version. Shipped bytes = the committed esbuild bundle under build/** (it IS
+# what npm and marketplace users run), plus src/** (non-test) and
+# requirements.txt as first-cause detectors with better error messages, plus
+# the RUNTIME `dependencies` map in package.json. build/** was added
+# 2026-07-20: it subsumes every cause that changes what users receive — direct
+# deps, lockfile-only transitive bumps, and esbuild codegen changes — none of
+# which the src/deps detectors could see (a lockfile-only runtime-dep bump
+# merged un-bumped on 2026-07-15 and sat unshipped for two days).
+# Docs-only, test-only, and github-actions changes stay exempt; byte-neutral
+# devDependency bumps stay exempt because they leave build/ untouched.
+# Rationale: publish.yml only publishes when the version is absent from npm,
+# so an un-bumped shipped-byte change silently never releases. This guard
+# makes the bump mandatory; dependabot-rebuild.yml auto-bumps bot PRs whose
+# rebuilt bundle changed, so Dependabot automation keeps flowing.
+# The guard file itself lives in .github/ (doesn't ship), so it needs no bump.
 
 on:
   pull_request:
@@ -27,11 +33,11 @@ jobs:
   require-version-bump:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
-      - name: Require a version bump when shipped code changes
+      - name: Require a version bump when shipped bytes change
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -51,15 +57,17 @@ jobs:
           changed="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}")"
           echo "Changed files:"; printf '%s\n' "$changed" | sed 's/^/  /'
 
-          # Shipped-code paths: TS/JS sources and python sidecars under src/ (minus
-          # tests/mocks), plus the python dependency manifest. build/ is generated.
+          # Shipped bytes: the committed bundle itself (build/**), plus source
+          # and the python dependency manifest (minus tests/mocks) as
+          # first-cause detectors.
           code="$(printf '%s\n' "$changed" \
-            | grep -E '^(src/.*|requirements\.txt)$' \
+            | grep -E '^(src/.*|requirements\.txt|build/.*)$' \
             | grep -vE '(\.test\.ts$|\.spec\.ts$|/__tests__/|/__mocks__/)' || true)"
 
           # Runtime deps are shipped code too: they are inlined into the
           # committed bundle. Compare only the `dependencies` map —
-          # devDependencies stay exempt so dev-dep automerge is unaffected.
+          # devDependencies stay exempt so dev-dep automerge is unaffected
+          # (a devDep bump that changes the bundle is caught by build/**).
           deps_changed=""
           if printf '%s\n' "$changed" | grep -qx 'package.json'; then
             old_deps="$(git show "${BASE_SHA}:package.json" | jq -cS '.dependencies // {}')"
@@ -72,34 +80,50 @@ jobs:
             fi
           fi
 
-          if [ -z "$code" ] && [ -z "$deps_changed" ]; then
-            echo "::notice::No shipped-code changes — version bump not required."
-            exit 0
-          fi
-          if [ -n "$code" ]; then
-            echo "Shipped-code changes detected:"; printf '%s\n' "$code" | sed 's/^/  /'
-          fi
-
           oldv="$(git show "${BASE_SHA}:package.json" \
             | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(JSON.parse(s).version))')"
           newv="$(node -e 'console.log(require("./package.json").version)')"
           echo "package.json version: base=${oldv}  head=${newv}"
 
+          if [ "$oldv" != "$newv" ]; then
+            # Bump present: require it to be an increase (typo'd downgrades)…
+            OLDV="$oldv" NEWV="$newv" node -e '
+              const a = process.env.OLDV.split(".").map(Number);
+              const b = process.env.NEWV.split(".").map(Number);
+              const cmp = (b[0]-a[0]) || (b[1]-a[1]) || (b[2]-a[2]);
+              if (cmp > 0) { console.log("Version bumped " + process.env.OLDV + " -> " + process.env.NEWV + "."); process.exit(0); }
+              console.error("::error::package.json version went " + process.env.OLDV + " -> " + process.env.NEWV + " (not an increase). Bump it forward.");
+              process.exit(1);
+            '
+            # …and require it to be UNPUBLISHED. Two concurrently-open PRs can
+            # each bump to the same next patch; without this, the second merge
+            # is a version collision publish.yml silently skips. Registry
+            # errors fail open (a registry outage must not block merges).
+            PKG="$(node -p "require('./package.json').name")"
+            set +e
+            existing="$(npm view "${PKG}@${newv}" version 2>/dev/null)"
+            set -e
+            if [ -n "$existing" ]; then
+              echo "::error::${PKG}@${newv} is already published on npm — this bump collides with an existing release (another PR likely claimed it first). Rebase on main and bump again:  pnpm version patch --no-git-tag-version"
+              exit 1
+            fi
+            echo "${PKG}@${newv} is unclaimed on npm."
+          fi
+
+          if [ -z "$code" ] && [ -z "$deps_changed" ]; then
+            echo "::notice::No shipped-byte changes — version bump not required."
+            exit 0
+          fi
+          if [ -n "$code" ]; then
+            echo "Shipped-byte changes detected:"; printf '%s\n' "$code" | sed 's/^/  /'
+          fi
+
           if [ "$oldv" = "$newv" ]; then
             if [ -n "$deps_changed" ]; then
               echo "::error::Runtime dependencies changed (the shipped bundle changes) but package.json version is unchanged (${oldv}). Bump at least a patch + add a CHANGELOG entry so publish.yml actually ships the dependency update:  pnpm version patch --no-git-tag-version"
             else
-              echo "::error::Shipped code changed but package.json version is unchanged (${oldv}). Bump it at least a patch:  pnpm version patch --no-git-tag-version  (and add a CHANGELOG entry)."
+              echo "::error::Shipped bytes changed (src/, requirements.txt, or the committed build/ bundle) but package.json version is unchanged (${oldv}). Bump it at least a patch:  pnpm version patch --no-git-tag-version  (and add a CHANGELOG entry)."
             fi
             exit 1
           fi
-
-          # Guard against a typo'd downgrade — require the new version to be greater.
-          OLDV="$oldv" NEWV="$newv" node -e '
-            const a = process.env.OLDV.split(".").map(Number);
-            const b = process.env.NEWV.split(".").map(Number);
-            const cmp = (b[0]-a[0]) || (b[1]-a[1]) || (b[2]-a[2]);
-            if (cmp > 0) { console.log("Version bumped " + process.env.OLDV + " -> " + process.env.NEWV + "."); process.exit(0); }
-            console.error("::error::package.json version went " + process.env.OLDV + " -> " + process.env.NEWV + " (not an increase). Bump it forward.");
-            process.exit(1);
-          '
+          echo "Shipped bytes changed and version is bumped — OK."

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,8 @@
 pnpm exec lint-staged
+# Rebuild the committed bundle when shipped inputs are staged, so a stale
+# build/ can never be committed alongside source (CI's verify step would
+# fail the PR otherwise).
+if git diff --cached --name-only | grep -qE '^(src/|package\.json$|pnpm-lock\.yaml$)'; then
+  pnpm run build
+  git add build
+fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.2] - 2026-07-20
+### Changed
+- CI/release hardening: `version-guard` now treats the committed `build/` bundle as shipped bytes (closing the lockfile-only and devDep silent-never-publish vectors) with an npm version-collision check; `publish.yml` gained a daily self-healing watchdog, manual dispatch, exact-version skip, CI-validated-commit checkout, and GitHub-Release self-heal; Dependabot bundle rebuilds now auto-bump a patch version; CI boots the committed bundle standalone on Node 20 every run; the bundle is now built with `--target=node20`, making the `engines.node >= 20` claim enforced at build time.
+
 ## [2.6.1] - 2026-07-20
 ### Changed
 - **`list-notes` fetches note properties in bulk instead of two Apple Events per note (#86).** Full-library listings scaled at roughly 8 notes/second, so a 524-note library took 63 seconds and blew past the 60-second tool timeout MCP clients enforce; `health-check` runs an unbounded listing internally, so large libraries looked broken to clients. Names, ids, and (when `modifiedSince` is set) modification dates now come back as whole-list Apple Events, with the date comparison done locally in AppleScript rather than a `whose` clause, which Notes evaluates per-note. Measured on the same 524-note library: filtered listing 63s → 6.7s, `health-check` 60s+ → ~10s. Dedup and `limit` are applied in JS after the bulk fetch. Thanks @oliverames.

--- a/build/index.js
+++ b/build/index.js
@@ -41697,7 +41697,7 @@ function detectChecklistAttempt(content) {
 function htmlToText(html) {
   return html.replace(/<[^>]*>/g, " ").replace(/&#x?[0-9a-f]+;/gi, " ").replace(/&[a-z]+;/gi, " ");
 }
-var HASHTAG_RE = /(?<![\p{L}\p{N}_])#([\p{L}\p{N}_]*\p{L}[\p{L}\p{N}_]*)/gu;
+var HASHTAG_RE = new RegExp("(?<![\\p{L}\\p{N}_])#([\\p{L}\\p{N}_]*\\p{L}[\\p{L}\\p{N}_]*)", "gu");
 function parseHashtags(body) {
   if (!body) return [];
   const text = htmlToText(body);

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes-mcp",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Notes - create, search, update, and manage notes via Claude and other AI assistants",
   "type": "module",
@@ -16,7 +16,8 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsc --noEmit && esbuild src/index.ts --bundle --platform=node --format=esm --outfile=build/index.js --banner:js=\"import { createRequire as __createRequire } from 'node:module'; const require = __createRequire(import.meta.url);\"",
+    "preinstall": "node -e \"const fs=require('fs');const ua=process.env.npm_config_user_agent||'';if(fs.existsSync('.git')&&!ua.startsWith('pnpm')){console.error('\\nThis repo uses pnpm. npm/yarn resolve dependencies off-lockfile and the committed bundle will mismatch CI.\\n\\n  corepack enable && pnpm install --frozen-lockfile\\n');process.exit(1)}\"",
+    "build": "tsc --noEmit && esbuild src/index.ts --bundle --platform=node --format=esm --target=node20 --outfile=build/index.js --banner:js=\"import { createRequire as __createRequire } from 'node:module'; const require = __createRequire(import.meta.url);\"",
     "start": "node build/index.js",
     "dev": "tsc --watch",
     "test": "vitest run",

--- a/scripts/sync-plugin-version.mjs
+++ b/scripts/sync-plugin-version.mjs
@@ -1,9 +1,16 @@
 import fs from "node:fs";
 import path from "node:path";
 
+// Normal mode: write package.json's version into every plugin manifest.
+// --check mode: write NOTHING; exit 0 silently when every manifest already
+// matches, exit 1 listing the mismatched files (CI runs this so a manifest
+// can never drift behind a version bump).
+const checkMode = process.argv.includes("--check");
+
 const root = process.cwd();
 const packageJson = readJson("package.json");
 const version = packageJson.version;
+const mismatches = [];
 
 updateJson(".claude-plugin/plugin.json", (data) => {
   data.version = version;
@@ -41,6 +48,17 @@ updateJson(".antigravity-plugin/marketplace.json", (data) => {
   }
 });
 
+if (checkMode && mismatches.length > 0) {
+  console.error(
+    `Plugin manifest versions do not match package.json (${version}):`,
+  );
+  for (const file of mismatches) {
+    console.error(`  ${file}`);
+  }
+  console.error("Fix: node scripts/sync-plugin-version.mjs");
+  process.exit(1);
+}
+
 function readJson(relativePath) {
   return JSON.parse(fs.readFileSync(path.join(root, relativePath), "utf8"));
 }
@@ -48,6 +66,14 @@ function readJson(relativePath) {
 function updateJson(relativePath, update) {
   const fullPath = path.join(root, relativePath);
   const data = readJson(relativePath);
+  const before = JSON.stringify(data, null, 2);
   update(data);
-  fs.writeFileSync(fullPath, `${JSON.stringify(data, null, 2)}\n`);
+  const after = JSON.stringify(data, null, 2);
+  if (checkMode) {
+    if (before !== after) {
+      mismatches.push(relativePath);
+    }
+    return;
+  }
+  fs.writeFileSync(fullPath, `${after}\n`);
 }


### PR DESCRIPTION
Applies the canonical CI-hardening spec (audit 2026-07-20) to apple-notes-mcp. One commit, version 2.6.1 -> 2.6.2 (the `--target=node20` bundle rebuild changes shipped bytes).

## What changed

| File | Change |
|---|---|
| `.github/workflows/version-guard.yml` | Replaced with canon: `build/**` now counts as shipped bytes (closes lockfile-only and devDep silent-never-publish vectors); bump must be a strict increase AND unclaimed on npm (collision check, fails open on registry outage); `workflow_dispatch` fork-point fallback. |
| `.github/workflows/publish.yml` | Replaced with canon: RENAME HAZARD header; daily self-healing watchdog (`17 9 * * *`); manual dispatch; exact-version existence skip; CI-validated `head_sha` checkout for `workflow_run`; concurrency serialization + publish-race tolerance; idempotent GitHub-Release self-heal on every trigger. |
| `.github/workflows/dependabot-rebuild.yml` | Write job auto-bumps a patch (plain `node -e` — no pnpm/install with the write token) when the rebuilt bundle differs and the version is unchanged vs the fork point; syncs manifests; prepends a CHANGELOG entry; rides the existing `[dependabot skip]` commit. Checkout now `fetch-depth: 0` for the merge-base. Pins bumped. |
| `.github/workflows/ci.yml` | RENAME HAZARD comment; new parallel `bundle-boots` job (standalone initialize handshake on Node 20, perl alarm wrapper — macOS runners have no `timeout`); emissions guard before the tracked-diff verify; `Check formatting` step (parity with siblings); `Verify plugin manifests match package.json version` step; pins bumped. |
| `.github/workflows/codeql.yml`, `scorecard.yml`, `dependabot-automerge.yml` | Action-pin catchup per the verified-SHA table (checkout v7.0.1, setup-node v7.0.0, upload-artifact v7.0.1, codecov v7.0.0, codeql-action v4.37.1, fetch-metadata v3.1.0). `pnpm/action-setup` deliberately left at v4.4.0. |
| `.github/dependabot.yml` | github-actions block: semver-major ignore removed (npm block untouched). |
| `scripts/sync-plugin-version.mjs` | New `--check` mode: writes nothing, exit 1 listing mismatched manifests, silent 0 on match. Verified both directions locally. |
| `package.json` | esbuild `--target=node20` (enforces `engines.node >= 20` at build time); pnpm-only `preinstall` guard (fails npm/yarn in a git checkout, inert for registry tarballs — tested both directions); 2.6.2. |
| `build/index.js` | Rebuilt with `--target=node20` (one regex literal downleveled to `new RegExp`); deterministic (post-commit rebuild is byte-identical). |
| `.husky/pre-commit` | Canonical hook: lint-staged + bundle rebuild/re-stage when shipped inputs are staged. |
| `CHANGELOG.md` + plugin manifests | 2.6.2 entry; manifests synced. |

## vitest 4: deferred

`vitest@4.1.10` + `@vitest/coverage-v8@4.1.10` fail 43 unit tests in `src/index.test.ts` — first failure class: `[vitest] The vi.fn() mock did not use 'function' or 'class' in its implementation` (v4's stricter constructor-mock semantics; the suite constructs a mocked `AppleNotesManager` via `vi.fn()`). Fixing requires test-file edits, so per spec the upgrade was reverted (integration suite was not reached).

## Local gates (all green)

- lint, typecheck, format:check, unit tests (485/485)
- integration tests against the real Notes.app (14/14)
- YAML parse of all 7 workflow files + dependabot.yml
- standalone bundle boot smoke (mktemp, no node_modules, initialize handshake) — local run on the pinned Node v24.17.0 (no Node 20 on this machine); the new CI job exercises real Node 20
- npm-guard both directions (npm install fails loudly at preinstall; pnpm install --frozen-lockfile passes; guard inert without `.git`)
- `node scripts/sync-plugin-version.mjs --check` passes; manifests == 2.6.2
- post-commit rebuild: `git diff --quiet -- build/` clean

## Deviations from the spec

- `pnpm version patch --no-git-tag-version` refuses to run on an unclean working tree (`ERR_PNPM_UNCLEAN_WORKING_TREE`), so the bump was done with a `node -e` edit + `node scripts/sync-plugin-version.mjs` — identical result, manifests verified.
- dependabot-rebuild.yml push-job checkout gained `fetch-depth: 0` (not in the spec text, but required for the spec's own `git merge-base origin/main HEAD` computation on what was previously a depth-1 checkout).
- Bundle-boots job implements the perl alarm wrapper in place of the spec snippet's `timeout 30`, as the spec's parenthetical directs.
