### PR TITLE
Fix update-note title reporting for HTML updates

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-notes",
-      "version": "2.6.2",
+      "version": "2.6.3",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-notes",
-      "version": "2.6.3",
+      "version": "2.6.4",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-notes",
-      "version": "2.6.2",
+      "version": "2.6.3",
       "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-notes",
-      "version": "2.6.3",
+      "version": "2.6.4",
       "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "apple-notes",
       "description": "Manage Apple Notes through natural language - create, search, read, update, delete, and organize notes and folders",
-      "version": "2.6.2",
+      "version": "2.6.3",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "apple-notes",
       "description": "Manage Apple Notes through natural language - create, search, read, update, delete, and organize notes and folders",
-      "version": "2.6.3",
+      "version": "2.6.4",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, and organize notes and folders (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, and organize notes and folders (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- **`update-note` no longer reports an ignored `newTitle` as the note's title for HTML updates.** In `format: "html"` mode, Apple Notes derives the visible title from the first line of `newContent` and the manager intentionally ignores `newTitle`, but the tool response still echoed `newTitle` as though it had been applied. The response now keeps the known current title for HTML updates, and the live tool schema explicitly tells callers to put the visible title first in `newContent`.
+- **`update-note` no longer reports an ignored `newTitle` as the note's title for HTML updates.** In `format: "html"` mode, Apple Notes derives the visible title from the first line of `newContent` and the manager intentionally ignores `newTitle`, but the tool response still echoed `newTitle` as though it had been applied. The response now reports the first visible HTML line (falling back to the known current title when the body has no text), and the live tool schema explicitly tells callers to put the visible title first in `newContent`.
 
 ## [2.6.2] - 2026-07-20
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`update-note` no longer reports an ignored `newTitle` as the note's title for HTML updates.** In `format: "html"` mode, Apple Notes derives the visible title from the first line of `newContent` and the manager intentionally ignores `newTitle`, but the tool response still echoed `newTitle` as though it had been applied. The response now keeps the known current title for HTML updates, and the live tool schema explicitly tells callers to put the visible title first in `newContent`.
+
 ## [2.6.2] - 2026-07-20
 ### Changed
 - CI/release hardening: `version-guard` now treats the committed `build/` bundle as shipped bytes (closing the lockfile-only and devDep silent-never-publish vectors) with an npm version-collision check; `publish.yml` gained a daily self-healing watchdog, manual dispatch, exact-version skip, CI-validated-commit checkout, and GitHub-Release self-heal; Dependabot bundle rebuilds now auto-bump a patch version; CI boots the committed bundle standalone on Node 20 every run; the bundle is now built with `--target=node20`, making the `engines.node >= 20` claim enforced at build time.

--- a/build/index.js
+++ b/build/index.js
@@ -41755,8 +41755,31 @@ function strippedImagesWarning(stripped) {
 }
 
 // src/utils/updateResponseTitle.ts
-function resolveUpdateResponseTitle(currentTitle, newTitle, format) {
-  if (format === "html") return currentTitle;
+var BLOCK_END_RE = /<\/(?:div|h[1-6]|p|li)>/gi;
+var BREAK_RE = /<br\s*\/?\s*>/gi;
+var TAG_RE = /<[^>]*>/g;
+var NON_RENDERED_BLOCK_RE = /<(script|style)\b[^>]*>[\s\S]*?<\/\1>/gi;
+function decodeHtmlEntities(text) {
+  const decodeCodePoint = (match, value, radix) => {
+    const codePoint = Number.parseInt(value, radix);
+    if (!Number.isInteger(codePoint) || codePoint < 0 || codePoint > 1114111 || codePoint >= 55296 && codePoint <= 57343) {
+      return match;
+    }
+    return String.fromCodePoint(codePoint);
+  };
+  return text.replace(/&#x([0-9a-f]+);?/gi, (match, hex) => decodeCodePoint(match, hex, 16)).replace(/&#([0-9]+);?/g, (match, decimal) => decodeCodePoint(match, decimal, 10)).replace(/&nbsp(?:;|(?![0-9a-z]))/gi, " ").replace(/&quot(?:;|(?![0-9a-z]))/gi, '"').replace(/&apos(?:;|(?![0-9a-z]))/gi, "'").replace(/&lt(?:;|(?![0-9a-z]))/gi, "<").replace(/&gt(?:;|(?![0-9a-z]))/gi, ">").replace(/&amp(?:;|(?![0-9a-z]))/gi, "&");
+}
+function firstVisibleHtmlLine(html) {
+  let text = html.replace(NON_RENDERED_BLOCK_RE, "").replace(BREAK_RE, "\n").replace(BLOCK_END_RE, "\n");
+  let previous;
+  do {
+    previous = text;
+    text = text.replace(TAG_RE, "");
+  } while (text !== previous);
+  return decodeHtmlEntities(text).split(/[\r\n\u2028\u2029]+/).map((line) => line.replace(/\s+/g, " ").trim()).find(Boolean);
+}
+function resolveUpdateResponseTitle(currentTitle, newTitle, format, newContent) {
+  if (format === "html") return firstVisibleHtmlLine(newContent) ?? currentTitle;
   return newTitle || currentTitle;
 }
 
@@ -42426,7 +42449,7 @@ server.registerTool(
       if (!success2) {
         return errorResponse(`Failed to update note "${note2.title}"`);
       }
-      const displayTitle = resolveUpdateResponseTitle(note2.title, newTitle, format);
+      const displayTitle = resolveUpdateResponseTitle(note2.title, newTitle, format, newContent);
       const sharedWarning2 = note2.shared ? "\n\n\u26A0\uFE0F This note is shared with collaborators. Your changes will be visible to them." : "";
       const checklistWarning2 = detectChecklistAttempt(newContent) ?? "";
       return successResponse(`Note updated: "${displayTitle}"${sharedWarning2}${checklistWarning2}`, {
@@ -42454,7 +42477,7 @@ server.registerTool(
     if (!success) {
       return errorResponse(`Failed to update note "${title}"`);
     }
-    const finalTitle = resolveUpdateResponseTitle(note.title, newTitle, format);
+    const finalTitle = resolveUpdateResponseTitle(note.title, newTitle, format, newContent);
     const sharedWarning = note.shared ? "\n\n\u26A0\uFE0F This note is shared with collaborators. Your changes will be visible to them." : "";
     const checklistWarning = detectChecklistAttempt(newContent) ?? "";
     return successResponse(`Note updated: "${finalTitle}"${sharedWarning}${checklistWarning}`, {

--- a/build/index.js
+++ b/build/index.js
@@ -41754,6 +41754,12 @@ function strippedImagesWarning(stripped) {
   )} decoded) exceeded the per-image inline cap and ${stripped.strippedCount === 1 ? "was" : "were"} replaced with placeholders so the response stays within MCP message limits. The images are still in the note: use list-attachments with save-attachment or fetch-attachment to export them, or raise APPLE_NOTES_MCP_MAX_INLINE_IMAGE_BYTES.`;
 }
 
+// src/utils/updateResponseTitle.ts
+function resolveUpdateResponseTitle(currentTitle, newTitle, format) {
+  if (format === "html") return currentTitle;
+  return newTitle || currentTitle;
+}
+
 // src/tools/doctor.ts
 import { spawnSync } from "child_process";
 function runDoctor(manager) {
@@ -42389,7 +42395,9 @@ server.registerTool(
     inputSchema: {
       id: external_exports.string().max(MAX.ID).optional().describe("Note ID (preferred - more reliable than title)"),
       title: external_exports.string().max(MAX.TITLE).optional().describe("Current note title (use id instead when available)"),
-      newTitle: external_exports.string().max(MAX.TITLE).optional().describe("New title for the note"),
+      newTitle: external_exports.string().max(MAX.TITLE).optional().describe(
+        "New title for plaintext updates. Ignored when format is 'html'; include the visible title as the first line of newContent instead."
+      ),
       newContent: external_exports.string().min(1, "New content is required").max(MAX.CONTENT).describe(
         "New note body. AppleScript cannot produce true Apple Notes checklists; checkbox inputs and `- [ ]` markdown do not render as checkable items. Use a plain list and convert in Notes.app with \u21E7\u2318L."
       ),
@@ -42418,7 +42426,7 @@ server.registerTool(
       if (!success2) {
         return errorResponse(`Failed to update note "${note2.title}"`);
       }
-      const displayTitle = newTitle || note2.title;
+      const displayTitle = resolveUpdateResponseTitle(note2.title, newTitle, format);
       const sharedWarning2 = note2.shared ? "\n\n\u26A0\uFE0F This note is shared with collaborators. Your changes will be visible to them." : "";
       const checklistWarning2 = detectChecklistAttempt(newContent) ?? "";
       return successResponse(`Note updated: "${displayTitle}"${sharedWarning2}${checklistWarning2}`, {
@@ -42446,7 +42454,7 @@ server.registerTool(
     if (!success) {
       return errorResponse(`Failed to update note "${title}"`);
     }
-    const finalTitle = newTitle || title;
+    const finalTitle = resolveUpdateResponseTitle(note.title, newTitle, format);
     const sharedWarning = note.shared ? "\n\n\u26A0\uFE0F This note is shared with collaborators. Your changes will be visible to them." : "";
     const checklistWarning = detectChecklistAttempt(newContent) ?? "";
     return successResponse(`Note updated: "${finalTitle}"${sharedWarning}${checklistWarning}`, {

--- a/build/index.js
+++ b/build/index.js
@@ -41770,8 +41770,13 @@ function decodeHtmlEntities(text) {
   return text.replace(/&#x([0-9a-f]+);?/gi, (match, hex) => decodeCodePoint(match, hex, 16)).replace(/&#([0-9]+);?/g, (match, decimal) => decodeCodePoint(match, decimal, 10)).replace(/&nbsp(?:;|(?![0-9a-z]))/gi, " ").replace(/&quot(?:;|(?![0-9a-z]))/gi, '"').replace(/&apos(?:;|(?![0-9a-z]))/gi, "'").replace(/&lt(?:;|(?![0-9a-z]))/gi, "<").replace(/&gt(?:;|(?![0-9a-z]))/gi, ">").replace(/&amp(?:;|(?![0-9a-z]))/gi, "&");
 }
 function firstVisibleHtmlLine(html) {
-  let text = html.replace(NON_RENDERED_BLOCK_RE, "").replace(BREAK_RE, "\n").replace(BLOCK_END_RE, "\n");
+  let text = html;
   let previous;
+  do {
+    previous = text;
+    text = text.replace(NON_RENDERED_BLOCK_RE, "");
+  } while (text !== previous);
+  text = text.replace(BREAK_RE, "\n").replace(BLOCK_END_RE, "\n");
   do {
     previous = text;
     text = text.replace(TAG_RE, "");

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes-mcp",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Notes - create, search, update, and manage notes via Claude and other AI assistants",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes-mcp",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Notes - create, search, update, and manage notes via Claude and other AI assistants",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -769,7 +769,7 @@ server.registerTool(
       if (!success) {
         return errorResponse(`Failed to update note "${note.title}"`);
       }
-      const displayTitle = resolveUpdateResponseTitle(note.title, newTitle, format);
+      const displayTitle = resolveUpdateResponseTitle(note.title, newTitle, format, newContent);
       // Add collaboration warning if note is shared
       const sharedWarning = note.shared
         ? "\n\n⚠️ This note is shared with collaborators. Your changes will be visible to them."
@@ -806,7 +806,7 @@ server.registerTool(
       return errorResponse(`Failed to update note "${title}"`);
     }
 
-    const finalTitle = resolveUpdateResponseTitle(note.title, newTitle, format);
+    const finalTitle = resolveUpdateResponseTitle(note.title, newTitle, format, newContent);
     // Add collaboration warning if note is shared
     const sharedWarning = note.shared
       ? "\n\n⚠️ This note is shared with collaborators. Your changes will be visible to them."

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import { getNoteMetadata } from "@/utils/noteMetadata.js";
 import { detectChecklistAttempt } from "@/utils/contentWarnings.js";
 import { parseHashtags } from "@/utils/hashtags.js";
 import { stripLargeInlineImages, strippedImagesWarning } from "@/utils/inlineImages.js";
+import { resolveUpdateResponseTitle } from "@/utils/updateResponseTitle.js";
 import { runDoctor, formatDoctorReport } from "@/tools/doctor.js";
 import { FULL_DISK_ACCESS_GUIDE_URL } from "@/utils/docsUrls.js";
 import { loadFileConfig } from "@/services/fileConfig.js";
@@ -719,7 +720,13 @@ server.registerTool(
         .max(MAX.TITLE)
         .optional()
         .describe("Current note title (use id instead when available)"),
-      newTitle: z.string().max(MAX.TITLE).optional().describe("New title for the note"),
+      newTitle: z
+        .string()
+        .max(MAX.TITLE)
+        .optional()
+        .describe(
+          "New title for plaintext updates. Ignored when format is 'html'; include the visible title as the first line of newContent instead."
+        ),
       newContent: z
         .string()
         .min(1, "New content is required")
@@ -762,7 +769,7 @@ server.registerTool(
       if (!success) {
         return errorResponse(`Failed to update note "${note.title}"`);
       }
-      const displayTitle = newTitle || note.title;
+      const displayTitle = resolveUpdateResponseTitle(note.title, newTitle, format);
       // Add collaboration warning if note is shared
       const sharedWarning = note.shared
         ? "\n\n⚠️ This note is shared with collaborators. Your changes will be visible to them."
@@ -799,7 +806,7 @@ server.registerTool(
       return errorResponse(`Failed to update note "${title}"`);
     }
 
-    const finalTitle = newTitle || title;
+    const finalTitle = resolveUpdateResponseTitle(note.title, newTitle, format);
     // Add collaboration warning if note is shared
     const sharedWarning = note.shared
       ? "\n\n⚠️ This note is shared with collaborators. Your changes will be visible to them."

--- a/src/utils/updateResponseTitle.test.ts
+++ b/src/utils/updateResponseTitle.test.ts
@@ -3,16 +3,54 @@ import { resolveUpdateResponseTitle } from "./updateResponseTitle.js";
 
 describe("resolveUpdateResponseTitle", () => {
   it("reports the requested title for plaintext updates", () => {
-    expect(resolveUpdateResponseTitle("Old title", "New title", "plaintext")).toBe("New title");
+    expect(resolveUpdateResponseTitle("Old title", "New title", "plaintext", "Body")).toBe(
+      "New title"
+    );
   });
 
   it("keeps the current title when a plaintext update does not rename the note", () => {
-    expect(resolveUpdateResponseTitle("Current title", undefined, "plaintext")).toBe(
+    expect(resolveUpdateResponseTitle("Current title", undefined, "plaintext", "Body")).toBe(
       "Current title"
     );
   });
 
-  it("does not report newTitle for HTML updates because the manager ignores it", () => {
-    expect(resolveUpdateResponseTitle("Visible title", " ", "html")).toBe("Visible title");
+  it("uses the first visible HTML line instead of the ignored newTitle", () => {
+    expect(
+      resolveUpdateResponseTitle(
+        "Old title",
+        " ",
+        "html",
+        "<h1>New &amp; Improved</h1><div>Body</div>"
+      )
+    ).toBe("New & Improved");
+  });
+
+  it("skips leading spacer blocks and preserves inline title text", () => {
+    expect(
+      resolveUpdateResponseTitle(
+        "Old title",
+        undefined,
+        "html",
+        "<div><br></div><h1><b>Actual</b> title</h1><div>Body</div>"
+      )
+    ).toBe("Actual title");
+  });
+
+  it("falls back to the current title when HTML has no visible text", () => {
+    expect(resolveUpdateResponseTitle("Current title", " ", "html", "<div><br></div>")).toBe(
+      "Current title"
+    );
+  });
+
+  it("does not decode entity-like text or throw on an invalid numeric entity", () => {
+    expect(
+      resolveUpdateResponseTitle("Old title", undefined, "html", "<h1>&amplifier &#999999999;</h1>")
+    ).toBe("&amplifier &#999999999;");
+  });
+
+  it("removes malformed nested tags without leaving a recognizable tag in the title", () => {
+    expect(
+      resolveUpdateResponseTitle("Old title", undefined, "html", "<h1>A<<b>>title</h1>")
+    ).not.toMatch(/<[^>]*>/);
   });
 });

--- a/src/utils/updateResponseTitle.test.ts
+++ b/src/utils/updateResponseTitle.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { resolveUpdateResponseTitle } from "./updateResponseTitle.js";
+
+describe("resolveUpdateResponseTitle", () => {
+  it("reports the requested title for plaintext updates", () => {
+    expect(resolveUpdateResponseTitle("Old title", "New title", "plaintext")).toBe("New title");
+  });
+
+  it("keeps the current title when a plaintext update does not rename the note", () => {
+    expect(resolveUpdateResponseTitle("Current title", undefined, "plaintext")).toBe(
+      "Current title"
+    );
+  });
+
+  it("does not report newTitle for HTML updates because the manager ignores it", () => {
+    expect(resolveUpdateResponseTitle("Visible title", " ", "html")).toBe("Visible title");
+  });
+});

--- a/src/utils/updateResponseTitle.test.ts
+++ b/src/utils/updateResponseTitle.test.ts
@@ -53,4 +53,15 @@ describe("resolveUpdateResponseTitle", () => {
       resolveUpdateResponseTitle("Old title", undefined, "html", "<h1>A<<b>>title</h1>")
     ).not.toMatch(/<[^>]*>/);
   });
+
+  it("ignores script and style contents before resolving the visible title", () => {
+    expect(
+      resolveUpdateResponseTitle(
+        "Old title",
+        undefined,
+        "html",
+        "<script>Hidden</script><style>Also hidden</style><h1>Actual title</h1>"
+      )
+    ).toBe("Actual title");
+  });
 });

--- a/src/utils/updateResponseTitle.ts
+++ b/src/utils/updateResponseTitle.ts
@@ -1,14 +1,59 @@
-/**
- * Resolve the title reported by update-note without claiming that `newTitle`
- * changed an HTML note. In HTML mode Apple Notes derives the visible title
- * from the first line of `newContent`, and the manager intentionally ignores
- * the separate `newTitle` argument.
- */
+const BLOCK_END_RE = /<\/(?:div|h[1-6]|p|li)>/gi;
+const BREAK_RE = /<br\s*\/?\s*>/gi;
+const TAG_RE = /<[^>]*>/g;
+const NON_RENDERED_BLOCK_RE = /<(script|style)\b[^>]*>[\s\S]*?<\/\1>/gi;
+
+function decodeHtmlEntities(text: string): string {
+  const decodeCodePoint = (match: string, value: string, radix: number): string => {
+    const codePoint = Number.parseInt(value, radix);
+    if (
+      !Number.isInteger(codePoint) ||
+      codePoint < 0 ||
+      codePoint > 0x10ffff ||
+      (codePoint >= 0xd800 && codePoint <= 0xdfff)
+    ) {
+      return match;
+    }
+    return String.fromCodePoint(codePoint);
+  };
+
+  return text
+    .replace(/&#x([0-9a-f]+);?/gi, (match, hex: string) => decodeCodePoint(match, hex, 16))
+    .replace(/&#([0-9]+);?/g, (match, decimal: string) => decodeCodePoint(match, decimal, 10))
+    .replace(/&nbsp(?:;|(?![0-9a-z]))/gi, " ")
+    .replace(/&quot(?:;|(?![0-9a-z]))/gi, '"')
+    .replace(/&apos(?:;|(?![0-9a-z]))/gi, "'")
+    .replace(/&lt(?:;|(?![0-9a-z]))/gi, "<")
+    .replace(/&gt(?:;|(?![0-9a-z]))/gi, ">")
+    .replace(/&amp(?:;|(?![0-9a-z]))/gi, "&");
+}
+
+function firstVisibleHtmlLine(html: string): string | undefined {
+  let text = html
+    .replace(NON_RENDERED_BLOCK_RE, "")
+    .replace(BREAK_RE, "\n")
+    .replace(BLOCK_END_RE, "\n");
+
+  // Repeat until stable so malformed nested markup cannot leave tag residue.
+  let previous: string;
+  do {
+    previous = text;
+    text = text.replace(TAG_RE, "");
+  } while (text !== previous);
+
+  return decodeHtmlEntities(text)
+    .split(/[\r\n\u2028\u2029]+/)
+    .map((line) => line.replace(/\s+/g, " ").trim())
+    .find(Boolean);
+}
+
+/** Resolve the title that `update-note` should report after a successful write. */
 export function resolveUpdateResponseTitle(
   currentTitle: string,
   newTitle: string | undefined,
-  format: "plaintext" | "html"
+  format: "plaintext" | "html",
+  newContent: string
 ): string {
-  if (format === "html") return currentTitle;
+  if (format === "html") return firstVisibleHtmlLine(newContent) ?? currentTitle;
   return newTitle || currentTitle;
 }

--- a/src/utils/updateResponseTitle.ts
+++ b/src/utils/updateResponseTitle.ts
@@ -1,0 +1,14 @@
+/**
+ * Resolve the title reported by update-note without claiming that `newTitle`
+ * changed an HTML note. In HTML mode Apple Notes derives the visible title
+ * from the first line of `newContent`, and the manager intentionally ignores
+ * the separate `newTitle` argument.
+ */
+export function resolveUpdateResponseTitle(
+  currentTitle: string,
+  newTitle: string | undefined,
+  format: "plaintext" | "html"
+): string {
+  if (format === "html") return currentTitle;
+  return newTitle || currentTitle;
+}

--- a/src/utils/updateResponseTitle.ts
+++ b/src/utils/updateResponseTitle.ts
@@ -29,13 +29,18 @@ function decodeHtmlEntities(text: string): string {
 }
 
 function firstVisibleHtmlLine(html: string): string | undefined {
-  let text = html
-    .replace(NON_RENDERED_BLOCK_RE, "")
-    .replace(BREAK_RE, "\n")
-    .replace(BLOCK_END_RE, "\n");
+  let text = html;
+
+  // Repeat until stable so removing one non-rendered block cannot expose another.
+  let previous: string;
+  do {
+    previous = text;
+    text = text.replace(NON_RENDERED_BLOCK_RE, "");
+  } while (text !== previous);
+
+  text = text.replace(BREAK_RE, "\n").replace(BLOCK_END_RE, "\n");
 
   // Repeat until stable so malformed nested markup cannot leave tag residue.
-  let previous: string;
   do {
     previous = text;
     text = text.replace(TAG_RE, "");


### PR DESCRIPTION
## What changed

`update-note` ignores `newTitle` when `format` is `html`, because Apple Notes takes the visible title from the first line of `newContent`. The tool response still echoed `newTitle` as though it had been applied.

This PR reports the first visible HTML line instead. If the replacement body has no visible text, it falls back to the known current title. It also clarifies the live schema description and adds regression coverage for plaintext and HTML title resolution.

## Why

I found this while using the documented title-cleanup flow. The update succeeded and the visible note title stayed intact, but the connector answered `Note updated: " "`. That response was inaccurate and made a successful update look suspicious.

## What I left alone

I also checked the semicolonless `&amp` returned by `get-note-content`. Notes.app itself emits that normalized HTML, so this PR does not change it.

## Verification

- `pnpm test` (493 tests)
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run format:check`
- `pnpm run build`
- Standalone initialization from the committed bundle
