### PR TITLE
fix: return actual timestamps from note search

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-notes",
-      "version": "2.6.2",
+      "version": "2.6.3",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-notes",
-      "version": "2.6.2",
+      "version": "2.6.3",
       "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "apple-notes",
       "description": "Manage Apple Notes through natural language - create, search, read, update, delete, and organize notes and folders",
-      "version": "2.6.2",
+      "version": "2.6.3",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, and organize notes and folders (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **`search-notes` now returns each result's real creation and modification timestamps.** Search results previously filled both fields with the current time, making unrelated notes appear to have been created and modified when the search ran. The search AppleScript now emits locale-independent date components for each match and the manager parses those values into the structured response.
+- Each date read in the search loop is individually guarded with an `on error` fallback, matching the adjacent folder-name read. Without it a note whose `creation date`/`modification date` property throws would be dropped from the results entirely — and, because its ID was already recorded for deduplication, any later reference to that note would be suppressed too. The fallback degrades to the previous behaviour (current time) for that one field instead.
 
 ## [2.6.2] - 2026-07-20
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.3] - 2026-07-20
+
+### Fixed
+- **`search-notes` now returns each result's real creation and modification timestamps.** Search results previously filled both fields with the current time, making unrelated notes appear to have been created and modified when the search ran. The search AppleScript now emits locale-independent date components for each match and the manager parses those values into the structured response.
+
 ## [2.6.2] - 2026-07-20
 ### Changed
 - CI/release hardening: `version-guard` now treats the committed `build/` bundle as shipped bytes (closing the lockfile-only and devDep silent-never-publish vectors) with an npm version-collision check; `publish.yml` gained a daily self-healing watchdog, manual dispatch, exact-version skip, CI-validated-commit checkout, and GitHub-Release self-heal; Dependabot bundle rebuilds now auto-bump a patch version; CI boots the committed bundle standalone on Node 20 every run; the bundle is now built with `--target=node20`, making the `engines.node >= 20` claim enforced at build time.

