### PR TITLE
fix: report visible title after HTML note updates

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-notes",
-      "version": "2.6.2",
+      "version": "2.6.3",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-notes",
-      "version": "2.6.2",
+      "version": "2.6.3",
       "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "apple-notes",
       "description": "Manage Apple Notes through natural language - create, search, read, update, delete, and organize notes and folders",
-      "version": "2.6.2",
+      "version": "2.6.3",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, and organize notes and folders (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.3] - 2026-07-20
+### Fixed
+- **`update-note` now reports the visible title after HTML updates.** HTML mode ignores `newTitle` and Notes.app derives the display title from the first rendered line of `newContent`, but the tool response previously echoed `newTitle` anyway. The response now derives the title from the submitted HTML and falls back to the current title when the body has no rendered text.
+
 ## [2.6.2] - 2026-07-20
 ### Changed
 - CI/release hardening: `version-guard` now treats the committed `build/` bundle as shipped bytes (closing the lockfile-only and devDep silent-never-publish vectors) with an npm version-collision check; `publish.yml` gained a daily self-healing watchdog, manual dispatch, exact-version skip, CI-validated-commit checkout, and GitHub-Release self-heal; Dependabot bundle rebuilds now auto-bump a patch version; CI boots the committed bundle standalone on Node 20 every run; the bundle is now built with `--target=node20`, making the `engines.node >= 20` claim enforced at build time.

--- a/README.md
+++ b/README.md
@@ -362,6 +362,8 @@ Updates an existing note's content and/or title.
 
 **Note:** Either `id` or `title` must be provided. Using `id` is recommended.
 
+**Returns:** Confirmation with the note's visible title and, for ID-based updates, its ID. For HTML updates, the title comes from the first rendered line of `newContent`, matching Notes.app. The response also warns if the note is shared.
+
 **Example - Using ID (recommended):**
 ```json
 {

--- a/build/index.js
+++ b/build/index.js
@@ -41754,6 +41754,38 @@ function strippedImagesWarning(stripped) {
   )} decoded) exceeded the per-image inline cap and ${stripped.strippedCount === 1 ? "was" : "were"} replaced with placeholders so the response stays within MCP message limits. The images are still in the note: use list-attachments with save-attachment or fetch-attachment to export them, or raise APPLE_NOTES_MCP_MAX_INLINE_IMAGE_BYTES.`;
 }
 
