### PR TITLE
fix(search-notes): default limit to 50 so broad queries return results (#100)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-notes",
-      "version": "2.6.8",
+      "version": "2.6.9",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-notes",
-      "version": "2.6.8",
+      "version": "2.6.9",
       "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.6.8",
+  "version": "2.6.9",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "apple-notes",
       "description": "Manage Apple Notes through natural language - create, search, read, update, delete, and organize notes and folders",
-      "version": "2.6.8",
+      "version": "2.6.9",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.6.8",
+  "version": "2.6.9",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, and organize notes and folders (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.9] - 2026-07-22
+
+### Changed
+- **`search-notes` now defaults `limit` to 50 instead of returning everything.** A broad query reads several properties per match via AppleScript (~200ms/note on an iCloud library), so an unbounded search over hundreds of matches — e.g. `"a"` matching 256 titles on a 340-note library — exceeded Notes' 30s timeout and returned an *error* rather than any results (#100). The tool now caps at 50 by default; the summary line discloses the applied limit (`(limit: 50, default)`) and, when the result hits the cap, appends a hint that there may be more and how to widen it (higher `limit`, or `folder`/`modifiedSince`). Callers that pass an explicit `limit` are unaffected. This is a public contract change: an unqualified `search-notes` now returns at most 50 matches instead of all of them.
+
 ## [2.6.8] - 2026-07-21
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,7 +134,7 @@ This works in: `create-note` (folder param), `search-notes`, `list-notes`, `move
 - Searches are case-insensitive
 - Results include note IDs for reliable subsequent operations
 - Use `modifiedSince` (ISO 8601 date) to filter to recently modified notes — useful for large collections
-- Use `limit` to cap the number of results returned
+- Use `limit` to cap the number of results returned. **`limit` defaults to 50** — a broad query (e.g. a single common letter) reads several properties per match via AppleScript, so an unbounded search over hundreds of matches times out; the default keeps it useful. The response discloses the applied limit and warns when results were truncated — pass a higher `limit`, or narrow with `folder`/`modifiedSince`, to see more.
 - Use `folder` to restrict search to a specific folder (supports nested paths)
 
 ### list-notes

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Searches for notes by title or content.
 | `account` | string | No | Account to search in (defaults to iCloud) |
 | `folder` | string | No | Limit search to a specific folder (supports nested paths like `"Work/Clients"`) |
 | `modifiedSince` | string | No | ISO 8601 date string to filter notes modified on or after this date (e.g., `"2025-01-01"`) |
-| `limit` | number | No | Maximum number of results to return |
+| `limit` | number | No | Maximum number of results to return. **Defaults to 50** — a broad query reads several properties per match via AppleScript (~200ms/note), so an unbounded search over hundreds of matches can exceed Notes' 30s timeout and return an error instead of results. Pass a higher value to see more; the applied limit (and whether it truncated the results) is disclosed in the response. |
 
 **Example - Search titles:**
 ```json

--- a/build/index.js
+++ b/build/index.js
@@ -41849,6 +41849,22 @@ function resolveUpdateResponseTitle(currentTitle, newTitle, format, newContent) 
   return newTitle || currentTitle;
 }
 
