### PR TITLE
ci: skip npm publishing in forks (continues #102, @oliverames)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,11 +45,12 @@ jobs:
   publish:
     runs-on: macos-latest
     if: >
-      (github.event_name == 'release') ||
-      (github.event_name == 'workflow_dispatch') ||
-      (github.event_name == 'schedule') ||
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' &&
-        (github.event.workflow_run.event == 'push' || github.event.workflow_run.event == 'workflow_dispatch'))
+      github.repository_owner == 'sweetrb' &&
+      ((github.event_name == 'release') ||
+       (github.event_name == 'workflow_dispatch') ||
+       (github.event_name == 'schedule') ||
+       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' &&
+         (github.event.workflow_run.event == 'push' || github.event.workflow_run.event == 'workflow_dispatch')))
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
Carries forward @oliverames's #102. A fork PR that modifies a workflow file can't be merged without the `workflow` OAuth scope, so the change is landed on this in-repo branch instead, crediting Oliver via `Co-authored-by`.

Gates the `publish` job on `github.repository_owner == 'sweetrb'` — true on every sweetrb repo, false on any fork — so a synced fork doesn't attempt to publish. Byte-identical across all four repos (companion PRs merged: numbers #38, photos #46; mail #106 in flight), so `./conformance-check.sh` stays green. Workflow-only, no version bump.

Closes #102.