+// src/utils/noteTitle.ts
+function decodeNumericEntity(match, value, radix) {
+  const codePoint = Number.parseInt(value, radix);
+  if (!Number.isInteger(codePoint) || codePoint < 0 || codePoint > 1114111) {
+    return match;
+  }
+  return String.fromCodePoint(codePoint);
+}
+function decodeHtmlEntities(value) {
+  return value.replace(/&nbsp;/gi, " ").replace(/&lt;/gi, "<").replace(/&gt;/gi, ">").replace(/&quot;/gi, '"').replace(/&#39;|&apos;/gi, "'").replace(/&#(\d+);/g, (match, decimal) => decodeNumericEntity(match, decimal, 10)).replace(/&#x([\da-f]+);/gi, (match, hex) => decodeNumericEntity(match, hex, 16)).replace(/&amp;/gi, "&");
+}
+function firstRenderedHtmlLine(html) {
+  let text = html.replace(/<br\s*\/?>/gi, "\n").replace(/<\/(?:div|p|h[1-6]|li)>/gi, "\n");
+  let previous;
+  do {
+    previous = text;
+    text = text.replace(/<[^>]*>/g, "");
+  } while (text !== previous);
+  return decodeHtmlEntities(text).split(/\r?\n/).map((line) => line.trim()).find(Boolean);
+}
+function resolveUpdatedNoteTitle({
+  currentTitle,
+  newTitle,
+  newContent,
+  format
+}) {
+  if (format === "html") {
+    return firstRenderedHtmlLine(newContent) ?? currentTitle;
+  }
+  return newTitle || currentTitle;
+}
+
 // src/tools/doctor.ts
 import { spawnSync } from "child_process";
 function runDoctor(manager) {
@@ -42385,7 +42417,7 @@ server.registerTool(
 server.registerTool(
   "update-note",
   {
-    description: "Use when: changing the title and/or replacing the body of an existing note, by id (preferred) or title.\nReturns: confirmation; warns when the note is shared.\nDo not use when: creating a new note (create-note).\nSafety: newContent REPLACES the entire body \u2014 it does not append. Read the note first if you need to preserve existing text, and run list-attachments first when the note may hold files, images, scans, PDFs, or audio, since a full-body replace can drop embedded attachments. Edits to shared notes are immediately visible to all collaborators.",
+    description: "Use when: changing the title and/or replacing the body of an existing note, by id (preferred) or title.\nReturns: confirmation with the note's visible title; warns when the note is shared.\nDo not use when: creating a new note (create-note).\nSafety: newContent REPLACES the entire body \u2014 it does not append. Read the note first if you need to preserve existing text, and run list-attachments first when the note may hold files, images, scans, PDFs, or audio, since a full-body replace can drop embedded attachments. Edits to shared notes are immediately visible to all collaborators.",
     inputSchema: {
       id: external_exports.string().max(MAX.ID).optional().describe("Note ID (preferred - more reliable than title)"),
       title: external_exports.string().max(MAX.TITLE).optional().describe("Current note title (use id instead when available)"),
@@ -42418,7 +42450,12 @@ server.registerTool(
       if (!success2) {
         return errorResponse(`Failed to update note "${note2.title}"`);
       }
-      const displayTitle = newTitle || note2.title;
+      const displayTitle = resolveUpdatedNoteTitle({
+        currentTitle: note2.title,
+        newTitle,
+        newContent,
+        format
+      });
       const sharedWarning2 = note2.shared ? "\n\n\u26A0\uFE0F This note is shared with collaborators. Your changes will be visible to them." : "";
       const checklistWarning2 = detectChecklistAttempt(newContent) ?? "";
       return successResponse(`Note updated: "${displayTitle}"${sharedWarning2}${checklistWarning2}`, {
@@ -42446,7 +42483,12 @@ server.registerTool(
     if (!success) {
       return errorResponse(`Failed to update note "${title}"`);
     }
-    const finalTitle = newTitle || title;
+    const finalTitle = resolveUpdatedNoteTitle({
+      currentTitle: note.title,
+      newTitle,
+      newContent,
+      format
+    });
     const sharedWarning = note.shared ? "\n\n\u26A0\uFE0F This note is shared with collaborators. Your changes will be visible to them." : "";
     const checklistWarning = detectChecklistAttempt(newContent) ?? "";
     return successResponse(`Note updated: "${finalTitle}"${sharedWarning}${checklistWarning}`, {

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes-mcp",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Notes - create, search, update, and manage notes via Claude and other AI assistants",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import { getNoteMetadata } from "@/utils/noteMetadata.js";
 import { detectChecklistAttempt } from "@/utils/contentWarnings.js";
 import { parseHashtags } from "@/utils/hashtags.js";
 import { stripLargeInlineImages, strippedImagesWarning } from "@/utils/inlineImages.js";
+import { resolveUpdatedNoteTitle } from "@/utils/noteTitle.js";
 import { runDoctor, formatDoctorReport } from "@/tools/doctor.js";
 import { FULL_DISK_ACCESS_GUIDE_URL } from "@/utils/docsUrls.js";
 import { loadFileConfig } from "@/services/fileConfig.js";
@@ -707,7 +708,7 @@ server.registerTool(
   "update-note",
   {
     description:
-      "Use when: changing the title and/or replacing the body of an existing note, by id (preferred) or title.\nReturns: confirmation; warns when the note is shared.\nDo not use when: creating a new note (create-note).\nSafety: newContent REPLACES the entire body — it does not append. Read the note first if you need to preserve existing text, and run list-attachments first when the note may hold files, images, scans, PDFs, or audio, since a full-body replace can drop embedded attachments. Edits to shared notes are immediately visible to all collaborators.",
+      "Use when: changing the title and/or replacing the body of an existing note, by id (preferred) or title.\nReturns: confirmation with the note's visible title; warns when the note is shared.\nDo not use when: creating a new note (create-note).\nSafety: newContent REPLACES the entire body — it does not append. Read the note first if you need to preserve existing text, and run list-attachments first when the note may hold files, images, scans, PDFs, or audio, since a full-body replace can drop embedded attachments. Edits to shared notes are immediately visible to all collaborators.",
     inputSchema: {
       id: z
         .string()
@@ -762,7 +763,12 @@ server.registerTool(
       if (!success) {
         return errorResponse(`Failed to update note "${note.title}"`);
       }
-      const displayTitle = newTitle || note.title;
+      const displayTitle = resolveUpdatedNoteTitle({
+        currentTitle: note.title,
+        newTitle,
+        newContent,
+        format,
+      });
       // Add collaboration warning if note is shared
       const sharedWarning = note.shared
         ? "\n\n⚠️ This note is shared with collaborators. Your changes will be visible to them."
@@ -799,7 +805,12 @@ server.registerTool(
       return errorResponse(`Failed to update note "${title}"`);
     }
 
-    const finalTitle = newTitle || title;
+    const finalTitle = resolveUpdatedNoteTitle({
+      currentTitle: note.title,
+      newTitle,
+      newContent,
+      format,
+    });
     // Add collaboration warning if note is shared
     const sharedWarning = note.shared
       ? "\n\n⚠️ This note is shared with collaborators. Your changes will be visible to them."

--- a/src/utils/noteTitle.test.ts
+++ b/src/utils/noteTitle.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { resolveUpdatedNoteTitle } from "@/utils/noteTitle.js";
+
+describe("resolveUpdatedNoteTitle", () => {
+  it("uses the first rendered HTML line instead of newTitle", () => {
+    expect(
+      resolveUpdatedNoteTitle({
+        currentTitle: "Old title",
+        newTitle: " ",
+        newContent: "<h1>Sailing Helmet Recommendations</h1><div>Body</div>",
+        format: "html",
+      })
+    ).toBe("Sailing Helmet Recommendations");
+  });
+
+  it("decodes inline formatting and entities in an HTML title", () => {
+    expect(
+      resolveUpdatedNoteTitle({
+        currentTitle: "Old title",
+        newContent: "<div><b>Tom &amp; Jerry</b></div><div>Body</div>",
+        format: "html",
+      })
+    ).toBe("Tom & Jerry");
+  });
+
+  it("falls back to the current title when HTML has no rendered text", () => {
+    expect(
+      resolveUpdatedNoteTitle({
+        currentTitle: "Keep this title",
+        newTitle: " ",
+        newContent: "<div><br></div>",
+        format: "html",
+      })
+    ).toBe("Keep this title");
+  });
+
+  it("does not fail the response on an invalid numeric entity", () => {
+    expect(
+      resolveUpdatedNoteTitle({
+        currentTitle: "Old title",
+        newContent: "<h1>Title &#999999999999;</h1>",
+        format: "html",
+      })
+    ).toBe("Title &#999999999999;");
+  });
+
+  it("uses newTitle for plaintext updates", () => {
+    expect(
+      resolveUpdatedNoteTitle({
+        currentTitle: "Old title",
+        newTitle: "New title",
+        newContent: "Body",
+        format: "plaintext",
+      })
+    ).toBe("New title");
+  });
+});

--- a/src/utils/noteTitle.ts
+++ b/src/utils/noteTitle.ts
@@ -1,0 +1,61 @@
+interface UpdatedNoteTitleInput {
+  currentTitle: string;
+  newTitle?: string;
+  newContent: string;
+  format: "plaintext" | "html";
+}
+
+function decodeNumericEntity(match: string, value: string, radix: number): string {
+  const codePoint = Number.parseInt(value, radix);
+  if (!Number.isInteger(codePoint) || codePoint < 0 || codePoint > 0x10ffff) {
+    return match;
+  }
+
+  return String.fromCodePoint(codePoint);
+}
+
+function decodeHtmlEntities(value: string): string {
+  return value
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;|&apos;/gi, "'")
+    .replace(/&#(\d+);/g, (match, decimal: string) => decodeNumericEntity(match, decimal, 10))
+    .replace(/&#x([\da-f]+);/gi, (match, hex: string) => decodeNumericEntity(match, hex, 16))
+    .replace(/&amp;/gi, "&");
+}
+
+function firstRenderedHtmlLine(html: string): string | undefined {
+  let text = html.replace(/<br\s*\/?>/gi, "\n").replace(/<\/(?:div|p|h[1-6]|li)>/gi, "\n");
+
+  let previous: string;
+  do {
+    previous = text;
+    text = text.replace(/<[^>]*>/g, "");
+  } while (text !== previous);
+
+  return decodeHtmlEntities(text)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find(Boolean);
+}
+
+/**
+ * Resolves the visible title an update-note response should report.
+ *
+ * Apple Notes ignores newTitle for HTML updates and derives the display title
+ * from the first rendered line of the replacement body.
+ */
+export function resolveUpdatedNoteTitle({
+  currentTitle,
+  newTitle,
+  newContent,
+  format,
+}: UpdatedNoteTitleInput): string {
+  if (format === "html") {
+    return firstRenderedHtmlLine(newContent) ?? currentTitle;
+  }
+
+  return newTitle || currentTitle;
+}


### PR DESCRIPTION
## What changed

`update-note` now derives its response title from the first rendered line of `newContent` in HTML mode. That matches the title Notes.app actually displays.

I found this while using the documented title-cleanup flow. The update succeeded and Notes showed `Sailing Helmet Recommendations`, but the tool response said `Note updated: " "` because it echoed `newTitle`, even though HTML mode ignores that field.

The parser handles inline tags, common HTML entities, and numeric entities. If the HTML has no rendered text, it keeps the current title. Plaintext update behavior is unchanged.

I did not add a post-write Notes.app read. That would add another Apple Event to every HTML update, and the submitted HTML already contains the title Notes uses.

## Testing

- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run format:check`
- `pnpm test` (490 tests passed)
- `pnpm run build`