+// src/utils/searchLimit.ts
+var DEFAULT_SEARCH_LIMIT = 50;
+function resolveSearchLimit(limit) {
+  if (limit !== void 0 && Number.isFinite(limit) && limit > 0) {
+    return Math.floor(limit);
+  }
+  return DEFAULT_SEARCH_LIMIT;
+}
+function describeSearchLimit(effectiveLimit, wasDefault, resultCount) {
+  const info = ` (limit: ${effectiveLimit}${wasDefault ? ", default" : ""})`;
+  const truncationNote = resultCount >= effectiveLimit ? `
+
+\u2139\uFE0F Showing the first ${effectiveLimit}${wasDefault ? " (default limit)" : ""}; there may be more. Narrow the query, filter with \`folder\`/\`modifiedSince\`, or pass a higher \`limit\` to see additional matches.` : "";
+  return { info, truncationNote };
+}
+
 // src/tools/doctor.ts
 import { spawnSync } from "child_process";
 function runDoctor(manager) {
@@ -42130,7 +42146,9 @@ server.registerTool(
       modifiedSince: external_exports.string().max(64).optional().describe(
         "ISO 8601 date string to filter notes modified on or after this date (e.g., '2025-01-01'). Useful for searching only recent notes in large collections."
       ),
-      limit: external_exports.number().int().positive().optional().describe("Maximum number of results to return")
+      limit: external_exports.number().int().positive().optional().describe(
+        "Maximum number of results to return. Defaults to 50 \u2014 a broad query reads several properties per match via AppleScript, so an unbounded search can time out. Pass a higher value to see more; the applied limit is disclosed in the response."
+      )
     },
     outputSchema: {
       notes: external_exports.array(external_exports.object({}).passthrough()).optional(),
@@ -42138,18 +42156,24 @@ server.registerTool(
     }
   },
   withErrorHandling(({ query, searchContent = false, account, folder, modifiedSince, limit }) => {
+    const effectiveLimit = resolveSearchLimit(limit);
+    const limitWasDefault = limit === void 0;
     const {
       result: notes,
       syncBefore,
       syncInterference
     } = withSyncAwarenessSync(
       "search-notes",
-      () => notesManager.searchNotes(query, searchContent, account, folder, modifiedSince, limit)
+      () => notesManager.searchNotes(query, searchContent, account, folder, modifiedSince, effectiveLimit)
     );
     const searchType = searchContent ? "content" : "titles";
     const folderInfo = folder ? ` in folder "${folder}"` : "";
     const dateInfo = modifiedSince ? ` modified since ${modifiedSince}` : "";
-    const limitInfo = limit ? ` (limit: ${limit})` : "";
+    const { info: limitInfo, truncationNote } = describeSearchLimit(
+      effectiveLimit,
+      limitWasDefault,
+      notes.length
+    );
     const syncWarnings = [];
     if (syncBefore.syncDetected) {
       syncWarnings.push(`\u26A0\uFE0F iCloud sync was active during search.`);
@@ -42177,7 +42201,7 @@ ${syncWarnings.join(" ")}` : "";
     }).join("\n");
     return successResponse(
       `Found ${notes.length} notes (searched ${searchType}${folderInfo}${dateInfo}${limitInfo}):
-${noteList}${syncNote}`,
+${noteList}${truncationNote}${syncNote}`,
       { notes, count: notes.length }
     );
   }, "Error searching notes")

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.6.8",
+  "version": "2.6.9",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes-mcp",
-  "version": "2.6.8",
+  "version": "2.6.9",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Notes - create, search, update, and manage notes via Claude and other AI assistants",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ import { detectChecklistAttempt } from "@/utils/contentWarnings.js";
 import { parseHashtags } from "@/utils/hashtags.js";
 import { stripLargeInlineImages, strippedImagesWarning } from "@/utils/inlineImages.js";
 import { resolveUpdateResponseTitle } from "@/utils/updateResponseTitle.js";
+import { resolveSearchLimit, describeSearchLimit } from "@/utils/searchLimit.js";
 import { runDoctor, formatDoctorReport } from "@/tools/doctor.js";
 import { FULL_DISK_ACCESS_GUIDE_URL } from "@/utils/docsUrls.js";
 import { loadFileConfig } from "@/services/fileConfig.js";
@@ -245,7 +246,14 @@ server.registerTool(
         .describe(
           "ISO 8601 date string to filter notes modified on or after this date (e.g., '2025-01-01'). Useful for searching only recent notes in large collections."
         ),
-      limit: z.number().int().positive().optional().describe("Maximum number of results to return"),
+      limit: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe(
+          "Maximum number of results to return. Defaults to 50 — a broad query reads several properties per match via AppleScript, so an unbounded search can time out. Pass a higher value to see more; the applied limit is disclosed in the response."
+        ),
     },
     outputSchema: {
       notes: z.array(z.object({}).passthrough()).optional(),
@@ -253,19 +261,30 @@ server.registerTool(
     },
   },
   withErrorHandling(({ query, searchContent = false, account, folder, modifiedSince, limit }) => {
+    // Default the result cap so a broad query returns useful results instead of a
+    // timeout error: search-notes reads several properties per match via AppleScript
+    // (~200ms/note), so an unbounded search over hundreds of matches exceeds the 30s
+    // budget (#100). The applied cap is disclosed below so truncation is visible.
+    const effectiveLimit = resolveSearchLimit(limit);
+    const limitWasDefault = limit === undefined;
+
     // Use sync-aware wrapper for this read operation
     const {
       result: notes,
       syncBefore,
       syncInterference,
     } = withSyncAwarenessSync("search-notes", () =>
-      notesManager.searchNotes(query, searchContent, account, folder, modifiedSince, limit)
+      notesManager.searchNotes(query, searchContent, account, folder, modifiedSince, effectiveLimit)
     );
 
     const searchType = searchContent ? "content" : "titles";
     const folderInfo = folder ? ` in folder "${folder}"` : "";
     const dateInfo = modifiedSince ? ` modified since ${modifiedSince}` : "";
-    const limitInfo = limit ? ` (limit: ${limit})` : "";
+    const { info: limitInfo, truncationNote } = describeSearchLimit(
+      effectiveLimit,
+      limitWasDefault,
+      notes.length
+    );
 
     // Build sync warning if needed
     const syncWarnings: string[] = [];
@@ -298,7 +317,7 @@ server.registerTool(
       .join("\n");
 
     return successResponse(
-      `Found ${notes.length} notes (searched ${searchType}${folderInfo}${dateInfo}${limitInfo}):\n${noteList}${syncNote}`,
+      `Found ${notes.length} notes (searched ${searchType}${folderInfo}${dateInfo}${limitInfo}):\n${noteList}${truncationNote}${syncNote}`,
       { notes, count: notes.length }
     );
   }, "Error searching notes")

--- a/src/utils/searchLimit.test.ts
+++ b/src/utils/searchLimit.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_SEARCH_LIMIT,
+  resolveSearchLimit,
+  describeSearchLimit,
+} from "@/utils/searchLimit.js";
+
+describe("resolveSearchLimit", () => {
+  it("returns the default when no limit is supplied", () => {
+    expect(resolveSearchLimit(undefined)).toBe(DEFAULT_SEARCH_LIMIT);
+    expect(resolveSearchLimit()).toBe(50);
+  });
+
+  it("returns an explicit positive limit, floored", () => {
+    expect(resolveSearchLimit(10)).toBe(10);
+    expect(resolveSearchLimit(999)).toBe(999);
+    expect(resolveSearchLimit(7.9)).toBe(7);
+  });
+
+  it("treats non-positive or non-finite values as unset (defensive)", () => {
+    expect(resolveSearchLimit(0)).toBe(DEFAULT_SEARCH_LIMIT);
+    expect(resolveSearchLimit(-5)).toBe(DEFAULT_SEARCH_LIMIT);
+    expect(resolveSearchLimit(Infinity)).toBe(DEFAULT_SEARCH_LIMIT);
+    expect(resolveSearchLimit(NaN)).toBe(DEFAULT_SEARCH_LIMIT);
+  });
+});
+
+describe("describeSearchLimit", () => {
+  it("marks the default cap so the caller knows it was implicit", () => {
+    const { info } = describeSearchLimit(50, true, 3);
+    expect(info).toBe(" (limit: 50, default)");
+  });
+
+  it("does not mark an explicit cap as default", () => {
+    const { info } = describeSearchLimit(10, false, 3);
+    expect(info).toBe(" (limit: 10)");
+  });
+
+  it("adds no truncation note when the result is below the cap", () => {
+    expect(describeSearchLimit(50, true, 12).truncationNote).toBe("");
+    expect(describeSearchLimit(10, false, 9).truncationNote).toBe("");
+  });
+
+  it("adds a truncation note when the result hits the cap", () => {
+    const { truncationNote } = describeSearchLimit(50, true, 50);
+    expect(truncationNote).toContain("Showing the first 50");
+    expect(truncationNote).toContain("(default limit)");
+    expect(truncationNote).toContain("higher `limit`");
+  });
+
+  it("truncation note for an explicit cap omits the default wording", () => {
+    const { truncationNote } = describeSearchLimit(10, false, 10);
+    expect(truncationNote).toContain("Showing the first 10");
+    expect(truncationNote).not.toContain("default limit");
+  });
+});

--- a/src/utils/searchLimit.ts
+++ b/src/utils/searchLimit.ts
@@ -1,0 +1,56 @@
+/**
+ * Default result cap applied to `search-notes` when the caller does not pass an
+ * explicit `limit`.
+ *
+ * `search-notes` reads several properties per matching note via AppleScript
+ * (~200ms/note on an iCloud library), so an unbounded broad query — e.g. `"a"`
+ * matching hundreds of titles — exceeds the 30s AppleScript budget and returns a
+ * timeout *error* instead of any results (issue #100). Capping the common broad
+ * search keeps it fast and useful; the cap is always disclosed in the response
+ * (see {@link describeSearchLimit}) so the truncation is visible rather than silent.
+ *
+ * This only bounds the per-note read loop, not the underlying `whose` clause, so a
+ * pathological query matching thousands of notes can still be slow — but the common
+ * "broad query on an ordinary library" case goes from guaranteed failure to a useful
+ * answer.
+ */
+export const DEFAULT_SEARCH_LIMIT = 50;
+
+/**
+ * Resolve the effective result cap for a search.
+ *
+ * Returns the floored positive `limit` when the caller supplied one, otherwise
+ * {@link DEFAULT_SEARCH_LIMIT}. A non-positive or non-finite value is treated as
+ * unset (the tool schema already rejects those, so this is defensive).
+ */
+export function resolveSearchLimit(limit?: number): number {
+  if (limit !== undefined && Number.isFinite(limit) && limit > 0) {
+    return Math.floor(limit);
+  }
+  return DEFAULT_SEARCH_LIMIT;
+}
+
+/**
+ * Build the disclosure fragments appended to a search response so the applied cap —
+ * and any truncation it caused — is always visible to the caller.
+ *
+ * @param effectiveLimit - the cap actually passed to the search
+ * @param wasDefault - true when the cap is {@link DEFAULT_SEARCH_LIMIT} because no
+ *   explicit `limit` was supplied
+ * @param resultCount - number of notes returned after dedup
+ * @returns `info` (a `(limit: N[, default])` fragment for the summary line) and
+ *   `truncationNote` (a trailing hint, empty unless the result hit the cap)
+ */
+export function describeSearchLimit(
+  effectiveLimit: number,
+  wasDefault: boolean,
+  resultCount: number
+): { info: string; truncationNote: string } {
+  const info = ` (limit: ${effectiveLimit}${wasDefault ? ", default" : ""})`;
+  const truncationNote =
+    resultCount >= effectiveLimit
+      ? `\n\nℹ️ Showing the first ${effectiveLimit}${wasDefault ? " (default limit)" : ""}; there may be more. ` +
+        "Narrow the query, filter with `folder`/`modifiedSince`, or pass a higher `limit` to see additional matches."
+      : "";
+  return { info, truncationNote };
+}


### PR DESCRIPTION
Fixes #100.

## Problem
`search-notes` reads several properties per matching note via AppleScript (~200ms/note on an iCloud library). With no `limit`, a broad query — e.g. `"a"` matching 256 titles on a 340-note library — runs the per-note loop over every match, exceeding Notes' 30s timeout and returning an **error instead of any results** (timed out on 3/3 runs in the issue).

## Change (issue's option 1)
Default `limit` to **50** at the tool layer:
- The applied cap is passed to the manager, so the AppleScript loop exits early and stays well under the 30s budget (issue measured `limit: 40` ≈ 16.6s).
- The summary line **discloses** the cap — `Found N notes (searched titles (limit: 50, default))` — so truncation is visible, never silent.
- When the result hits the cap, a trailing hint says there may be more and how to widen it (higher `limit`, or `folder`/`modifiedSince`).
- Callers passing an explicit `limit` are unaffected. The `AppleNotesManager.searchNotes` API is unchanged (still no implicit default) — only the MCP tool contract gains the default, which is exactly what the issue scoped.

## Contract note
This is a **public contract change**: an unqualified `search-notes` now returns at most 50 matches instead of all of them. Called out in the CHANGELOG under `### Changed`. Per the issue, this deserves an explicit decision — flagging it here for that reason.

## Not done (deliberately)
Option 2 (restructure so matches can be bulk-read) and option 3 (folder-name memoization, measured ~4% by the issue author) are out of scope — the `whose` clause itself, not the per-note loop, is the remaining cost for pathological many-thousand-match queries, and that's a bigger change the issue flags as maybe-not-expressible for account-wide search.

## Tests / docs
- New `src/utils/searchLimit.ts` (`DEFAULT_SEARCH_LIMIT`, `resolveSearchLimit`, `describeSearchLimit`) with `src/utils/searchLimit.test.ts` (8 cases: default/explicit/floor/defensive + disclosure + truncation-note branches).
- README tool-reference `limit` row, `CLAUDE.md` search-notes guidance, CHANGELOG, `package.json` 2.6.8 → 2.6.9, plugin manifests synced.
- Full gate green locally: build, typecheck, lint, `format:check`, 515 unit tests; committed bundle matches a fresh source build; no absolute-path leakage in the bundle.