### PR TITLE
ci: close two CHANGELOG holes in version-guard (heading deletion, Unreleased drain)

### DIFF
--- a/.github/workflows/version-guard.yml
+++ b/.github/workflows/version-guard.yml
@@ -120,6 +120,55 @@ jobs:
           newv="$(node -e 'console.log(require("./package.json").version)')"
           echo "package.json version: base=${oldv}  head=${newv}"
 
+          # ── CHANGELOG history is append-only ──────────────────────────────
+          # The rule below only proves the NEW version has a heading. A PR that
+          # RENAMES an existing heading instead of adding one satisfies it while
+          # ERASING a published release: retitling "## [1.1.12] - 2026-08-03"
+          # to "## [1.1.13] - 2026-08-04" leaves 1.1.13 documented and 1.1.12
+          # gone. Not hypothetical — apple-numbers-mcp #54 did exactly that, and
+          # since nothing downstream reads CHANGELOG.md it stayed invisible
+          # until an audit found the one missing heading across every published
+          # version in the four repos.
+          # So: every "## [X.Y.Z]" heading present at the base must still be
+          # present here. Adding is free; renaming or deleting one fails.
+          # Compared against the CHECKED-OUT tree — the merge result under
+          # pull_request, HEAD under workflow_dispatch — so a branch that is
+          # merely stale (main released while the PR sat open) is never blamed
+          # for headings it has not merged yet.
+          if [ ! -f CHANGELOG.md ]; then
+            echo "::error::CHANGELOG.md is missing from this branch. It is the only record of what each published version contains — restore it."
+            exit 1
+          fi
+          # Reading the base copy needs real history. The checkout above pins
+          # fetch-depth: 0; deepen defensively, then refuse to run rather than
+          # pass unevaluated, so a future edit to that input cannot silently
+          # turn this check into a no-op.
+          if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+            git fetch --no-tags --quiet --unshallow || true
+          fi
+          if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            echo "::error::Base commit ${BASE_SHA} is not present in this clone (shallow checkout?), so the CHANGELOG history check cannot be evaluated. Restore 'fetch-depth: 0' on the checkout step."
+            exit 1
+          fi
+          if git cat-file -e "${BASE_SHA}:CHANGELOG.md" 2>/dev/null; then
+            base_heads="$(git show "${BASE_SHA}:CHANGELOG.md" | sed -nE 's/^## \[([0-9]+\.[0-9]+\.[0-9]+)\].*/\1/p')"
+            head_heads="$(sed -nE 's/^## \[([0-9]+\.[0-9]+\.[0-9]+)\].*/\1/p' CHANGELOG.md)"
+            # Loop + `grep -qxF` rather than `comm`: no sort-order or locale
+            # assumptions, and a version string is full of regex metacharacters.
+            lost=""
+            while IFS= read -r v; do
+              [ -n "$v" ] || continue
+              printf '%s\n' "$head_heads" | grep -qxF -- "$v" || lost="${lost}${v} "
+            done <<< "$base_heads"
+            if [ -n "$lost" ]; then
+              echo "::error::CHANGELOG.md no longer has a '## [X.Y.Z]' heading for release(s) documented on the base: ${lost% }. A published release's section must never be renamed, retitled or removed — add a NEW heading for this release and restore the one(s) above."
+              exit 1
+            fi
+            echo "CHANGELOG.md preserves every release heading present on the base."
+          else
+            echo "::notice::No CHANGELOG.md at the base commit — no release headings to preserve."
+          fi
+
           if [ "$oldv" != "$newv" ]; then
             # Bump present: require it to be an increase (typo'd downgrades)…
             OLDV="$oldv" NEWV="$newv" node -e '
@@ -159,6 +208,27 @@ jobs:
               exit 1
             fi
             echo "CHANGELOG.md documents ${newv}."
