### PR TITLE
fix(hermes): repair pnpm version + README after .hermes-plugin removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+- **`.hermes-plugin/` packaging docs** (`README.md`, `config.yaml`). Hermes Agent has no plugin/marketplace drop-in, so a directory of manifest-looking files was easy to misread as an installable package. The setup it documented is not lost — the `hermes mcp add` command, the `~/.hermes/config.yaml` `mcp_servers:` snippet, and the restart note now live inline in the README's "Other Hosts" section. Matches apple-mail-mcp#116, keeping multi-host packaging parity across the four Apple MCP servers. No effect on the published package: `.hermes-plugin/` was never in `package.json` `files[]`.
+
+### Fixed
+- **`pnpm version` no longer breaks with the `.hermes-plugin/` removal.** The `version` lifecycle script listed `.hermes-plugin` in its `git add`; `git add` exits 128 on a pathspec that matches nothing, which would have broken the documented release step (`pnpm version <patch|minor|major> --no-git-tag-version`) for every subsequent release. The stale path is dropped from the `git add` list.
+
 ### Security
 - Override the MCP SDK's transitive `@hono/node-server` and `fast-uri` dependencies to patched releases. This clears the path-traversal advisory in Hono's static file serving and the host-confusion advisories in `fast-uri` while the SDK's own dependency ranges still resolve vulnerable versions.
 

--- a/README.md
+++ b/README.md
@@ -71,9 +71,24 @@ The Codex plugin runs the published `apple-notes-mcp` server through `npx` and s
 
 ### Other Hosts (Hermes, Antigravity)
 
-Configuration for two more hosts is included — each registers the same `apple-notes` MCP server (`npx -y apple-notes-mcp`):
+Two more hosts can run the same `apple-notes` MCP server (`npx -y apple-notes-mcp`):
 
-- **[Hermes Agent](https://hermes-agent.nousresearch.com/)** (NousResearch) — Hermes has no plugin/marketplace drop-in. Add the server with `hermes mcp add apple-notes --command npx --args -y apple-notes-mcp`, or merge [`.hermes-plugin/config.yaml`](https://github.com/sweetrb/apple-notes-mcp/blob/main/.hermes-plugin/config.yaml) into `~/.hermes/config.yaml`. Details: [`.hermes-plugin/README.md`](https://github.com/sweetrb/apple-notes-mcp/blob/main/.hermes-plugin/README.md).
+- **[Hermes Agent](https://hermes-agent.nousresearch.com/)** (NousResearch) — Hermes has no plugin/marketplace drop-in, so there is nothing in this repo to install from. Register the server with the CLI:
+
+  ```bash
+  hermes mcp add apple-notes --command npx --args -y apple-notes-mcp
+  ```
+
+  Or add it to `~/.hermes/config.yaml` by hand:
+
+  ```yaml
+  mcp_servers:
+    apple-notes:
+      command: npx
+      args: ["-y", "apple-notes-mcp"]
+  ```
+
+  Restart your Hermes session afterward so the tools load.
 - **[Antigravity](https://antigravity.google/)** (Google) — add the server entry from [`.antigravity-plugin/mcp_config.json`](https://github.com/sweetrb/apple-notes-mcp/blob/main/.antigravity-plugin/mcp_config.json) to `~/.gemini/config/mcp_config.json` (or via Antigravity's MCP settings).
 
 ### Using Claude Desktop

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "format:check": "prettier --check src",
     "typecheck": "tsc --noEmit",
     "sync:skills": "node scripts/sync-skills.mjs",
-    "version": "node scripts/sync-plugin-version.mjs && git add .claude-plugin .agents/plugins codex .hermes-plugin .antigravity-plugin",
+    "version": "node scripts/sync-plugin-version.mjs && git add .claude-plugin .agents/plugins codex .antigravity-plugin",
     "prepublishOnly": "pnpm run lint && pnpm test && pnpm run build",
     "prepare": "husky; pnpm run build"
   },


### PR DESCRIPTION
**`main` is currently un-releasable — this fixes it.**

The `.hermes-plugin/` removal merged with **only the two file deletions**; the three accompanying edits were lost to a staging mistake on my side (`git add` was given the already-deleted `.hermes-plugin` path alongside the real files, which makes git add exit 128 and stage *nothing* — the same failure mode this change is about, with the error unhelpfully suppressed). So `main` has the directory gone but still referenced in two places.

## What's broken on main right now

**1. `pnpm version` fails.** The `version` lifecycle script still lists the deleted path:

```
"version": "node scripts/sync-plugin-version.mjs && git add .claude-plugin .agents/plugins codex .hermes-plugin .antigravity-plugin"
```

`git add` exits **128** on a pathspec that matches nothing, so `pnpm version <patch|minor|major> --no-git-tag-version` — the documented release step for this repo — fails today. Any release would stop there.

**2. The README 404s.** The "Other Hosts" Hermes bullet still links to both deleted files. This PR inlines the setup instead: the `hermes mcp add` command, the `~/.hermes/config.yaml` `mcp_servers:` snippet, and the restart note.

**3. No CHANGELOG entry** for the removal. Added under `[Unreleased]` (Removed + Fixed).

This is exactly the content [apple-mail-mcp#116](https://github.com/sweetrb/apple-mail-mcp/pull/116) landed as a single commit; mail is unaffected because its staging was correct.

## No version bump

`.hermes-plugin/` was never in `package.json` `files[]`, there is no `src/` change, and the committed bundle is byte-identical — nothing that ships to npm changes.
