### PR TITLE
fix: report the actual folder in search results

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-notes",
-      "version": "2.6.7",
+      "version": "2.6.8",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-notes",
-      "version": "2.6.7",
+      "version": "2.6.8",
       "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.6.7",
+  "version": "2.6.8",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "apple-notes",
       "description": "Manage Apple Notes through natural language - create, search, read, update, delete, and organize notes and folders",
-      "version": "2.6.7",
+      "version": "2.6.8",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.6.7",
+  "version": "2.6.8",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, and organize notes and folders (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.8] - 2026-07-21
+
+### Fixed
+- **`search-notes` now reports the note's actual folder instead of falling back to `Notes`.** Notes.app does not resolve `name of container of n` as one chained AppleScript expression, so the lookup threw and every result used the fallback even when the note was in a nested folder or Recently Deleted. The script now captures the container first, then reads its name.
+
 ## [2.6.7] - 2026-07-21
 
 ### Fixed

--- a/build/index.js
+++ b/build/index.js
@@ -39585,7 +39585,8 @@ var AppleNotesManager = class {
               set modifiedParts to ""
             end try
             try
-              set noteFolder to name of container of n
+              set noteContainer to container of n
+              set noteFolder to name of noteContainer
             on error
               set noteFolder to "Notes"
             end try

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.6.7",
+  "version": "2.6.8",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes-mcp",
-  "version": "2.6.7",
+  "version": "2.6.8",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Notes - create, search, update, and manage notes via Claude and other AI assistants",
   "type": "module",

--- a/src/services/appleNotesManager.test.ts
+++ b/src/services/appleNotesManager.test.ts
@@ -713,6 +713,20 @@ describe("AppleNotesManager", () => {
       expect(results[2].folder).toBe("Archive");
     });
 
+    it("dereferences the note container before reading its folder name", () => {
+      mockExecuteAppleScript.mockReturnValue({
+        success: true,
+        output: ["Meeting Notes", "x-coredata://ABC/ICNote/p1", "Work"].join(F),
+      });
+
+      manager.searchNotes("meeting");
+
+      const script = mockExecuteAppleScript.mock.calls[0][0] as string;
+      expect(script).toContain("set noteContainer to container of n");
+      expect(script).toContain("set noteFolder to name of noteContainer");
+      expect(script).not.toContain("set noteFolder to name of container of n");
+    });
+
     it("returns actual creation and modification timestamps", () => {
       mockExecuteAppleScript.mockReturnValue({
         success: true,

--- a/src/services/appleNotesManager.ts
+++ b/src/services/appleNotesManager.ts
@@ -911,7 +911,8 @@ export class AppleNotesManager {
               set modifiedParts to ""
             end try
             try
-              set noteFolder to name of container of n
+              set noteContainer to container of n
+              set noteFolder to name of noteContainer
             on error
               set noteFolder to "Notes"
             end try


### PR DESCRIPTION
## What changed

`search-notes` was labeling every result as `Notes`, including notes in nested folders and Recently Deleted.

Notes.app throws when AppleScript reads `name of container of n` as one expression. Capturing the container first, then reading its name, returns the real folder. I added a regression test for the generated script and bumped the package and plugin versions to 2.6.8.

This keeps the existing response shape. Search results still report the containing folder's name rather than reconstructing its full nested path.

## Live verification

I reproduced this against my Notes library. With 2.6.7, an active note in `Personal/Tattoos` reported `Notes`. The patched build reports `Tattoos`, while two deleted duplicates report `Recently Deleted`.

## Checks

- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run format:check`
- `pnpm test` (507 tests)
- `pnpm run build`
- Live MCP call against nested and deleted notes