+
+            # …and require "## [Unreleased]" to be EMPTY. The heading check
+            # above proves the new version is documented somewhere; it says
+            # nothing about notes still parked under "## [Unreleased]", which
+            # this release drains: everything on main ships in the next publish,
+            # so prose left under that marker describes released behaviour while
+            # claiming to be unreleased, and nothing later renames the section.
+            # Until now nothing guarded that at all. dependabot-rebuild.yml
+            # inserts its "## [X.Y.Z]" heading directly BELOW the marker and
+            # leaves it empty, so bot PRs pass unchanged.
+            if [ -z "$(awk 'index($0,"## [Unreleased]")==1{print "y"; exit}' CHANGELOG.md)" ]; then
+              echo "::error::CHANGELOG.md has no '## [Unreleased]' heading. Keep an empty one at the top — dependabot-rebuild.yml hard-exits without that marker, so dropping it silently breaks the Dependabot rebuild + auto-bump path."
+              exit 1
+            fi
+            unrel="$(awk 'index($0,"## [Unreleased]")==1{u=1;next} u&&index($0,"## ")==1{exit} u{print}' CHANGELOG.md)"
+            if [ -n "$(printf '%s' "$unrel" | tr -d '[:space:]')" ]; then
+              echo "::error::Version is bumped to ${newv} but '## [Unreleased]' is not empty. This release publishes everything on main, so those notes ship as ${newv} while sitting under a heading that says they are unreleased — and nothing renames that section later. Move them under '## [${newv}] - $(date -u +%Y-%m-%d)' and leave '## [Unreleased]' empty. Content found:"
+              printf '%s\n' "$unrel" | sed 's/^/  /'
+              exit 1
+            fi
+            echo "'## [Unreleased]' is empty."
           fi
 
           if [ -z "$code" ] && [ -z "$deps_changed" ]; then


### PR DESCRIPTION
CI-only change to `.github/workflows/version-guard.yml`. `.github/` does not ship, so **no version bump is owed** and none is included.

## The two holes

`version-guard` already proves a bumped version **has** a `## [X.Y.Z]` heading. Two ways to satisfy that while still losing the record stayed open.

**Hole 1 — heading deletion.** The existing rule only proves the *new* version has a heading. A PR that **renames** an existing heading instead of adding one satisfies it while **erasing a published release**: retitling `## [1.1.12] - 2026-08-03` to `## [1.1.13] - 2026-08-04` leaves 1.1.13 documented and 1.1.12 gone. Not hypothetical — **apple-numbers-mcp #54 did exactly that**, and since nothing downstream reads `CHANGELOG.md` it stayed invisible until an audit found the one missing heading across every published version in the four repos.

**Hole 2 — the Unreleased drain.** Nothing guarded this at all. A release publishes everything on `main`, so notes left under `## [Unreleased]` ship as that version while sitting under a heading claiming they are unreleased — and nothing later renames the section. (`unreleased-drain-is-unguarded` was a known open gap.)

## Design

Hole 1 is closed **outside** the bump branch, because a rename can land in a PR that bumps (numbers #54 did) or one that does not. Base side is `git show "${BASE_SHA}:CHANGELOG.md"`; head side is the **checked-out working tree**, deliberately *not* `git show "${HEAD_SHA}:…"` — under `pull_request` the checkout is the merge commit, so a stale branch already contains main's newer headings, and reading `HEAD_SHA` would false-fail every PR left open across a release. Under `workflow_dispatch` the tree *is* HEAD and BASE is the `origin/main` fork point (an ancestor), so base headings are a subset unless the branch deleted one. This also matches the file's existing style: the current CHANGELOG check and `newv` already read the working tree.

Membership is tested with a `while read` + `grep -qxF` loop rather than `comm`, copying `conformance-check.sh`'s documented reasoning — no sort-order or locale assumptions, and a version string is full of regex metacharacters.

Hole 2 is closed **inside** the bump branch, right after the existing heading check. It first asserts the marker exists (`dependabot-rebuild.yml` hard-exits without it), then that the section body is whitespace-only, and prints the offending content indented so the fix is obvious. Both use `index($0,"## [Unreleased]")==1` — `conformance-check.sh`'s own idiom — avoiding awk `\[` escape portability questions; the terminator `index($0,"## ")==1` correctly ignores `### Fixed` sub-headings.

### Edge cases, explicit

- **Shallow checkout:** deepen with `--unshallow` when `--is-shallow-repository` is true, then **hard-fail** if the base commit is still unreachable rather than skipping. Skipping would be the same false-pass class `conformance-check.sh`'s preflights exist to prevent.
- **First commit / `CHANGELOG.md` absent at base:** `git cat-file -e "${BASE_SHA}:CHANGELOG.md"` fails → `::notice::` and continue. Distinguished from an unreachable base commit, which fails.
- **`CHANGELOG.md` deleted by the PR:** explicit hard fail — it is the maximal heading deletion, and would otherwise crash `sed` under `set -e`.
- **`set -euo pipefail` safety:** every new pipeline is either an `if`/`||` condition or ends in a command that cannot fail. No unguarded pipefail exits.

## Verification (run locally against this repo)

The `run:` block was extracted from the **parsed YAML** and executed end-to-end in scratch git repos, with `npm` stubbed so the registry check is hermetic.

| # | Scenario | Expected | Result |
|---|---|---|---|
| 1 | Heading **rename** (numbers #54 replay) on this repo's real 63-heading CHANGELOG | FAIL | FAIL, error names `2.6.16` |
| 2a | Docs-only, no bump | PASS | PASS |
| 2b | Real release PR: bump + new heading + empty `Unreleased` | PASS | PASS |
| 3a | Bump + **non-empty** `## [Unreleased]` | FAIL | FAIL, prints the stranded content |
| 3b | Same non-empty `Unreleased`, **no bump** | PASS | PASS — rule correctly scoped to bumps |
| 3c | `## [Unreleased]` marker **deleted** + bump | FAIL | FAIL, cites dependabot-rebuild |
| 3d | `### Fixed` content directly under `Unreleased` + bump | FAIL | FAIL — sub-heading is content, not a terminator |
| 3e | `CHANGELOG.md` deleted entirely | FAIL | FAIL |
| 4 | **Dependabot**: `dependabot-rebuild.yml`'s exact auto-bump node snippet run verbatim, then guarded | PASS | PASS — bot PRs unaffected |
| 4b | `workflow_dispatch` fallback (empty `BASE_SHA`) | PASS | PASS |
| 5a | No `CHANGELOG.md` at base (first-commit case) | PASS + notice | PASS |
| 5b | **Date-only** heading edit, version preserved | PASS | PASS |
| 5c | Real `--depth 1` shallow clone, base unreachable | FAIL | FAIL (fails closed at the pre-existing base diff) |
| 6 | Shallow `--depth 2`, base reachable | PASS | PASS — `--unshallow` path safe under `set -euo pipefail` |

Also verified:

- **Pure insertion** — `1 file changed, 70 insertions(+)`, 0 lines removed or altered.
- YAML parses (PyYAML); `name: version-guard`, job key `require-version-bump`, and both triggers (`pull_request`, `workflow_dispatch`) unchanged — so the required check contexts are untouched.
- `bash -n` clean on the extracted `run:` block.
- `prettier --check` clean on the workflow.
- `pnpm lint` / `typecheck` / `format:check` / `test` (519 tests, 20 files) all green.

## Accepted trade-off

Archiving old entries **out** of `CHANGELOG.md` now fails. That is intentional and documented inline — the file is the only record of what each published version contains, and the guard cannot distinguish deliberate archival from the rename that erased 1.1.12.

Second-order effect worth knowing: if `## [Unreleased]` on `main` ever became non-empty, every bumping PR (including Dependabot's) would fail until the notes are filed. That *is* the drain being enforced, it fails loudly rather than silently, and all four repos have an empty `## [Unreleased]` on `main` today.

## Note on the optional header-comment edit

The plan offered an optional companion edit rewriting the file's header comment (lines 19-21) to describe all three CHANGELOG rules. **It was deliberately not applied.** `.github/workflows/version-guard.yml` is in `conformance-check.sh`'s byte-identical set, and no exact wording was specified — four independently-authored rewrites would drift and break that invariant. The inserted blocks carry their own inline rationale. If the header should be updated, it needs one authored text applied identically to all four in a follow-up.

## Rollout

This is one of four identical PRs (mail / notes / numbers / photos). `conformance-check.sh` will report `DRIFT` on `version-guard.yml` until all four land — transient and expected during the rollout.
