### PR TITLE
Skip npm publishing in forks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,11 +45,12 @@ jobs:
   publish:
     runs-on: macos-latest
     if: >
-      (github.event_name == 'release') ||
-      (github.event_name == 'workflow_dispatch') ||
-      (github.event_name == 'schedule') ||
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' &&
-        (github.event.workflow_run.event == 'push' || github.event.workflow_run.event == 'workflow_dispatch'))
+      github.repository == 'sweetrb/apple-notes-mcp' &&
+      ((github.event_name == 'release') ||
+       (github.event_name == 'workflow_dispatch') ||
+       (github.event_name == 'schedule') ||
+       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' &&
+         (github.event.workflow_run.event == 'push' || github.event.workflow_run.event == 'workflow_dispatch')))
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
   publish:
     runs-on: macos-latest
     if: >
-      github.repository == 'sweetrb/apple-notes-mcp' &&
+      github.repository_owner == 'sweetrb' &&
       ((github.event_name == 'release') ||
        (github.event_name == 'workflow_dispatch') ||
        (github.event_name == 'schedule') ||


### PR DESCRIPTION
## What changed

This keeps the `Publish to npm` job scoped to `sweetrb/apple-notes-mcp`. Forks can keep the workflow file and run normal CI, but their publish job now skips before it requests an npm OIDC exchange or tries to create a GitHub Release.

I hit this in `oliverames/apple-notes-mcp`: once the fork's package version moved ahead of npm, its scheduled workflow tried to publish from the fork and failed the trusted-publisher exchange. The upstream triggers and release recovery behavior are unchanged.

## Checks

- `actionlint` 1.7.12 across all workflows
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run typecheck`
- `pnpm test` (507 tests)
- `pnpm run build`
