### PR TITLE
fix(deps): floor js-yaml on 4.3.1 — GHSA-5p4m-2wfm-xmqj (high)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Security
+
+- **Floored `js-yaml` to `^4.3.1`, clearing GHSA-5p4m-2wfm-xmqj (high).** Quadratic CPU consumption while resolving `!!omap` keys — a malicious YAML document can be made to burn CPU superlinearly in the number of map entries. The advisory notes the CVE-2026-59870 fix was never backported to the 3.x line, so 4.3.1 is the first complete release. `js-yaml` reaches the tree as `eslint` -> `js-yaml`, which is **development scope**, and it does not appear in the committed `build/index.js` — verified, 0 references — so no published artifact ever carried it and this owes no version bump. No `js-yaml` override existed here before; apple-mail-mcp carried one pinned at `^4.2.0` — below this fix — which is how the gap was found.
+
 ## [2.6.16] - 2026-08-06
 
 ### Fixed

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   ip-address: ^10.3.1
   postcss: ^8.5.23
   hono: ^4.12.34
+  js-yaml: ^4.3.1
 
 importers:
 
@@ -1139,8 +1140,8 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -1855,7 +1856,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -2725,7 +2726,7 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -55,3 +55,9 @@ overrides:
   # 2m36s. It matured at 2026-08-04T02:36:40Z and is floored here now, with no
   # minimumReleaseAgeExclude carve-out ever having been added.
   hono: ^4.12.34
+  # GHSA-5p4m-2wfm-xmqj (high): quadratic CPU consumption resolving !!omap,
+  # fixed in 4.3.1 — the CVE-2026-59870 fix was never backported to the 3.x line.
+  # Reached as eslint -> js-yaml, so development scope, and absent from the
+  # shipped build/index.js bundle: nothing vulnerable was ever published. Floored
+  # as a caret range, never an exact pin, for the reason recorded on fast-uri above.
+  js-yaml: ^4.3.1


### PR DESCRIPTION
GHSA-5p4m-2wfm-xmqj (**high**) — quadratic CPU consumption resolving `!!omap` keys, where a malicious YAML document burns CPU superlinearly in the number of map entries. First complete release is **4.3.1**; the advisory notes the CVE-2026-59870 fix was never backported to 3.x.

## Nothing vulnerable ever shipped

`js-yaml` reaches the tree as `eslint` → `js-yaml` — **development scope** — and it does not appear in the committed `build/index.js` (verified: 0 references). The bundle is **byte-identical** before and after this change, so this owes **no version bump** and `require-version-bump` should pass without one.

## How the gap was found, and why it is worth writing down

The advisory fired on apple-mail-mcp, which *already had* a `js-yaml` override — pinned at `^4.2.0`, a floor written for an earlier advisory and **below** this fix. That is the failure mode worth naming: **a caret range does not protect against an out-of-date floor.** The caret stops the tree moving backwards; it never moves it forwards onto a newer fix. So an override can sit in the file looking like protection while enforcing a version that is no longer safe — the mirror image of the `fast-uri: 3.1.4` exact-pin-became-a-ceiling incident already documented beside it.

The other three repos carried no `js-yaml` entry at all, so all four are floored here in one pass.

## Verification

- `js-yaml@4.3.1` resolved in all four lockfiles, with the override present in the lockfile's own `overrides:` section — the only proof an override is actually live.
- 4.3.1 published 2026-07-31, so it is **7 days past** the repos' 1440-minute `minimumReleaseAge` soak. No `minimumReleaseAgeExclude` carve-out was added.
- `pnpm audit`: **no known vulnerabilities** in all four.
- Bundle hash unchanged in all four.
- lint / typecheck / test / format:check clean — 449 (mail), 519 (notes), 111 (numbers), 290 (photos).