--- a/build/index.js
+++ b/build/index.js
@@ -39565,14 +39565,24 @@ var AppleNotesManager = class {
           set noteId to id of n
           if seenIds does not contain noteId then
             set end of seenIds to noteId
-            set noteCreated to creation date of n
-            set noteModified to modification date of n
+            try
+              set noteCreated to creation date of n
+              set createdParts to ${asDatePartsExpr("noteCreated")}
+            on error
+              set createdParts to ""
+            end try
+            try
+              set noteModified to modification date of n
+              set modifiedParts to ${asDatePartsExpr("noteModified")}
+            on error
+              set modifiedParts to ""
+            end try
             try
               set noteFolder to name of container of n
             on error
               set noteFolder to "Notes"
             end try
-            set end of resultList to noteName & ${AS_FIELD_SEP} & noteId & ${AS_FIELD_SEP} & noteFolder & ${AS_FIELD_SEP} & ${asDatePartsExpr("noteCreated")} & ${AS_FIELD_SEP} & ${asDatePartsExpr("noteModified")}${limitCheck}
+            set end of resultList to noteName & ${AS_FIELD_SEP} & noteId & ${AS_FIELD_SEP} & noteFolder & ${AS_FIELD_SEP} & createdParts & ${AS_FIELD_SEP} & modifiedParts${limitCheck}
           end if
         end try
       end repeat

--- a/build/index.js
+++ b/build/index.js
@@ -39565,12 +39565,14 @@ var AppleNotesManager = class {
           set noteId to id of n
           if seenIds does not contain noteId then
             set end of seenIds to noteId
+            set noteCreated to creation date of n
+            set noteModified to modification date of n
             try
               set noteFolder to name of container of n
             on error
               set noteFolder to "Notes"
             end try
-            set end of resultList to noteName & ${AS_FIELD_SEP} & noteId & ${AS_FIELD_SEP} & noteFolder${limitCheck}
+            set end of resultList to noteName & ${AS_FIELD_SEP} & noteId & ${AS_FIELD_SEP} & noteFolder & ${AS_FIELD_SEP} & ${asDatePartsExpr("noteCreated")} & ${AS_FIELD_SEP} & ${asDatePartsExpr("noteModified")}${limitCheck}
           end if
         end try
       end repeat
@@ -39589,7 +39591,7 @@ var AppleNotesManager = class {
     const notes = [];
     const seenIds = /* @__PURE__ */ new Set();
     for (const item of items) {
-      const [title, id, folder2] = item.split(FIELD_SEP);
+      const [title, id, folder2, created, modified] = item.split(FIELD_SEP);
       if (!title?.trim()) continue;
       const noteId = id?.trim() || generateFallbackId();
       if (seenIds.has(noteId)) continue;
@@ -39600,8 +39602,8 @@ var AppleNotesManager = class {
         content: "",
         // Not fetched in search
         tags: [],
-        created: /* @__PURE__ */ new Date(),
-        modified: /* @__PURE__ */ new Date(),
+        created: parseAppleScriptDate(created ?? ""),
+        modified: parseAppleScriptDate(modified ?? ""),
         folder: folder2?.trim(),
         account: targetAccount
       });

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes-mcp",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Notes - create, search, update, and manage notes via Claude and other AI assistants",
   "type": "module",

--- a/src/services/appleNotesManager.test.ts
+++ b/src/services/appleNotesManager.test.ts
@@ -691,6 +691,29 @@ describe("AppleNotesManager", () => {
       expect(results[2].folder).toBe("Archive");
     });
 
+    it("returns actual creation and modification timestamps", () => {
+      mockExecuteAppleScript.mockReturnValue({
+        success: true,
+        output: [
+          "Meeting Notes",
+          "x-coredata://ABC/ICNote/p1",
+          "Work",
+          "2024-2-3-10-11-12",
+          "2025-6-7-13-14-15",
+        ].join(F),
+      });
+
+      const [result] = manager.searchNotes("meeting");
+
+      expect(result.created).toEqual(new Date(2024, 1, 3, 10, 11, 12));
+      expect(result.modified).toEqual(new Date(2025, 5, 7, 13, 14, 15));
+      const script = mockExecuteAppleScript.mock.calls[0][0];
+      expect(script).toContain("set noteCreated to creation date of n");
+      expect(script).toContain("set noteModified to modification date of n");
+      expect(script).toContain("year of noteCreated");
+      expect(script).toContain("year of noteModified");
+    });
+
     it("returns empty array when no matches found", () => {
       mockExecuteAppleScript.mockReturnValue({
         success: true,
@@ -854,7 +877,7 @@ describe("AppleNotesManager", () => {
       manager.searchNotes("note", false, undefined, undefined, "not-a-date");
 
       const script = mockExecuteAppleScript.mock.calls[0][0];
-      expect(script).not.toContain("modification date");
+      expect(script).not.toContain("modification date >= thresholdDate");
     });
 
     it("applies limit to search results", () => {

--- a/src/services/appleNotesManager.ts
+++ b/src/services/appleNotesManager.ts
@@ -888,14 +888,24 @@ export class AppleNotesManager {
           set noteId to id of n
           if seenIds does not contain noteId then
             set end of seenIds to noteId
-            set noteCreated to creation date of n
-            set noteModified to modification date of n
+            try
+              set noteCreated to creation date of n
+              set createdParts to ${asDatePartsExpr("noteCreated")}
+            on error
+              set createdParts to ""
+            end try
+            try
+              set noteModified to modification date of n
+              set modifiedParts to ${asDatePartsExpr("noteModified")}
+            on error
+              set modifiedParts to ""
+            end try
             try
               set noteFolder to name of container of n
             on error
               set noteFolder to "Notes"
             end try
-            set end of resultList to noteName & ${AS_FIELD_SEP} & noteId & ${AS_FIELD_SEP} & noteFolder & ${AS_FIELD_SEP} & ${asDatePartsExpr("noteCreated")} & ${AS_FIELD_SEP} & ${asDatePartsExpr("noteModified")}${limitCheck}
+            set end of resultList to noteName & ${AS_FIELD_SEP} & noteId & ${AS_FIELD_SEP} & noteFolder & ${AS_FIELD_SEP} & createdParts & ${AS_FIELD_SEP} & modifiedParts${limitCheck}
           end if
         end try
       end repeat

--- a/src/services/appleNotesManager.ts
+++ b/src/services/appleNotesManager.ts
@@ -875,7 +875,7 @@ export class AppleNotesManager {
           if (count of resultList) >= ${safeLimit} then exit repeat`
         : "";
 
-    // Get names, IDs, and folder for each matching note.
+    // Get names, IDs, folder, and real timestamps for each matching note.
     // Notes.app can return the same CoreData note more than once when asking
     // an account for all notes, so dedupe on note ID before adding results.
     const searchCommand = `
@@ -888,12 +888,14 @@ export class AppleNotesManager {
           set noteId to id of n
           if seenIds does not contain noteId then
             set end of seenIds to noteId
+            set noteCreated to creation date of n
+            set noteModified to modification date of n
             try
               set noteFolder to name of container of n
             on error
               set noteFolder to "Notes"
             end try
-            set end of resultList to noteName & ${AS_FIELD_SEP} & noteId & ${AS_FIELD_SEP} & noteFolder${limitCheck}
+            set end of resultList to noteName & ${AS_FIELD_SEP} & noteId & ${AS_FIELD_SEP} & noteFolder & ${AS_FIELD_SEP} & ${asDatePartsExpr("noteCreated")} & ${AS_FIELD_SEP} & ${asDatePartsExpr("noteModified")}${limitCheck}
           end if
         end try
       end repeat
@@ -919,7 +921,7 @@ export class AppleNotesManager {
     const notes: Note[] = [];
     const seenIds = new Set<string>();
     for (const item of items) {
-      const [title, id, folder] = item.split(FIELD_SEP);
+      const [title, id, folder, created, modified] = item.split(FIELD_SEP);
       if (!title?.trim()) continue;
       const noteId = id?.trim() || generateFallbackId();
       if (seenIds.has(noteId)) continue;
@@ -929,8 +931,8 @@ export class AppleNotesManager {
         title: title.trim(),
         content: "", // Not fetched in search
         tags: [] as string[],
-        created: new Date(),
-        modified: new Date(),
+        created: parseAppleScriptDate(created ?? ""),
+        modified: parseAppleScriptDate(modified ?? ""),
         folder: folder?.trim(),
         account: targetAccount,
       });

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -133,7 +133,13 @@ describe("live Notes.app operations", { timeout: 120_000 }, () => {
 
     try {
       const hits = mgr.searchNotes(marker, false, liveAccount!);
-      expect(hits.some((n) => n.title.includes(marker))).toBe(true);
+      const hit = hits.find((n) => n.title.includes(marker));
+      expect(hit).toBeDefined();
+
+      const details = mgr.getNoteById(hit!.id);
+      expect(details).not.toBeNull();
+      expect(hit!.created).toEqual(details!.created);
+      expect(hit!.modified).toEqual(details!.modified);
     } finally {
       expect(mgr.deleteNoteById(created!.id)).toBe(true);
     }


### PR DESCRIPTION
`search-notes` currently fills every result's `created` and `modified` fields with the time the search ran. I noticed it while searching a live 422-note library because unrelated notes all appeared to have been created at the same moment.

This changes the AppleScript response to include each matching note's creation and modification dates in the existing locale-independent numeric format. The manager now parses those values into the structured response. Search matching, limits, and the human-readable result stay unchanged.

The regression coverage includes both a focused unit test and a live Notes.app integration assertion. The live test creates a temporary note, searches for it, and confirms the search timestamps exactly match the metadata returned directly for the same note before cleaning it up.

## Verification

- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test` (486 tests)
- `pnpm run test:integration` (14 tests against Notes.app)
- `pnpm run build`
- `pnpm run format:check`
- `node scripts/sync-plugin-version.mjs --check`
- `git diff --check`
- Live read-only MCP search for `Surfshorts`, which returned the note's actual creation time (`2026-07-20T21:00:51.000Z`) and modification time (`2026-07-20T21:18:53.000Z`)

Version 2.6.3 is currently unclaimed on npm.
