### PR TITLE
fix(accounts): resolve the Notes account instead of assuming "iCloud" (continues #128, @lakerfan0306)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-notes",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-notes",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "apple-notes",
       "description": "Manage Apple Notes through natural language - create, search, read, update, delete, and organize notes and folders",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, and organize notes and folders (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 ## [Unreleased]
 
+## [2.7.1] - 2026-08-12
+
+### Fixed
+
+- **Operations ignored Notes.app's real default account and used the literal string `"iCloud"`.** Every method that took an optional `account` fell back to a hardcoded `"iCloud"`, so the implicit path was wrong for anyone whose default account is not iCloud, whose account name is localized, or whose account name carries a trailing U+F8FF (Apple logo) character — the last is what the reporter actually hit, and no amount of passing the "right" name helped, because the name they could see was not the name AppleScript matched. The default path now resolves through AppleScript's own `default account`. The health check's `operations` probe had the same bug in a second form — it listed notes in `accounts[0]`, whichever account happened to enumerate first, and called it the default; it now exercises the real default. Diagnosed by @lakerfan0306 in #128.
+
+- **An explicit `account` was matched only exactly, and the obvious fix would have made destructive operations silently target the wrong account.** Explicit names now resolve as: exact match wins outright, a *unique* prefix match resolves, and a prefix matching more than one account is **refused** with every candidate named. The refusal is the load-bearing part. The natural repair for the bug above — `first account whose name starts with "X"`, as proposed in #128 — resolves an ambiguous prefix to whichever account AppleScript happens to list first and reports success; applied across the ~10 account-scoped call sites that includes `delete-note`, `move-note` and `batch-move-notes`, so the failure mode is a delete or a move landing in someone else's account with no error. On a library with `rob@superiortech.io` and `robert.b.sweet@gmail.com`, `account="rob"` is now an error naming both, while `account="robert"` still resolves. Same resolution shape as the sibling fix in apple-mail-mcp #137.
+
+- **An unresolvable account was reported as "note not found".** The methods that swallow AppleScript failures into `false`/`null` could not distinguish a precondition error from a real outcome, so naming a nonexistent or ambiguous account sent the caller hunting for a missing note that was never the problem — worst on exactly the destructive paths where the distinction matters. Account-resolution failures are now tagged and re-raised with their real message by `delete-note`, `move-note`, `batch-move-notes`, `create-note`, `update-note`, `create-folder`, `delete-folder`, `get-note-content`, `get-note-plaintext` and `get-note-details`. Genuine operation failures still return `false`/`null` as before.
+
+- **Returned payloads reported the account as `"iCloud"` when the caller had not named one.** `list-folders` and `create-folder` now carry the account name back from the same AppleScript call that resolved it (no extra round trip); `create-note`, `search-notes` and `get-note-details` report it via a default-account lookup cached for the life of the server process — one `osascript` call total, since the manager is a module-level singleton. `list-folders`' text summary now also echoes the **resolved** name rather than the requested one, so a unique-prefix match shows what it actually resolved to.
+
+### Documentation
+
+- Every `account` parameter description in the tool schemas, the README tool reference, and the manager's JSDoc said "defaults to iCloud". All now state the real behavior. The README's **Working with Accounts** section documents the resolution ladder, the ambiguity refusal and why it is a refusal rather than a best guess.
+
 ## [2.7.0] - 2026-08-09
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Creates a new note in Apple Notes.
 | `content` | string | Yes | The body content of the note (do not repeat the title here) |
 | `tags` | string[] | No | Returned-only metadata — **NOT written to Notes.app**. Apple Notes tags can't be set via AppleScript, so values passed here are echoed back in the response but do not appear on the created note. Use inline `#hashtags` in `content` instead (Notes.app turns those into real tags) |
 | `folder` | string | No | Folder to create the note in. Supports nested paths like `"Work/Clients"`. **The folder must already exist** — create it first with [`create-folder`](#create-folder). Defaults to account root |
-| `account` | string | No | Account name (defaults to iCloud). Must be an account Notes.app already has configured — see [`list-accounts`](#list-accounts) |
+| `account` | string | No | Account name (defaults to Notes.app's default account; matched exactly or by a *unique* prefix — an ambiguous prefix is refused). Must be an account Notes.app already has configured — see [`list-accounts`](#list-accounts) |
 | `format` | string | No | Content format: `"plaintext"` (default) or `"html"`. In both formats, the title is automatically prepended as `<h1>`. In plaintext mode, newlines become `<br>`, tabs become `<br>`, and backslashes are preserved as HTML entities |
 
 **Example (tagged with inline hashtags):**
@@ -224,7 +224,7 @@ Searches for notes by title or content.
 |-----------|------|----------|-------------|
 | `query` | string | Yes | Text to search for |
 | `searchContent` | boolean | No | If `true`, searches note body; if `false` (default), searches titles only |
-| `account` | string | No | Account to search in (defaults to iCloud) |
+| `account` | string | No | Account to search in (defaults to Notes.app's default account; exact or unique-prefix match) |
 | `folder` | string | No | Limit search to a specific folder (supports nested paths like `"Work/Clients"`) |
 | `modifiedSince` | string | No | ISO 8601 date string to filter notes modified on or after this date (e.g., `"2025-01-01"`) |
 | `limit` | number | No | Maximum number of results to return. **Defaults to 50** — a broad query reads several properties per match via AppleScript (~200ms/note), so an unbounded search over hundreds of matches can exceed Notes' 30s timeout and return an error instead of results. Pass a higher value to see more; the applied limit (and whether it truncated the results) is disclosed in the response. |
@@ -266,7 +266,7 @@ Retrieves the full content of a specific note.
 |-----------|------|----------|-------------|
 | `id` | string | No | Note ID (preferred - more reliable than title) |
 | `title` | string | No | Note title (use `id` instead when available) |
-| `account` | string | No | Account containing the note (defaults to iCloud, ignored if `id` is provided) |
+| `account` | string | No | Account containing the note (defaults to Notes.app's default account; exact or unique-prefix match, ignored if `id` is provided) |
 
 **Note:** Either `id` or `title` must be provided. Using `id` is recommended as it's unique and avoids issues with duplicate titles.
 
@@ -309,7 +309,7 @@ Retrieves a note's body as plain text, with no HTML markup.
 |-----------|------|----------|-------------|
 | `id` | string | No | Note ID (preferred - more reliable than title) |
 | `title` | string | No | Note title (use `id` instead when available) |
-| `account` | string | No | Account containing the note (defaults to iCloud, ignored if `id` is provided) |
+| `account` | string | No | Account containing the note (defaults to Notes.app's default account; exact or unique-prefix match, ignored if `id` is provided) |
 
 **Note:** Either `id` or `title` must be provided. This reads the note's native `plaintext` property, so it skips the HTML-to-text conversion that `get-note-content` plus a Markdown pass would do. Use `get-note-content` when you need the HTML, or `get-note-markdown` when you want Markdown with checklist state.
 
@@ -324,7 +324,7 @@ Retrieves metadata about a note (without full content).
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `title` | string | Yes | Exact title of the note |
-| `account` | string | No | Account containing the note (defaults to iCloud) |
+| `account` | string | No | Account containing the note (defaults to Notes.app's default account; exact or unique-prefix match) |
 
 **Example:**
 ```json
@@ -383,7 +383,7 @@ Updates an existing note's content and/or title.
 | `title` | string | No | Current title of the note to update (use `id` instead when available) |
 | `newTitle` | string | No | New title (if changing the title; ignored when `format` is `"html"`) |
 | `newContent` | string | Yes | New content for the note body |
-| `account` | string | No | Account containing the note (defaults to iCloud, ignored if `id` is provided) |
+| `account` | string | No | Account containing the note (defaults to Notes.app's default account; exact or unique-prefix match, ignored if `id` is provided) |
 | `format` | string | No | Content format: `"plaintext"` (default) or `"html"`. When `"html"`, content replaces the entire note body as raw HTML and `newTitle` is ignored (the first HTML element serves as the title) |
 
 **Note:** Either `id` or `title` must be provided. Using `id` is recommended.
@@ -440,7 +440,7 @@ Deletes a note (moves to Recently Deleted in Notes.app).
 |-----------|------|----------|-------------|
 | `id` | string | No | Note ID (preferred - more reliable than title) |
 | `title` | string | No | Exact title of the note to delete (use `id` instead when available) |
-| `account` | string | No | Account containing the note (defaults to iCloud, ignored if `id` is provided) |
+| `account` | string | No | Account containing the note (defaults to Notes.app's default account; exact or unique-prefix match, ignored if `id` is provided) |
 
 **Note:** Either `id` or `title` must be provided. Using `id` is recommended.
 
@@ -473,7 +473,7 @@ Moves a note to a different folder. The note is relocated in place via Notes.app
 | `id` | string | No | Note ID (preferred - more reliable than title) |
 | `title` | string | No | Title of the note to move (use `id` instead when available) |
 | `folder` | string | Yes | Destination folder name or nested path (e.g., `"Work/Clients"`) |
-| `account` | string | No | Account containing the note (defaults to iCloud, ignored if `id` is provided) |
+| `account` | string | No | Account containing the note (defaults to Notes.app's default account; exact or unique-prefix match, ignored if `id` is provided) |
 
 **Note:** Either `id` or `title` must be provided. Using `id` is recommended.
 
@@ -509,7 +509,7 @@ Appends or prepends content to an existing note without replacing it. Always rea
 | `position` | string | No | `"after"` (default) appends to the end; `"before"` prepends to the start |
 | `separator` | string | No | String placed between existing content and new content (default: two newlines → `<div><br></div>` in HTML) |
 | `format` | string | No | Format of the content being appended: `"plaintext"` (default) or `"html"` |
-| `account` | string | No | Account containing the note (defaults to iCloud, ignored if `id` is provided) |
+| `account` | string | No | Account containing the note (defaults to Notes.app's default account; exact or unique-prefix match, ignored if `id` is provided) |
 
 **Note:** Either `id` or `title` must be provided. Using `id` is recommended.
 
@@ -545,7 +545,7 @@ Returns the `notes://showNote?identifier=<uuid>` deep-link URL for a note. The U
 |-----------|------|----------|-------------|
 | `id` | string | No | Note ID (preferred - more reliable than title) |
 | `title` | string | No | Note title (use `id` instead when available) |
-| `account` | string | No | Account containing the note (defaults to iCloud, ignored if `id` is provided) |
+| `account` | string | No | Account containing the note (defaults to Notes.app's default account; exact or unique-prefix match, ignored if `id` is provided) |
 
 **Note:** Either `id` or `title` must be provided. Using `id` is recommended. Password-protected notes cannot be linked.
 
@@ -568,7 +568,7 @@ Lists all notes, optionally filtered by folder, date, and limit.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `account` | string | No | Account to list notes from (defaults to iCloud) |
+| `account` | string | No | Account to list notes from (defaults to Notes.app's default account; exact or unique-prefix match) |
 | `folder` | string | No | Filter to notes in this folder only (supports nested paths like `"Work/Clients"`) |
 | `modifiedSince` | string | No | ISO 8601 date string to filter notes modified on or after this date (e.g., `"2025-01-01"`) |
 | `limit` | number | No | Maximum number of notes to return |
@@ -619,7 +619,7 @@ Lists all folders in an account with full hierarchical paths.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `account` | string | No | Account to list folders from (defaults to iCloud) |
+| `account` | string | No | Account to list folders from (defaults to Notes.app's default account; exact or unique-prefix match) |
 
 **Example:**
 ```json
@@ -637,7 +637,7 @@ Creates a new folder, including a whole nested hierarchy in one call.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes | Folder name, or a nested path separated by `/` (e.g. `"Retro Tech/PC/CPUs"`). Every intermediate folder is created; segments that already exist are skipped |
-| `account` | string | No | Account to create folder in (defaults to iCloud) |
+| `account` | string | No | Account to create folder in (defaults to Notes.app's default account; exact or unique-prefix match) |
 
 **Example:**
 ```json
@@ -664,7 +664,7 @@ Deletes a folder.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes | Name or path of the folder to delete (supports nested paths like `"Work/Old"`) |
-| `account` | string | No | Account containing the folder (defaults to iCloud) |
+| `account` | string | No | Account containing the folder (defaults to Notes.app's default account; exact or unique-prefix match) |
 
 **Example:**
 ```json
@@ -963,7 +963,10 @@ AI: [calls get-note-content with title="Shopping List"]
 
 ### Working with Accounts
 
-By default, all operations use iCloud. To work with other accounts:
+Omit `account` and an operation targets whichever account **Notes.app itself
+reports as the default** — not a hardcoded "iCloud". That matters if your default
+is a non-iCloud account, if the account name is localized, or if it carries a
+trailing U+F8FF () character.
 
 ```
 User: "What accounts do I have?"
@@ -974,6 +977,23 @@ User: "List notes in my Gmail account"
 AI: [calls list-notes with account="Gmail"]
     "Your Gmail account has 5 notes..."
 ```
+
+When you do pass `account`, it is resolved in this order:
+
+1. **Exact name match** wins outright.
+2. A **unique prefix match** resolves — `account="robert"` finds
+   `robert.b.sweet@gmail.com`.
+3. An **ambiguous prefix is refused**, with every candidate named:
+
+   ```
+   Account "rob" is ambiguous - it matches 2 accounts:
+   rob@superiortech.io, robert.b.sweet@gmail.com. Use the full account name.
+   ```
+
+That third rule is deliberate. Silently taking the *first* prefix match would
+make `delete-note` or `move-note` land in the wrong account and report success.
+An unresolvable account is reported as such rather than as "note not found", so
+you are not sent looking for the wrong problem.
 
 ### Organizing with Folders
 

--- a/build/index.js
+++ b/build/index.js
@@ -39407,11 +39407,47 @@ function buildFolderReference(folderPath) {
   }
   return parts.reverse().map((part) => `folder "${escapePlainStringForAppleScript(part)}"`).join(" of ");
 }
+var AS_ACCOUNT_REF = "__acctRef";
+var ACCOUNT_RESOLUTION_ERROR = "AccountResolutionError:";
+function throwIfAccountResolutionFailed(error2) {
+  if (!error2) return;
+  const at = error2.indexOf(ACCOUNT_RESOLUTION_ERROR);
+  if (at === -1) return;
+  throw new Error(error2.slice(at + ACCOUNT_RESOLUTION_ERROR.length).trim());
+}
+function buildAccountResolution(account) {
+  if (account === void 0) {
+    return `set ${AS_ACCOUNT_REF} to default account`;
+  }
+  const safeAccount = sanitizeAccountName(account);
+  return `
+    set ${AS_ACCOUNT_REF} to missing value
+    set _exactMatches to (every account whose name is "${safeAccount}")
+    if (count of _exactMatches) is 1 then
+      set ${AS_ACCOUNT_REF} to item 1 of _exactMatches
+    else
+      set _prefixMatches to (every account whose name starts with "${safeAccount}")
+      if (count of _prefixMatches) is 1 then
+        set ${AS_ACCOUNT_REF} to item 1 of _prefixMatches
+      else if (count of _prefixMatches) > 1 then
+        set _candidateNames to {}
+        repeat with _candidate in _prefixMatches
+          set end of _candidateNames to name of (contents of _candidate)
+        end repeat
+        set AppleScript's text item delimiters to ", "
+        set _joinedNames to _candidateNames as text
+        set AppleScript's text item delimiters to ""
+        error "${ACCOUNT_RESOLUTION_ERROR} Account \\"${safeAccount}\\" is ambiguous - it matches " & (count of _prefixMatches) & " accounts: " & _joinedNames & ". Use the full account name."
+      end if
+    end if
+    if ${AS_ACCOUNT_REF} is missing value then error "${ACCOUNT_RESOLUTION_ERROR} Account \\"${safeAccount}\\" not found"
+  `;
+}
 function buildAccountScopedScript(scope, command) {
-  const safeAccount = sanitizeAccountName(scope.account);
   return `
     tell application "Notes"
-      tell account "${safeAccount}"
+      ${buildAccountResolution(scope.account)}
+      tell ${AS_ACCOUNT_REF}
         ${command}
       end tell
     end tell
@@ -39452,16 +39488,48 @@ function extractCoreDataId(output, prefix) {
 }
 var AppleNotesManager = class {
   /**
-   * Default account used when no account is specified.
-   * iCloud is the primary account for most Apple Notes users.
-   */
-  defaultAccount = "iCloud";
-  /**
-   * Resolves the account to use for an operation.
-   * Falls back to default if not specified.
+   * Normalizes a caller-supplied account name for the script builders.
+   *
+   * Returns `undefined` when no account was requested, which
+   * {@link buildAccountResolution} turns into Notes.app's own
+   * `default account`. It deliberately no longer substitutes a hardcoded
+   * `"iCloud"` — that name is wrong for anyone whose default account differs,
+   * is localized, or carries a U+F8FF suffix (#128).
    */
   resolveAccount(account) {
-    return account || this.defaultAccount;
+    const trimmed = account?.trim();
+    return trimmed ? trimmed : void 0;
+  }
+  /**
+   * Cached name of Notes.app's default account, for payload reporting only.
+   * `null` = not yet queried; `""` = queried and unavailable (don't retry).
+   */
+  defaultAccountName = null;
+  /**
+   * The account name to report back in a returned payload.
+   *
+   * Returns the caller's account verbatim when they named one. When they did
+   * not, it reports the *real* default account rather than the hardcoded
+   * "iCloud" the payloads used to claim (#128).
+   *
+   * Most scripts resolve the account inline via {@link buildAccountResolution}
+   * and cost nothing extra; this exists for the handful of methods whose script
+   * output can't carry the name back — notably `createNote`, whose nested-folder
+   * branch depends on the implicit result of `make new note` and must not have
+   * its return value extended (the -1728 workaround above).
+   *
+   * The lookup runs at most once per manager instance and is cached, including
+   * the failure case, so a Notes.app that can't answer is not re-asked on every
+   * call. Returns `undefined` when unknown — `account` is an optional field, and
+   * omitting it is honest where guessing was not.
+   */
+  reportedAccount(targetAccount) {
+    if (targetAccount !== void 0) return targetAccount;
+    if (this.defaultAccountName === null) {
+      const result = executeAppleScript(buildAppLevelScript("return name of default account"));
+      this.defaultAccountName = result.success ? result.output.trim() : "";
+    }
+    return this.defaultAccountName || void 0;
   }
   /**
    * Checks if a note is password-protected by its ID.
@@ -39481,7 +39549,7 @@ var AppleNotesManager = class {
    * Checks if a note is password-protected by its title.
    *
    * @param title - Exact title of the note
-   * @param account - Account to search in (defaults to iCloud)
+   * @param account - Account to search in (defaults to Notes.app's default account)
    * @returns true if the note is password-protected, false otherwise
    */
   isNotePasswordProtected(title, account) {
@@ -39502,7 +39570,7 @@ var AppleNotesManager = class {
    * @param content - Body content (plain text that will be HTML-escaped, or raw HTML when format is "html")
    * @param tags - Optional tags (stored in returned object, not used by Notes.app)
    * @param folder - Optional folder name to create the note in
-   * @param account - Account to use (defaults to iCloud)
+   * @param account - Account to use (defaults to Notes.app's default account)
    * @param format - Content format: "plaintext" escapes and wraps in div tags (default), "html" uses content as-is
    * @returns Created Note object with metadata, or null on failure
    *
@@ -39542,6 +39610,7 @@ var AppleNotesManager = class {
     const script = buildAccountScopedScript({ account: targetAccount }, createCommand);
     const result = executeMutationAppleScript(script);
     if (!result.success) {
+      throwIfAccountResolutionFailed(result.error);
       console.error(`Failed to create note "${title}":`, result.error);
       return null;
     }
@@ -39557,7 +39626,7 @@ var AppleNotesManager = class {
       created: now,
       modified: now,
       folder,
-      account: targetAccount
+      account: this.reportedAccount(targetAccount)
     };
   }
   /**
@@ -39568,7 +39637,7 @@ var AppleNotesManager = class {
    *
    * @param query - Text to search for
    * @param searchContent - If true, search note bodies; if false, search titles
-   * @param account - Account to search in (defaults to iCloud)
+   * @param account - Account to search in (defaults to Notes.app's default account)
    * @param folder - Optional folder to limit search to
    * @param modifiedSince - Optional ISO 8601 date string to filter notes modified on or after this date
    * @param limit - Optional maximum number of results to return (default: no limit)
@@ -39660,6 +39729,7 @@ var AppleNotesManager = class {
     const items = result.output.split(RECORD_SEP);
     const notes = [];
     const seenIds = /* @__PURE__ */ new Set();
+    const reportedAccount = this.reportedAccount(targetAccount);
     for (const item of items) {
       const [title, id, folder2, created, modified] = item.split(FIELD_SEP);
       if (!title?.trim()) continue;
@@ -39675,7 +39745,7 @@ var AppleNotesManager = class {
         created: parseAppleScriptDate(created ?? ""),
         modified: parseAppleScriptDate(modified ?? ""),
         folder: folder2?.trim(),
-        account: targetAccount
+        account: reportedAccount
       });
     }
     return notes;
@@ -39688,7 +39758,7 @@ var AppleNotesManager = class {
    * getNoteDetails() or isNotePasswordProtected().
    *
    * @param title - Exact title of the note
-   * @param account - Account to search in (defaults to iCloud)
+   * @param account - Account to search in (defaults to Notes.app's default account)
    * @returns HTML content of the note, or empty string if not found
    *
    * @example
@@ -39706,6 +39776,7 @@ var AppleNotesManager = class {
     const script = buildAccountScopedScript({ account: targetAccount }, getCommand);
     const result = executeAppleScript(script);
     if (!result.success) {
+      throwIfAccountResolutionFailed(result.error);
       console.error(`Failed to get content of note "${title}":`, result.error);
       return "";
     }
@@ -39744,7 +39815,7 @@ var AppleNotesManager = class {
    * round-trip entirely.
    *
    * @param title - Exact title of the note
-   * @param account - Account to search in (defaults to iCloud)
+   * @param account - Account to search in (defaults to Notes.app's default account)
    * @returns Plain-text content of the note, or empty string if not found
    */
   getNotePlaintext(title, account) {
@@ -39754,6 +39825,7 @@ var AppleNotesManager = class {
     const script = buildAccountScopedScript({ account: targetAccount }, getCommand);
     const result = executeAppleScript(script);
     if (!result.success) {
+      throwIfAccountResolutionFailed(result.error);
       console.error(`Failed to get plaintext of note "${title}":`, result.error);
       return "";
     }
@@ -39832,7 +39904,7 @@ var AppleNotesManager = class {
    * including creation date, modification date, and sharing status.
    *
    * @param title - Exact title of the note
-   * @param account - Account to search in (defaults to iCloud)
+   * @param account - Account to search in (defaults to Notes.app's default account)
    * @returns Note object with full metadata, or null if not found
    */
   getNoteDetails(title, account) {
@@ -39849,6 +39921,7 @@ var AppleNotesManager = class {
     const script = buildAccountScopedScript({ account: targetAccount }, getCommand);
     const result = executeAppleScript(script);
     if (!result.success) {
+      throwIfAccountResolutionFailed(result.error);
       console.error(`Failed to get details for note "${title}":`, result.error);
       return null;
     }
@@ -39866,7 +39939,7 @@ var AppleNotesManager = class {
       modified: parsed.modified,
       shared: parsed.shared,
       passwordProtected: parsed.passwordProtected,
-      account: targetAccount
+      account: this.reportedAccount(targetAccount)
     };
   }
   /**
@@ -39876,7 +39949,7 @@ var AppleNotesManager = class {
    * from the "Recently Deleted" folder in Notes.app.
    *
    * @param title - Exact title of the note to delete
-   * @param account - Account containing the note (defaults to iCloud)
+   * @param account - Account containing the note (defaults to Notes.app's default account)
    * @returns true if deletion succeeded, false otherwise
    */
   deleteNote(title, account) {
@@ -39886,6 +39959,7 @@ var AppleNotesManager = class {
     const script = buildAccountScopedScript({ account: targetAccount }, deleteCommand);
     const result = executeMutationAppleScript(script);
     if (!result.success) {
+      throwIfAccountResolutionFailed(result.error);
       console.error(`Failed to delete note "${title}":`, result.error);
       return false;
     }
@@ -39928,7 +40002,7 @@ var AppleNotesManager = class {
    * @param title - Current title of the note to update
    * @param newTitle - New title (optional, keeps existing if not provided; ignored in html format)
    * @param newContent - New content for the note body
-   * @param account - Account containing the note (defaults to iCloud)
+   * @param account - Account containing the note (defaults to Notes.app's default account)
    * @param format - Content format: "plaintext" wraps in div tags (default), "html" uses content as-is
    * @returns true if update succeeded, false otherwise
    */
@@ -39950,6 +40024,7 @@ var AppleNotesManager = class {
     const script = buildAccountScopedScript({ account: targetAccount }, updateCommand);
     const result = executeMutationAppleScript(script);
     if (!result.success) {
+      throwIfAccountResolutionFailed(result.error);
       console.error(`Failed to update note "${title}":`, result.error);
       return false;
     }
@@ -40147,7 +40222,7 @@ var AppleNotesManager = class {
   /**
    * Lists all notes in an account, optionally filtered by folder, date, and limit.
    *
-   * @param account - Account to list notes from (defaults to iCloud)
+   * @param account - Account to list notes from (defaults to Notes.app's default account)
    * @param folder - Optional folder to filter by
    * @param modifiedSince - Optional ISO 8601 date string to filter notes modified on or after this date
    * @param limit - Optional maximum number of results to return (default: no limit)
@@ -40248,12 +40323,13 @@ var AppleNotesManager = class {
    * so that duplicate folder names (e.g., multiple "Archive" folders) are
    * distinguishable and can be used directly in other operations.
    *
-   * @param account - Account to list folders from (defaults to iCloud)
+   * @param account - Account to list folders from (defaults to Notes.app's default account)
    * @returns Array of Folder objects with path-based names
    */
   listFolders(account) {
     const targetAccount = this.resolveAccount(account);
     const listCommand = `
+      set acctName to name of it
       set folderList to {}
       set allFolders to every folder
       repeat with f in allFolders
@@ -40264,7 +40340,7 @@ var AppleNotesManager = class {
           set parentId to id of cRef
         end if
         set sharedFlag to shared of fRef as text
-        set end of folderList to (id of fRef) & ${AS_FIELD_SEP} & (name of fRef) & ${AS_FIELD_SEP} & parentId & ${AS_FIELD_SEP} & sharedFlag
+        set end of folderList to (id of fRef) & ${AS_FIELD_SEP} & (name of fRef) & ${AS_FIELD_SEP} & parentId & ${AS_FIELD_SEP} & sharedFlag & ${AS_FIELD_SEP} & acctName
       end repeat
       set AppleScript's text item delimiters to ${AS_RECORD_SEP}
       return folderList as text
@@ -40284,7 +40360,11 @@ var AppleNotesManager = class {
         id: (parts[0] || "").trim(),
         name: (parts[1] || "").trim(),
         parentId: (parts[2] || "").trim(),
-        shared: (parts[3] || "").trim().toLowerCase() === "true"
+        shared: (parts[3] || "").trim().toLowerCase() === "true",
+        // The account name as Notes.app actually reports it. When the caller
+        // omitted `account` this is the resolved default, which is the whole
+        // point — reporting a hardcoded "iCloud" here was the #128 bug.
+        account: (parts[4] || "").trim()
       };
     });
     const byId = new Map(entries.map((e) => [e.id, e]));
@@ -40300,7 +40380,7 @@ var AppleNotesManager = class {
     return entries.map((entry) => ({
       id: entry.id,
       name: buildPath(entry),
-      account: targetAccount,
+      account: entry.account || targetAccount || "",
       shared: entry.shared
     }));
   }
@@ -40308,7 +40388,7 @@ var AppleNotesManager = class {
    * Creates a new folder in an account.
    *
    * @param name - Name for the new folder
-   * @param account - Account to create folder in (defaults to iCloud)
+   * @param account - Account to create folder in (defaults to Notes.app's default account)
    * @returns Created Folder object, or null on failure
    */
   createFolder(name, account) {
@@ -40341,6 +40421,7 @@ var AppleNotesManager = class {
       const script = buildAccountScopedScript({ account: targetAccount }, createCommand);
       const result = executeMutationAppleScript(script);
       if (!result.success) {
+        throwIfAccountResolutionFailed(result.error);
         console.error(`Failed to create folder "${name}":`, result.error);
         return null;
       }
@@ -40348,14 +40429,15 @@ var AppleNotesManager = class {
     const fullRef = buildFolderReference(name);
     const idScript = buildAccountScopedScript(
       { account: targetAccount },
-      `return id of ${fullRef}`
+      `return (id of ${fullRef}) & ${AS_FIELD_SEP} & (name of it)`
     );
     const idResult = executeAppleScript(idScript);
-    const folderId = idResult.success ? extractCoreDataId(idResult.output, "folder") : "";
+    const [rawId = "", rawAccount = ""] = idResult.success ? idResult.output.split(FIELD_SEP) : [];
+    const folderId = idResult.success ? extractCoreDataId(rawId, "folder") : "";
     return {
       id: folderId,
       name,
-      account: targetAccount
+      account: rawAccount.trim() || targetAccount || ""
     };
   }
   /**
@@ -40364,7 +40446,7 @@ var AppleNotesManager = class {
    * Note: This may fail if the folder contains notes.
    *
    * @param name - Name of the folder to delete
-   * @param account - Account containing the folder (defaults to iCloud)
+   * @param account - Account containing the folder (defaults to Notes.app's default account)
    * @returns true if deletion succeeded, false otherwise
    */
   deleteFolder(name, account) {
@@ -40373,6 +40455,7 @@ var AppleNotesManager = class {
     const script = buildAccountScopedScript({ account: targetAccount }, deleteCommand);
     const result = executeMutationAppleScript(script);
     if (!result.success) {
+      throwIfAccountResolutionFailed(result.error);
       console.error(`Failed to delete folder "${name}":`, result.error);
       return false;
     }
@@ -40392,7 +40475,7 @@ var AppleNotesManager = class {
    *
    * @param title - Title of the note to move
    * @param destinationFolder - Name of the folder to move to (must already exist)
-   * @param account - Account containing the note (defaults to iCloud)
+   * @param account - Account containing the note (defaults to Notes.app's default account)
    * @returns true if the move succeeded, false otherwise
    */
   moveNote(title, destinationFolder, account) {
@@ -40414,15 +40497,15 @@ var AppleNotesManager = class {
    *
    * @param id - CoreData URL identifier for the note
    * @param destinationFolder - Name of the folder to move to (must already exist)
-   * @param account - Account containing the destination folder (defaults to iCloud)
+   * @param account - Account containing the destination folder (defaults to Notes.app's default account)
    * @returns true if the move succeeded, false otherwise
    */
   moveNoteById(id, destinationFolder, account) {
     const targetAccount = this.resolveAccount(account);
     const safeId = sanitizeId(id);
-    const safeAccount = sanitizeAccountName(targetAccount);
-    const destFolderRef = `${buildFolderReference(destinationFolder)} of account "${safeAccount}"`;
+    const destFolderRef = `${buildFolderReference(destinationFolder)} of ${AS_ACCOUNT_REF}`;
     const moveCommand = `
+      ${buildAccountResolution(targetAccount)}
       set destFolder to ${destFolderRef}
       set noteRef to note id "${safeId}"
       move noteRef to destFolder
@@ -40430,6 +40513,7 @@ var AppleNotesManager = class {
     const script = buildAppLevelScript(moveCommand);
     const result = executeMutationAppleScript(script);
     if (!result.success) {
+      throwIfAccountResolutionFailed(result.error);
       console.error(
         `Cannot move note to "${destinationFolder}" (folder may not exist):`,
         result.error
@@ -40625,7 +40709,7 @@ var AppleNotesManager = class {
    * Returns the notes:// deep-link URL for a note by title.
    *
    * @param title - Exact note title
-   * @param account - Account to search in (defaults to iCloud)
+   * @param account - Account to search in (defaults to Notes.app's default account)
    * @returns notes://showNote?identifier=<uuid> string, or null on failure
    */
   getNoteLink(title, account) {
@@ -40799,12 +40883,11 @@ var AppleNotesManager = class {
       });
       return { healthy: false, checks };
     }
-    const defaultAccount = accounts[0]?.name || "iCloud";
-    const notes = this.listNotes(defaultAccount);
+    const notes = this.listNotes();
     checks.push({
       name: "operations",
       passed: true,
-      message: `Basic operations working (${notes.length} note(s) in ${defaultAccount})`
+      message: `Basic operations working (${notes.length} note(s) in the default account)`
     });
     const allPassed = checks.every((c) => c.passed);
     return { healthy: allPassed, checks };
@@ -41026,18 +41109,18 @@ var AppleNotesManager = class {
    * Lists attachments for a note by its title.
    *
    * @param title - Title of the note
-   * @param account - Account containing the note (defaults to iCloud)
+   * @param account - Account containing the note (defaults to Notes.app's default account)
    * @returns Array of Attachment objects, or empty array if the note genuinely has none
    * @throws If the AppleScript call fails, so a lookup failure is never mistaken for
    *   an attachment-free note (callers gate destructive full-body updates on this)
    */
   listAttachments(title, account) {
     const targetAccount = this.resolveAccount(account);
-    const safeAccount = escapePlainStringForAppleScript(targetAccount);
     const safeTitle = escapePlainStringForAppleScript(title);
     const script = `
       tell application "Notes"
-        tell account "${safeAccount}"
+        ${buildAccountResolution(targetAccount)}
+        tell ${AS_ACCOUNT_REF}
           set theNote to note "${safeTitle}"
         set attachmentList to {}
         set attachmentIds to id of every attachment of theNote
@@ -41337,7 +41420,7 @@ var AppleNotesManager = class {
    *
    * @param ids - Array of CoreData URL identifiers for notes to move
    * @param folder - Destination folder name
-   * @param account - Account containing the folder (defaults to iCloud)
+   * @param account - Account containing the folder (defaults to Notes.app's default account)
    * @returns Array of results with id, success status, and optional error message
    *
    * @example
@@ -41351,8 +41434,7 @@ var AppleNotesManager = class {
   batchMoveNotes(ids, folder, account) {
     if (ids.length === 0) return [];
     const targetAccount = this.resolveAccount(account);
-    const safeAccount = sanitizeAccountName(targetAccount);
-    const destFolderRef = `${buildFolderReference(folder)} of account "${safeAccount}"`;
+    const destFolderRef = `${buildFolderReference(folder)} of ${AS_ACCOUNT_REF}`;
     const results = new Array(ids.length);
     const runnable = [];
     ids.forEach((id, i) => {
@@ -41369,6 +41451,7 @@ var AppleNotesManager = class {
     if (runnable.length > 0) {
       const idList = runnable.map((r) => `"${r.safe}"`).join(", ");
       const script = buildAppLevelScript(`
+        ${buildAccountResolution(targetAccount)}
         set destFolder to ${destFolderRef}
         set out to ""
         repeat with rawId in {${idList}}
@@ -41400,6 +41483,7 @@ var AppleNotesManager = class {
       `);
       const res = executeMutationAppleScript(script);
       if (!res.success) {
+        throwIfAccountResolutionFailed(res.error);
         for (const r of runnable) {
           results[r.index] = this.createBatchResult(
             ids[r.index],
@@ -41580,7 +41664,7 @@ var AppleNotesManager = class {
    * [x] (done) or [ ] (undone) prefixes.
    *
    * @param title - Exact title of the note
-   * @param account - Account containing the note (defaults to iCloud)
+   * @param account - Account containing the note (defaults to Notes.app's default account)
    * @returns Markdown content, or empty string if not found
    *
    * @example
@@ -42171,11 +42255,15 @@ var MAX = {
 };
 var noteTitleSchema = {
   title: external_exports.string().min(1, "Note title is required").max(MAX.TITLE),
-  account: external_exports.string().max(MAX.ACCOUNT).optional().describe("Account name (defaults to iCloud)")
+  account: external_exports.string().max(MAX.ACCOUNT).optional().describe(
+    "Account name (defaults to Notes.app's default account; exact or unique-prefix match)"
+  )
 };
 var folderNameSchema = {
   name: external_exports.string().min(1, "Folder name is required").max(MAX.FOLDER),
-  account: external_exports.string().max(MAX.ACCOUNT).optional().describe("Account name (defaults to iCloud)")
+  account: external_exports.string().max(MAX.ACCOUNT).optional().describe(
+    "Account name (defaults to Notes.app's default account; exact or unique-prefix match)"
+  )
 };
 function registerTool(name, config2, cb) {
   const { outputSchema, ...rest } = config2;
@@ -42202,7 +42290,7 @@ registerTool(
         "Folder to create the note in (supports nested paths like 'Work/Clients'). The folder must already exist \u2014 this tool does not create it; call create-folder first, which is idempotent and creates intermediate segments."
       ),
       account: external_exports.string().max(MAX.ACCOUNT).optional().describe(
-        "Account name (defaults to iCloud). Must be an account Notes.app already has configured \u2014 see list-accounts."
+        "Account name (defaults to the account Notes.app itself reports as default). Matched exactly, or by a unique prefix; an ambiguous prefix is refused. Must be an account Notes.app already has configured \u2014 see list-accounts."
       )
     },
     outputSchema: {
@@ -42311,7 +42399,9 @@ registerTool(
     inputSchema: {
       id: external_exports.string().max(MAX.ID).optional().describe("Note ID (preferred - more reliable than title)"),
       title: external_exports.string().max(MAX.TITLE).optional().describe("Note title (use id instead when available)"),
-      account: external_exports.string().max(MAX.ACCOUNT).optional().describe("Account name (defaults to iCloud, ignored if id is provided)")
+      account: external_exports.string().max(MAX.ACCOUNT).optional().describe(
+        "Account name (defaults to Notes.app's default account; exact or unique-prefix match, ignored if id is provided)"
+      )
     },
     outputSchema: {
       title: external_exports.string().optional(),
@@ -42386,7 +42476,9 @@ registerTool(
     inputSchema: {
       id: external_exports.string().max(MAX.ID).optional().describe("Note ID (preferred - more reliable than title)"),
       title: external_exports.string().max(MAX.TITLE).optional().describe("Note title (use id instead when available)"),
-      account: external_exports.string().max(MAX.ACCOUNT).optional().describe("Account name (defaults to iCloud, ignored if id is provided)")
+      account: external_exports.string().max(MAX.ACCOUNT).optional().describe(
+        "Account name (defaults to Notes.app's default account; exact or unique-prefix match, ignored if id is provided)"
+      )
     },
     outputSchema: {
       title: external_exports.string().optional(),
@@ -42809,7 +42901,9 @@ registerTool(
     inputSchema: {
       id: external_exports.string().max(MAX.ID).optional().describe("Note ID (preferred - more reliable than title)"),
       title: external_exports.string().max(MAX.TITLE).optional().describe("Note title (use id instead when available)"),
-      account: external_exports.string().max(MAX.ACCOUNT).optional().describe("Account name (defaults to iCloud, ignored if id is provided)")
+      account: external_exports.string().max(MAX.ACCOUNT).optional().describe(
+        "Account name (defaults to Notes.app's default account; exact or unique-prefix match, ignored if id is provided)"
+      )
     },
     outputSchema: {
       ok: external_exports.boolean().optional(),
@@ -43024,12 +43118,16 @@ ${syncWarnings.join(" ")}` : "";
     if (folders.length === 0) {
       return successResponse(`No folders found${acct}${syncNote}`, { folders: [], count: 0 });
     }
+    const resolvedAcct = folders[0]?.account ? ` (${folders[0].account})` : acct;
     const folderList = folders.map((f) => `  - ${f.name}`).join("\n");
-    return successResponse(`Found ${folders.length} folders${acct}:
-${folderList}${syncNote}`, {
-      folders,
-      count: folders.length
-    });
+    return successResponse(
+      `Found ${folders.length} folders${resolvedAcct}:
+${folderList}${syncNote}`,
+      {
+        folders,
+        count: folders.length
+      }
+    );
   }, "Error listing folders")
 );
 registerTool(
@@ -43040,7 +43138,9 @@ registerTool(
       name: external_exports.string().min(1, "Folder name is required").max(MAX.FOLDER).describe(
         'Folder name or nested path separated by "/". E.g., "Retro Tech/PC/CPUs" creates all intermediate folders. Existing segments are skipped.'
       ),
-      account: external_exports.string().max(MAX.ACCOUNT).optional().describe("Account name (defaults to iCloud)")
+      account: external_exports.string().max(MAX.ACCOUNT).optional().describe(
+        "Account name (defaults to Notes.app's default account; exact or unique-prefix match)"
+      )
     },
     outputSchema: {
       ok: external_exports.boolean().optional(),
@@ -43383,7 +43483,9 @@ registerTool(
       folder: external_exports.string().max(MAX.FOLDER).describe(
         'Destination folder name or nested path (e.g. "Work/Clients"). Must already exist \u2014 create-folder first.'
       ),
-      account: external_exports.string().max(MAX.ACCOUNT).optional().describe("Account containing the destination folder (defaults to iCloud)")
+      account: external_exports.string().max(MAX.ACCOUNT).optional().describe(
+        "Account containing the destination folder (defaults to Notes.app's default account; exact or unique-prefix match)"
+      )
     },
     outputSchema: {
       ok: external_exports.boolean().optional(),

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes-mcp",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Notes - create, search, update, and manage notes via Claude and other AI assistants",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,7 +155,13 @@ const MAX = {
  */
 const noteTitleSchema = {
   title: z.string().min(1, "Note title is required").max(MAX.TITLE),
-  account: z.string().max(MAX.ACCOUNT).optional().describe("Account name (defaults to iCloud)"),
+  account: z
+    .string()
+    .max(MAX.ACCOUNT)
+    .optional()
+    .describe(
+      "Account name (defaults to Notes.app's default account; exact or unique-prefix match)"
+    ),
 };
 
 /**
@@ -163,7 +169,13 @@ const noteTitleSchema = {
  */
 const folderNameSchema = {
   name: z.string().min(1, "Folder name is required").max(MAX.FOLDER),
-  account: z.string().max(MAX.ACCOUNT).optional().describe("Account name (defaults to iCloud)"),
+  account: z
+    .string()
+    .max(MAX.ACCOUNT)
+    .optional()
+    .describe(
+      "Account name (defaults to Notes.app's default account; exact or unique-prefix match)"
+    ),
 };
 
 // =============================================================================
@@ -255,7 +267,7 @@ registerTool(
         .max(MAX.ACCOUNT)
         .optional()
         .describe(
-          "Account name (defaults to iCloud). Must be an account Notes.app already has configured — see list-accounts."
+          "Account name (defaults to the account Notes.app itself reports as default). Matched exactly, or by a unique prefix; an ambiguous prefix is refused. Must be an account Notes.app already has configured — see list-accounts."
         ),
     },
     outputSchema: {
@@ -416,7 +428,9 @@ registerTool(
         .string()
         .max(MAX.ACCOUNT)
         .optional()
-        .describe("Account name (defaults to iCloud, ignored if id is provided)"),
+        .describe(
+          "Account name (defaults to Notes.app's default account; exact or unique-prefix match, ignored if id is provided)"
+        ),
     },
     outputSchema: {
       title: z.string().optional(),
@@ -517,7 +531,9 @@ registerTool(
         .string()
         .max(MAX.ACCOUNT)
         .optional()
-        .describe("Account name (defaults to iCloud, ignored if id is provided)"),
+        .describe(
+          "Account name (defaults to Notes.app's default account; exact or unique-prefix match, ignored if id is provided)"
+        ),
     },
     outputSchema: {
       title: z.string().optional(),
@@ -1122,7 +1138,9 @@ registerTool(
         .string()
         .max(MAX.ACCOUNT)
         .optional()
-        .describe("Account name (defaults to iCloud, ignored if id is provided)"),
+        .describe(
+          "Account name (defaults to Notes.app's default account; exact or unique-prefix match, ignored if id is provided)"
+        ),
     },
     outputSchema: {
       ok: z.boolean().optional(),
@@ -1401,11 +1419,18 @@ registerTool(
       return successResponse(`No folders found${acct}${syncNote}`, { folders: [], count: 0 });
     }
 
+    // Label with the account name Notes.app actually resolved to, not the one
+    // that was asked for — a unique prefix like "robert" resolves to the full
+    // "robert.b.sweet@gmail.com", and echoing the request would hide that (#128).
+    const resolvedAcct = folders[0]?.account ? ` (${folders[0].account})` : acct;
     const folderList = folders.map((f) => `  - ${f.name}`).join("\n");
-    return successResponse(`Found ${folders.length} folders${acct}:\n${folderList}${syncNote}`, {
-      folders,
-      count: folders.length,
-    });
+    return successResponse(
+      `Found ${folders.length} folders${resolvedAcct}:\n${folderList}${syncNote}`,
+      {
+        folders,
+        count: folders.length,
+      }
+    );
   }, "Error listing folders")
 );
 
@@ -1424,7 +1449,13 @@ registerTool(
         .describe(
           'Folder name or nested path separated by "/". E.g., "Retro Tech/PC/CPUs" creates all intermediate folders. Existing segments are skipped.'
         ),
-      account: z.string().max(MAX.ACCOUNT).optional().describe("Account name (defaults to iCloud)"),
+      account: z
+        .string()
+        .max(MAX.ACCOUNT)
+        .optional()
+        .describe(
+          "Account name (defaults to Notes.app's default account; exact or unique-prefix match)"
+        ),
     },
     outputSchema: {
       ok: z.boolean().optional(),
@@ -1896,7 +1927,9 @@ registerTool(
         .string()
         .max(MAX.ACCOUNT)
         .optional()
-        .describe("Account containing the destination folder (defaults to iCloud)"),
+        .describe(
+          "Account containing the destination folder (defaults to Notes.app's default account; exact or unique-prefix match)"
+        ),
     },
     outputSchema: {
       ok: z.boolean().optional(),

--- a/src/services/appleNotesManager.test.ts
+++ b/src/services/appleNotesManager.test.ts
@@ -415,15 +415,121 @@ describe("AppleNotesManager", () => {
     vi.clearAllMocks();
   });
 
+  // ---------------------------------------------------------------------------
+  // Account Resolution (#128)
+  // ---------------------------------------------------------------------------
+
+  describe("account resolution", () => {
+    it("targets Notes.app's own default account when none is given", () => {
+      mockExecuteAppleScript.mockReturnValue({ success: true, output: "" });
+
+      manager.searchNotes("anything");
+
+      const script = String(mockExecuteAppleScript.mock.calls[0][0]);
+      // A hardcoded "iCloud" is wrong whenever the real default account differs
+      // — a non-iCloud default, a localized name, or a U+F8FF suffix (#128).
+      expect(script).toContain("set __acctRef to default account");
+      expect(script).not.toContain('tell account "iCloud"');
+    });
+
+    it("prefers an exact name match over a prefix match", () => {
+      mockExecuteAppleScript.mockReturnValue({ success: true, output: "" });
+
+      manager.searchNotes("anything", false, "Work");
+
+      const script = String(mockExecuteAppleScript.mock.calls[0][0]);
+      const exactAt = script.indexOf('every account whose name is "Work"');
+      const prefixAt = script.indexOf('every account whose name starts with "Work"');
+      expect(exactAt).toBeGreaterThan(-1);
+      expect(prefixAt).toBeGreaterThan(-1);
+      // Exact is tested first, and prefix is only consulted in the else branch.
+      expect(exactAt).toBeLessThan(prefixAt);
+    });
+
+    it("refuses an ambiguous prefix match instead of silently picking the first", () => {
+      mockExecuteAppleScript.mockReturnValue({ success: true, output: "" });
+
+      manager.searchNotes("anything", false, "rob");
+
+      const script = String(mockExecuteAppleScript.mock.calls[0][0]);
+      // `first account whose name starts with ...` would resolve "rob" to
+      // whichever of rob@… / robert@… Notes lists first and report success —
+      // on the delete/move paths that is a destructive wrong-account write.
+      expect(script).not.toContain("first account whose name starts with");
+      expect(script).toContain("is ambiguous");
+      expect(script).toContain("(count of _prefixMatches) > 1");
+    });
+
+    it("errors rather than proceeding when the named account does not exist", () => {
+      mockExecuteAppleScript.mockReturnValue({ success: true, output: "" });
+
+      manager.searchNotes("anything", false, "Nope");
+
+      const script = String(mockExecuteAppleScript.mock.calls[0][0]);
+      expect(script).toContain('Account \\"Nope\\" not found"');
+      // Tagged so the swallow-into-false callers can tell a precondition error
+      // from a genuine "note not found" outcome.
+      expect(script).toContain("AccountResolutionError:");
+    });
+
+    it("reports an unresolvable account as such instead of 'note not found' on destructive paths", () => {
+      mockExecuteAppleScript.mockReturnValue({
+        success: false,
+        output: "",
+        error:
+          'AccountResolutionError: Account "rob" is ambiguous - it matches 2 accounts: rob@a, rob@b. Use the full account name.',
+      });
+
+      // deleteNote normally swallows failures into `false`; an unresolvable
+      // account must surface instead, or the caller goes hunting for a missing
+      // note that was never the problem.
+      expect(() => manager.deleteNote("Doomed", "rob")).toThrow(/is ambiguous/);
+      expect(() => manager.deleteNote("Doomed", "rob")).not.toThrow(/AccountResolutionError/);
+    });
+
+    it("still swallows a genuine operation failure into false", () => {
+      mockExecuteAppleScript.mockReturnValue({
+        success: false,
+        output: "",
+        error: 'Can\'t get note "Doomed".',
+      });
+
+      expect(manager.deleteNote("Doomed", "iCloud")).toBe(false);
+    });
+
+    it("resolves the account for destructive paths too (deleteNote, batch move)", () => {
+      mockExecuteAppleScript.mockReturnValue({ success: true, output: "" });
+
+      manager.deleteNote("Doomed", "rob");
+      const deleteScript = String(mockExecuteAppleScript.mock.calls.at(-1)?.[0]);
+      expect(deleteScript).toContain("is ambiguous");
+      expect(deleteScript).not.toContain("first account whose name starts with");
+
+      manager.batchMoveNotes(["x-coredata://ABC/ICNote/p1"], "Archive", "rob");
+      const moveScript = String(mockExecuteAppleScript.mock.calls.at(-1)?.[0]);
+      expect(moveScript).toContain("is ambiguous");
+      expect(moveScript).toContain("of __acctRef");
+    });
+
+    it("treats a blank account string as 'use the default'", () => {
+      mockExecuteAppleScript.mockReturnValue({ success: true, output: "" });
+
+      manager.searchNotes("anything", false, "   ");
+
+      const script = String(mockExecuteAppleScript.mock.calls[0][0]);
+      expect(script).toContain("set __acctRef to default account");
+    });
+  });
+
   describe("listAttachments — security", () => {
     it("escapes the account name so it cannot break out of the AppleScript literal (injection regression)", () => {
       mockExecuteAppleScript.mockReturnValue({ success: true, output: "" });
       manager.listAttachments("My Note", 'evil" injected');
       const script = String(mockExecuteAppleScript.mock.calls.at(-1)?.[0]);
       // The account's double-quote must be escaped (\\") — a raw quote would
-      // terminate the tell-account string literal and allow `do shell script` injection.
-      expect(script).toContain('tell account "evil\\" injected"');
-      expect(script).not.toContain('tell account "evil" injected"');
+      // terminate the account-name string literal and allow `do shell script` injection.
+      expect(script).toContain('every account whose name is "evil\\" injected"');
+      expect(script).not.toContain('every account whose name is "evil" injected"');
     });
   });
 
@@ -445,17 +551,21 @@ describe("AppleNotesManager", () => {
     });
 
     it("returns Note object on successful creation", () => {
-      mockExecuteAppleScript.mockReturnValue({
-        success: true,
-        output: "note id x-coredata://12345/ICNote/p100",
-      });
+      mockExecuteAppleScript
+        .mockReturnValueOnce({
+          success: true,
+          output: "note id x-coredata://12345/ICNote/p100",
+        })
+        // The reported account comes from Notes.app's own default account (#128),
+        // not a hardcoded "iCloud".
+        .mockReturnValueOnce({ success: true, output: "Personal" });
 
       const result = manager.createNote("Shopping List", "Eggs, Milk, Bread");
 
       expect(result).not.toBeNull();
       expect(result?.title).toBe("Shopping List");
       expect(result?.content).toBe("Eggs, Milk, Bread");
-      expect(result?.account).toBe("iCloud"); // Default account
+      expect(result?.account).toBe("Personal");
     });
 
     it("strips the 'note id ' prefix from the returned id (#create-note-id)", () => {
@@ -513,7 +623,7 @@ describe("AppleNotesManager", () => {
 
       expect(result?.account).toBe("Gmail");
       expect(mockExecuteAppleScript).toHaveBeenCalledWith(
-        expect.stringContaining('tell account "Gmail"'),
+        expect.stringContaining('every account whose name is "Gmail"'),
         NO_RETRY_OPTIONS
       );
     });
@@ -842,7 +952,7 @@ describe("AppleNotesManager", () => {
       manager.searchNotes("work", false, "Exchange");
 
       expect(mockExecuteAppleScript).toHaveBeenCalledWith(
-        expect.stringContaining('tell account "Exchange"')
+        expect.stringContaining('every account whose name is "Exchange"')
       );
     });
 
@@ -868,7 +978,7 @@ describe("AppleNotesManager", () => {
       manager.searchNotes("task", false, "Exchange", "Projects");
 
       const script = mockExecuteAppleScript.mock.calls[0][0];
-      expect(script).toContain('tell account "Exchange"');
+      expect(script).toContain('every account whose name is "Exchange"');
       expect(script).toContain('notes of folder "Projects"');
     });
 
@@ -943,7 +1053,7 @@ describe("AppleNotesManager", () => {
       expect(script).toContain("modification date >= thresholdDate");
       expect(script).toContain('notes of folder "Work"');
       expect(script).toContain("(count of resultList) >= 10");
-      expect(script).toContain('tell account "iCloud"');
+      expect(script).toContain('every account whose name is "iCloud"');
     });
   });
 
@@ -994,7 +1104,7 @@ describe("AppleNotesManager", () => {
       manager.getNoteContent("My Note", "Gmail");
 
       expect(mockExecuteAppleScript).toHaveBeenCalledWith(
-        expect.stringContaining('tell account "Gmail"')
+        expect.stringContaining('every account whose name is "Gmail"')
       );
     });
   });
@@ -1030,7 +1140,7 @@ describe("AppleNotesManager", () => {
       manager.getNotePlaintext("My Note", "Gmail");
 
       expect(mockExecuteAppleScript).toHaveBeenCalledWith(
-        expect.stringContaining('tell account "Gmail"')
+        expect.stringContaining('every account whose name is "Gmail"')
       );
     });
   });
@@ -1271,7 +1381,6 @@ describe("AppleNotesManager", () => {
       expect(result).not.toBeNull();
       expect(result?.title).toBe("Project Notes");
       expect(result?.id).toBe("x-coredata://ABC123/ICNote/p200");
-      expect(result?.account).toBe("iCloud");
     });
 
     it("returns null when note not found", () => {
@@ -1303,7 +1412,7 @@ describe("AppleNotesManager", () => {
 
       expect(result?.account).toBe("Exchange");
       expect(mockExecuteAppleScript).toHaveBeenCalledWith(
-        expect.stringContaining('tell account "Exchange"')
+        expect.stringContaining('every account whose name is "Exchange"')
       );
     });
 
@@ -1363,7 +1472,7 @@ describe("AppleNotesManager", () => {
       manager.deleteNote("Draft", "Gmail");
 
       expect(mockExecuteAppleScript).toHaveBeenCalledWith(
-        expect.stringContaining('tell account "Gmail"'),
+        expect.stringContaining('every account whose name is "Gmail"'),
         NO_RETRY_OPTIONS
       );
     });
@@ -2143,28 +2252,31 @@ describe("AppleNotesManager", () => {
     ].join(F);
 
     it("returns true when the native move completes successfully", () => {
-      // Mock sequence: getNoteDetails (resolve id) -> native move
+      // Mock sequence: getNoteDetails (resolve id) -> default-account lookup
+      // (once per manager instance, for the reported account) -> native move.
       mockExecuteAppleScript
         .mockReturnValueOnce({ success: true, output: detailsOutput })
+        .mockReturnValueOnce({ success: true, output: "iCloud" })
         .mockReturnValueOnce({ success: true, output: "" });
 
       const result = manager.moveNote("My Note", "Archive");
 
       expect(result).toBe(true);
-      // No copy-then-delete: just the details lookup + a single native `move`.
-      expect(mockExecuteAppleScript).toHaveBeenCalledTimes(2);
+      // No copy-then-delete: the details lookup + a single native `move`.
+      expect(mockExecuteAppleScript).toHaveBeenCalledTimes(3);
     });
 
     it("uses the native AppleScript `move` command (preserves attachments/identity)", () => {
       mockExecuteAppleScript
         .mockReturnValueOnce({ success: true, output: detailsOutput })
+        .mockReturnValueOnce({ success: true, output: "iCloud" })
         .mockReturnValueOnce({ success: true, output: "" });
 
       manager.moveNote("My Note", "Archive");
 
-      // The second call is the move; assert it issues a native `move ... to` and
+      // The last call is the move; assert it issues a native `move ... to` and
       // does NOT rebuild the note via `make new note` (the old lossy path).
-      const moveScript = mockExecuteAppleScript.mock.calls[1][0] as string;
+      const moveScript = String(mockExecuteAppleScript.mock.calls.at(-1)?.[0]);
       expect(moveScript).toContain("move noteRef to destFolder");
       expect(moveScript).not.toContain("make new note");
     });
@@ -2185,6 +2297,7 @@ describe("AppleNotesManager", () => {
     it("returns false when the move fails (e.g. destination folder missing)", () => {
       mockExecuteAppleScript
         .mockReturnValueOnce({ success: true, output: detailsOutput })
+        .mockReturnValueOnce({ success: true, output: "iCloud" })
         .mockReturnValueOnce({
           success: false,
           output: "",
@@ -2194,7 +2307,7 @@ describe("AppleNotesManager", () => {
       const result = manager.moveNote("My Note", "Nonexistent Folder");
 
       expect(result).toBe(false);
-      expect(mockExecuteAppleScript).toHaveBeenCalledTimes(2); // Details + failed move
+      expect(mockExecuteAppleScript).toHaveBeenCalledTimes(3); // Details + account lookup + failed move
     });
   });
 
@@ -3046,18 +3159,18 @@ describe("AppleNotesManager", () => {
       manager.listAttachments("My Note", "Gmail");
 
       expect(mockExecuteAppleScript).toHaveBeenCalledWith(
-        expect.stringContaining('account "Gmail"')
+        expect.stringContaining('every account whose name is "Gmail"')
       );
     });
 
-    it("defaults to iCloud account", () => {
+    it("defaults to Notes.app's own default account, not a hardcoded iCloud", () => {
       mockExecuteAppleScript.mockReturnValueOnce({ success: true, output: "" });
 
       manager.listAttachments("My Note");
 
-      expect(mockExecuteAppleScript).toHaveBeenCalledWith(
-        expect.stringContaining('account "iCloud"')
-      );
+      const script = String(mockExecuteAppleScript.mock.calls.at(-1)?.[0]);
+      expect(script).toContain("set __acctRef to default account");
+      expect(script).not.toContain('"iCloud"');
     });
 
     it("returns empty array when note has no attachments", () => {

--- a/src/services/appleNotesManager.ts
+++ b/src/services/appleNotesManager.ts
@@ -435,8 +435,11 @@ export function parseNotePropertiesOutput(output: string): ParsedNoteProperties 
  * Used by script builders to scope operations.
  */
 interface AccountScope {
-  /** Account name (e.g., "iCloud", "Gmail") */
-  account: string;
+  /**
+   * Account name (e.g., "iCloud", "Gmail"), or undefined to target whichever
+   * account Notes.app itself reports as the default.
+   */
+  account?: string;
 }
 
 /**
@@ -498,28 +501,116 @@ export function buildFolderReference(folderPath: string): string {
 }
 
 /**
+ * AppleScript variable that every account-scoped script binds to the single
+ * resolved account reference.
+ */
+const AS_ACCOUNT_REF = "__acctRef";
+
+/**
+ * Sentinel prefixed to every account-resolution failure raised from AppleScript.
+ *
+ * Account resolution failing is a *precondition* error, not an operation
+ * outcome, so the methods that otherwise swallow AppleScript failures into
+ * `false`/`null` must not report it as "note not found" — that sends the caller
+ * hunting for the wrong problem on exactly the destructive paths where the
+ * distinction matters most. {@link throwIfAccountResolutionFailed} re-raises it.
+ */
+export const ACCOUNT_RESOLUTION_ERROR = "AccountResolutionError:";
+
+/**
+ * Re-raises an account-resolution failure hidden inside an AppleScript error.
+ *
+ * No-op for every other error, so callers keep their existing swallow-and-
+ * return-false behavior for genuine operation failures.
+ */
+function throwIfAccountResolutionFailed(error: string | undefined): void {
+  if (!error) return;
+  const at = error.indexOf(ACCOUNT_RESOLUTION_ERROR);
+  if (at === -1) return;
+  throw new Error(error.slice(at + ACCOUNT_RESOLUTION_ERROR.length).trim());
+}
+
+/**
+ * Emits AppleScript that binds {@link AS_ACCOUNT_REF} to exactly one account.
+ *
+ * Must be emitted INSIDE a `tell application "Notes"` block.
+ *
+ * Resolution ladder:
+ * 1. **No account requested** → Notes.app's own `default account`, never the
+ *    literal `"iCloud"`. A hardcoded name is wrong whenever the real one
+ *    differs for *any* reason: the user's default simply is not iCloud, the
+ *    account name is localized, or it carries a U+F8FF (Apple logo) suffix.
+ * 2. **Exact name match** wins outright.
+ * 3. A **unique prefix match** resolves — so a caller that passes a shortened
+ *    or subtly-different name still lands on the right account.
+ * 4. **More than one prefix match is refused**, naming every candidate.
+ *
+ * Step 4 is the load-bearing one. `first account whose name starts with ...`
+ * silently picks whichever account AppleScript lists first and reports success;
+ * on the `delete`/`move` paths that means a destructive operation landing in
+ * the wrong account. This is the same hazard resolved in the sibling repo as
+ * apple-mail-mcp #137, and it is why prefix matching is gated on uniqueness
+ * rather than taking `first`.
+ *
+ * Reported by @lakerfan0306 in #128.
+ */
+function buildAccountResolution(account?: string): string {
+  if (account === undefined) {
+    return `set ${AS_ACCOUNT_REF} to default account`;
+  }
+
+  const safeAccount = sanitizeAccountName(account);
+  return `
+    set ${AS_ACCOUNT_REF} to missing value
+    set _exactMatches to (every account whose name is "${safeAccount}")
+    if (count of _exactMatches) is 1 then
+      set ${AS_ACCOUNT_REF} to item 1 of _exactMatches
+    else
+      set _prefixMatches to (every account whose name starts with "${safeAccount}")
+      if (count of _prefixMatches) is 1 then
+        set ${AS_ACCOUNT_REF} to item 1 of _prefixMatches
+      else if (count of _prefixMatches) > 1 then
+        set _candidateNames to {}
+        repeat with _candidate in _prefixMatches
+          set end of _candidateNames to name of (contents of _candidate)
+        end repeat
+        set AppleScript's text item delimiters to ", "
+        set _joinedNames to _candidateNames as text
+        set AppleScript's text item delimiters to ""
+        error "${ACCOUNT_RESOLUTION_ERROR} Account \\"${safeAccount}\\" is ambiguous - it matches " & (count of _prefixMatches) & " accounts: " & _joinedNames & ". Use the full account name."
+      end if
+    end if
+    if ${AS_ACCOUNT_REF} is missing value then error "${ACCOUNT_RESOLUTION_ERROR} Account \\"${safeAccount}\\" not found"
+  `;
+}
+
+/**
  * Builds an AppleScript command wrapped in account context.
  *
  * Most Notes.app operations need to be scoped to an account:
  * ```applescript
  * tell application "Notes"
- *   tell account "iCloud"
+ *   -- resolution ladder binds __acctRef to exactly one account
+ *   tell __acctRef
  *     -- command here
  *   end tell
  * end tell
  * ```
  *
- * This builder generates that wrapper structure.
+ * This builder generates that wrapper structure. The account is resolved by
+ * {@link buildAccountResolution} rather than interpolated as a literal
+ * `tell account "<name>"`, so an omitted account follows Notes.app's real
+ * default and an ambiguous name is refused instead of silently picking one.
  *
- * @param scope - Account to target
+ * @param scope - Account to target; omit `account` for Notes.app's default
  * @param command - The AppleScript command to execute
  * @returns Complete AppleScript ready for execution
  */
 function buildAccountScopedScript(scope: AccountScope, command: string): string {
-  const safeAccount = sanitizeAccountName(scope.account);
   return `
     tell application "Notes"
-      tell account "${safeAccount}"
+      ${buildAccountResolution(scope.account)}
+      tell ${AS_ACCOUNT_REF}
         ${command}
       end tell
     end tell
@@ -654,17 +745,52 @@ function extractCoreDataId(output: string, prefix: string): string {
  */
 export class AppleNotesManager {
   /**
-   * Default account used when no account is specified.
-   * iCloud is the primary account for most Apple Notes users.
+   * Normalizes a caller-supplied account name for the script builders.
+   *
+   * Returns `undefined` when no account was requested, which
+   * {@link buildAccountResolution} turns into Notes.app's own
+   * `default account`. It deliberately no longer substitutes a hardcoded
+   * `"iCloud"` — that name is wrong for anyone whose default account differs,
+   * is localized, or carries a U+F8FF suffix (#128).
    */
-  private readonly defaultAccount = "iCloud";
+  private resolveAccount(account?: string): string | undefined {
+    const trimmed = account?.trim();
+    return trimmed ? trimmed : undefined;
+  }
 
   /**
-   * Resolves the account to use for an operation.
-   * Falls back to default if not specified.
+   * Cached name of Notes.app's default account, for payload reporting only.
+   * `null` = not yet queried; `""` = queried and unavailable (don't retry).
    */
-  private resolveAccount(account?: string): string {
-    return account || this.defaultAccount;
+  private defaultAccountName: string | null = null;
+
+  /**
+   * The account name to report back in a returned payload.
+   *
+   * Returns the caller's account verbatim when they named one. When they did
+   * not, it reports the *real* default account rather than the hardcoded
+   * "iCloud" the payloads used to claim (#128).
+   *
+   * Most scripts resolve the account inline via {@link buildAccountResolution}
+   * and cost nothing extra; this exists for the handful of methods whose script
+   * output can't carry the name back — notably `createNote`, whose nested-folder
+   * branch depends on the implicit result of `make new note` and must not have
+   * its return value extended (the -1728 workaround above).
+   *
+   * The lookup runs at most once per manager instance and is cached, including
+   * the failure case, so a Notes.app that can't answer is not re-asked on every
+   * call. Returns `undefined` when unknown — `account` is an optional field, and
+   * omitting it is honest where guessing was not.
+   */
+  private reportedAccount(targetAccount?: string): string | undefined {
+    if (targetAccount !== undefined) return targetAccount;
+
+    if (this.defaultAccountName === null) {
+      const result = executeAppleScript(buildAppLevelScript("return name of default account"));
+      this.defaultAccountName = result.success ? result.output.trim() : "";
+    }
+
+    return this.defaultAccountName || undefined;
   }
 
   /**
@@ -686,7 +812,7 @@ export class AppleNotesManager {
    * Checks if a note is password-protected by its title.
    *
    * @param title - Exact title of the note
-   * @param account - Account to search in (defaults to iCloud)
+   * @param account - Account to search in (defaults to Notes.app's default account)
    * @returns true if the note is password-protected, false otherwise
    */
   isNotePasswordProtected(title: string, account?: string): boolean {
@@ -709,7 +835,7 @@ export class AppleNotesManager {
    * @param content - Body content (plain text that will be HTML-escaped, or raw HTML when format is "html")
    * @param tags - Optional tags (stored in returned object, not used by Notes.app)
    * @param folder - Optional folder name to create the note in
-   * @param account - Account to use (defaults to iCloud)
+   * @param account - Account to use (defaults to Notes.app's default account)
    * @param format - Content format: "plaintext" escapes and wraps in div tags (default), "html" uses content as-is
    * @returns Created Note object with metadata, or null on failure
    *
@@ -782,6 +908,7 @@ export class AppleNotesManager {
     const result = executeMutationAppleScript(script);
 
     if (!result.success) {
+      throwIfAccountResolutionFailed(result.error);
       console.error(`Failed to create note "${title}":`, result.error);
       return null;
     }
@@ -804,7 +931,7 @@ export class AppleNotesManager {
       created: now,
       modified: now,
       folder,
-      account: targetAccount,
+      account: this.reportedAccount(targetAccount),
     };
   }
 
@@ -816,7 +943,7 @@ export class AppleNotesManager {
    *
    * @param query - Text to search for
    * @param searchContent - If true, search note bodies; if false, search titles
-   * @param account - Account to search in (defaults to iCloud)
+   * @param account - Account to search in (defaults to Notes.app's default account)
    * @param folder - Optional folder to limit search to
    * @param modifiedSince - Optional ISO 8601 date string to filter notes modified on or after this date
    * @param limit - Optional maximum number of results to return (default: no limit)
@@ -942,6 +1069,8 @@ export class AppleNotesManager {
 
     const notes: Note[] = [];
     const seenIds = new Set<string>();
+    // Resolve once, not per record — the first call can hit AppleScript.
+    const reportedAccount = this.reportedAccount(targetAccount);
     for (const item of items) {
       const [title, id, folder, created, modified] = item.split(FIELD_SEP);
       if (!title?.trim()) continue;
@@ -956,7 +1085,7 @@ export class AppleNotesManager {
         created: parseAppleScriptDate(created ?? ""),
         modified: parseAppleScriptDate(modified ?? ""),
         folder: folder?.trim(),
-        account: targetAccount,
+        account: reportedAccount,
       });
     }
     return notes;
@@ -970,7 +1099,7 @@ export class AppleNotesManager {
    * getNoteDetails() or isNotePasswordProtected().
    *
    * @param title - Exact title of the note
-   * @param account - Account to search in (defaults to iCloud)
+   * @param account - Account to search in (defaults to Notes.app's default account)
    * @returns HTML content of the note, or empty string if not found
    *
    * @example
@@ -991,6 +1120,7 @@ export class AppleNotesManager {
     const result = executeAppleScript(script);
 
     if (!result.success) {
+      throwIfAccountResolutionFailed(result.error);
       console.error(`Failed to get content of note "${title}":`, result.error);
       return "";
     }
@@ -1035,7 +1165,7 @@ export class AppleNotesManager {
    * round-trip entirely.
    *
    * @param title - Exact title of the note
-   * @param account - Account to search in (defaults to iCloud)
+   * @param account - Account to search in (defaults to Notes.app's default account)
    * @returns Plain-text content of the note, or empty string if not found
    */
   getNotePlaintext(title: string, account?: string): string {
@@ -1047,6 +1177,7 @@ export class AppleNotesManager {
     const result = executeAppleScript(script);
 
     if (!result.success) {
+      throwIfAccountResolutionFailed(result.error);
       console.error(`Failed to get plaintext of note "${title}":`, result.error);
       return "";
     }
@@ -1135,7 +1266,7 @@ export class AppleNotesManager {
    * including creation date, modification date, and sharing status.
    *
    * @param title - Exact title of the note
-   * @param account - Account to search in (defaults to iCloud)
+   * @param account - Account to search in (defaults to Notes.app's default account)
    * @returns Note object with full metadata, or null if not found
    */
   getNoteDetails(title: string, account?: string): Note | null {
@@ -1155,6 +1286,7 @@ export class AppleNotesManager {
     const result = executeAppleScript(script);
 
     if (!result.success) {
+      throwIfAccountResolutionFailed(result.error);
       console.error(`Failed to get details for note "${title}":`, result.error);
       return null;
     }
@@ -1174,7 +1306,7 @@ export class AppleNotesManager {
       modified: parsed.modified,
       shared: parsed.shared,
       passwordProtected: parsed.passwordProtected,
-      account: targetAccount,
+      account: this.reportedAccount(targetAccount),
     };
   }
 
@@ -1185,7 +1317,7 @@ export class AppleNotesManager {
    * from the "Recently Deleted" folder in Notes.app.
    *
    * @param title - Exact title of the note to delete
-   * @param account - Account containing the note (defaults to iCloud)
+   * @param account - Account containing the note (defaults to Notes.app's default account)
    * @returns true if deletion succeeded, false otherwise
    */
   deleteNote(title: string, account?: string): boolean {
@@ -1197,6 +1329,7 @@ export class AppleNotesManager {
     const result = executeMutationAppleScript(script);
 
     if (!result.success) {
+      throwIfAccountResolutionFailed(result.error);
       console.error(`Failed to delete note "${title}":`, result.error);
       return false;
     }
@@ -1244,7 +1377,7 @@ export class AppleNotesManager {
    * @param title - Current title of the note to update
    * @param newTitle - New title (optional, keeps existing if not provided; ignored in html format)
    * @param newContent - New content for the note body
-   * @param account - Account containing the note (defaults to iCloud)
+   * @param account - Account containing the note (defaults to Notes.app's default account)
    * @param format - Content format: "plaintext" wraps in div tags (default), "html" uses content as-is
    * @returns true if update succeeded, false otherwise
    */
@@ -1277,6 +1410,7 @@ export class AppleNotesManager {
     const result = executeMutationAppleScript(script);
 
     if (!result.success) {
+      throwIfAccountResolutionFailed(result.error);
       console.error(`Failed to update note "${title}":`, result.error);
       return false;
     }
@@ -1527,7 +1661,7 @@ export class AppleNotesManager {
   /**
    * Lists all notes in an account, optionally filtered by folder, date, and limit.
    *
-   * @param account - Account to list notes from (defaults to iCloud)
+   * @param account - Account to list notes from (defaults to Notes.app's default account)
    * @param folder - Optional folder to filter by
    * @param modifiedSince - Optional ISO 8601 date string to filter notes modified on or after this date
    * @param limit - Optional maximum number of results to return (default: no limit)
@@ -1650,7 +1784,7 @@ export class AppleNotesManager {
    * so that duplicate folder names (e.g., multiple "Archive" folders) are
    * distinguishable and can be used directly in other operations.
    *
-   * @param account - Account to list folders from (defaults to iCloud)
+   * @param account - Account to list folders from (defaults to Notes.app's default account)
    * @returns Array of Folder objects with path-based names
    */
   listFolders(account?: string): Folder[] {
@@ -1659,6 +1793,7 @@ export class AppleNotesManager {
     // Get each folder's ID, name, parent ID, and shared state in a single AppleScript call.
     // Using IDs enables correct tree building even with duplicate folder names.
     const listCommand = `
+      set acctName to name of it
       set folderList to {}
       set allFolders to every folder
       repeat with f in allFolders
@@ -1669,7 +1804,7 @@ export class AppleNotesManager {
           set parentId to id of cRef
         end if
         set sharedFlag to shared of fRef as text
-        set end of folderList to (id of fRef) & ${AS_FIELD_SEP} & (name of fRef) & ${AS_FIELD_SEP} & parentId & ${AS_FIELD_SEP} & sharedFlag
+        set end of folderList to (id of fRef) & ${AS_FIELD_SEP} & (name of fRef) & ${AS_FIELD_SEP} & parentId & ${AS_FIELD_SEP} & sharedFlag & ${AS_FIELD_SEP} & acctName
       end repeat
       set AppleScript's text item delimiters to ${AS_RECORD_SEP}
       return folderList as text
@@ -1693,6 +1828,10 @@ export class AppleNotesManager {
         name: (parts[1] || "").trim(),
         parentId: (parts[2] || "").trim(),
         shared: (parts[3] || "").trim().toLowerCase() === "true",
+        // The account name as Notes.app actually reports it. When the caller
+        // omitted `account` this is the resolved default, which is the whole
+        // point — reporting a hardcoded "iCloud" here was the #128 bug.
+        account: (parts[4] || "").trim(),
       };
     });
 
@@ -1716,7 +1855,7 @@ export class AppleNotesManager {
     return entries.map((entry) => ({
       id: entry.id,
       name: buildPath(entry),
-      account: targetAccount,
+      account: entry.account || targetAccount || "",
       shared: entry.shared,
     }));
   }
@@ -1725,7 +1864,7 @@ export class AppleNotesManager {
    * Creates a new folder in an account.
    *
    * @param name - Name for the new folder
-   * @param account - Account to create folder in (defaults to iCloud)
+   * @param account - Account to create folder in (defaults to Notes.app's default account)
    * @returns Created Folder object, or null on failure
    */
   createFolder(name: string, account?: string): Folder | null {
@@ -1776,24 +1915,28 @@ export class AppleNotesManager {
       const result = executeMutationAppleScript(script);
 
       if (!result.success) {
+        throwIfAccountResolutionFailed(result.error);
         console.error(`Failed to create folder "${name}":`, result.error);
         return null;
       }
     }
 
     // Get the ID of the final (deepest) folder
+    // Ask for the account's real name in the same call, so an omitted `account`
+    // reports the resolved default rather than a hardcoded "iCloud" (#128).
     const fullRef = buildFolderReference(name);
     const idScript = buildAccountScopedScript(
       { account: targetAccount },
-      `return id of ${fullRef}`
+      `return (id of ${fullRef}) & ${AS_FIELD_SEP} & (name of it)`
     );
     const idResult = executeAppleScript(idScript);
-    const folderId = idResult.success ? extractCoreDataId(idResult.output, "folder") : "";
+    const [rawId = "", rawAccount = ""] = idResult.success ? idResult.output.split(FIELD_SEP) : [];
+    const folderId = idResult.success ? extractCoreDataId(rawId, "folder") : "";
 
     return {
       id: folderId,
       name,
-      account: targetAccount,
+      account: rawAccount.trim() || targetAccount || "",
     };
   }
 
@@ -1803,7 +1946,7 @@ export class AppleNotesManager {
    * Note: This may fail if the folder contains notes.
    *
    * @param name - Name of the folder to delete
-   * @param account - Account containing the folder (defaults to iCloud)
+   * @param account - Account containing the folder (defaults to Notes.app's default account)
    * @returns true if deletion succeeded, false otherwise
    */
   deleteFolder(name: string, account?: string): boolean {
@@ -1814,6 +1957,7 @@ export class AppleNotesManager {
     const result = executeMutationAppleScript(script);
 
     if (!result.success) {
+      throwIfAccountResolutionFailed(result.error);
       console.error(`Failed to delete folder "${name}":`, result.error);
       return false;
     }
@@ -1835,7 +1979,7 @@ export class AppleNotesManager {
    *
    * @param title - Title of the note to move
    * @param destinationFolder - Name of the folder to move to (must already exist)
-   * @param account - Account containing the note (defaults to iCloud)
+   * @param account - Account containing the note (defaults to Notes.app's default account)
    * @returns true if the move succeeded, false otherwise
    */
   moveNote(title: string, destinationFolder: string, account?: string): boolean {
@@ -1863,19 +2007,19 @@ export class AppleNotesManager {
    *
    * @param id - CoreData URL identifier for the note
    * @param destinationFolder - Name of the folder to move to (must already exist)
-   * @param account - Account containing the destination folder (defaults to iCloud)
+   * @param account - Account containing the destination folder (defaults to Notes.app's default account)
    * @returns true if the move succeeded, false otherwise
    */
   moveNoteById(id: string, destinationFolder: string, account?: string): boolean {
     const targetAccount = this.resolveAccount(account);
     const safeId = sanitizeId(id);
-    const safeAccount = sanitizeAccountName(targetAccount);
     // buildFolderReference validates the destination path; a malformed folder is
     // a precondition error, so let it throw. The destination folder must already
     // exist — Notes.app's `move` does not create it.
-    const destFolderRef = `${buildFolderReference(destinationFolder)} of account "${safeAccount}"`;
+    const destFolderRef = `${buildFolderReference(destinationFolder)} of ${AS_ACCOUNT_REF}`;
 
     const moveCommand = `
+      ${buildAccountResolution(targetAccount)}
       set destFolder to ${destFolderRef}
       set noteRef to note id "${safeId}"
       move noteRef to destFolder
@@ -1884,6 +2028,7 @@ export class AppleNotesManager {
     const result = executeMutationAppleScript(script);
 
     if (!result.success) {
+      throwIfAccountResolutionFailed(result.error);
       console.error(
         `Cannot move note to "${destinationFolder}" (folder may not exist):`,
         result.error
@@ -2111,7 +2256,7 @@ export class AppleNotesManager {
    * Returns the notes:// deep-link URL for a note by title.
    *
    * @param title - Exact note title
-   * @param account - Account to search in (defaults to iCloud)
+   * @param account - Account to search in (defaults to Notes.app's default account)
    * @returns notes://showNote?identifier=<uuid> string, or null on failure
    */
   getNoteLink(title: string, account?: string): string | null {
@@ -2309,14 +2454,15 @@ export class AppleNotesManager {
       return { healthy: false, checks };
     }
 
-    // Check 4: Basic operations work (list notes in default account)
-    const defaultAccount = accounts[0]?.name || "iCloud";
-    const notes = this.listNotes(defaultAccount);
+    // Check 4: Basic operations work (list notes in the default account).
+    // Pass no account so this exercises Notes.app's real `default account`
+    // rather than whichever account happens to be listed first (#128).
+    const notes = this.listNotes();
     // Even 0 notes is fine - we just want to verify the operation works
     checks.push({
       name: "operations",
       passed: true,
-      message: `Basic operations working (${notes.length} note(s) in ${defaultAccount})`,
+      message: `Basic operations working (${notes.length} note(s) in the default account)`,
     });
 
     const allPassed = checks.every((c) => c.passed);
@@ -2590,19 +2736,19 @@ export class AppleNotesManager {
    * Lists attachments for a note by its title.
    *
    * @param title - Title of the note
-   * @param account - Account containing the note (defaults to iCloud)
+   * @param account - Account containing the note (defaults to Notes.app's default account)
    * @returns Array of Attachment objects, or empty array if the note genuinely has none
    * @throws If the AppleScript call fails, so a lookup failure is never mistaken for
    *   an attachment-free note (callers gate destructive full-body updates on this)
    */
   listAttachments(title: string, account?: string): Attachment[] {
     const targetAccount = this.resolveAccount(account);
-    const safeAccount = escapePlainStringForAppleScript(targetAccount);
     const safeTitle = escapePlainStringForAppleScript(title);
 
     const script = `
       tell application "Notes"
-        tell account "${safeAccount}"
+        ${buildAccountResolution(targetAccount)}
+        tell ${AS_ACCOUNT_REF}
           set theNote to note "${safeTitle}"
         set attachmentList to {}
         set attachmentIds to id of every attachment of theNote
@@ -2965,7 +3111,7 @@ export class AppleNotesManager {
    *
    * @param ids - Array of CoreData URL identifiers for notes to move
    * @param folder - Destination folder name
-   * @param account - Account containing the folder (defaults to iCloud)
+   * @param account - Account containing the folder (defaults to Notes.app's default account)
    * @returns Array of results with id, success status, and optional error message
    *
    * @example
@@ -2989,10 +3135,9 @@ export class AppleNotesManager {
     // command — which preserves the note's identity and metadata rather than
     // copy+delete — inside a single app-level loop with per-id `try` isolation.
     const targetAccount = this.resolveAccount(account);
-    const safeAccount = sanitizeAccountName(targetAccount);
     // buildFolderReference validates the (single, shared) destination path; a
     // malformed folder is a precondition error for the whole call, so let it throw.
-    const destFolderRef = `${buildFolderReference(folder)} of account "${safeAccount}"`;
+    const destFolderRef = `${buildFolderReference(folder)} of ${AS_ACCOUNT_REF}`;
 
     const results: { id: string; success: boolean; error?: string }[] = new Array(ids.length);
     const runnable: { index: number; safe: string }[] = [];
@@ -3012,6 +3157,7 @@ export class AppleNotesManager {
     if (runnable.length > 0) {
       const idList = runnable.map((r) => `"${r.safe}"`).join(", ");
       const script = buildAppLevelScript(`
+        ${buildAccountResolution(targetAccount)}
         set destFolder to ${destFolderRef}
         set out to ""
         repeat with rawId in {${idList}}
@@ -3044,6 +3190,10 @@ export class AppleNotesManager {
       const res = executeMutationAppleScript(script);
 
       if (!res.success) {
+        // An unresolvable/ambiguous account is a precondition error for the
+        // whole call, not a per-note outcome — surface it rather than reporting
+        // N identical "batch move failed" rows that hide the real cause.
+        throwIfAccountResolutionFailed(res.error);
         // Whole-batch failure (e.g. destination folder unresolved, Notes not
         // responding): can't isolate, so fail every runnable note.
         for (const r of runnable) {
@@ -3291,7 +3441,7 @@ export class AppleNotesManager {
    * [x] (done) or [ ] (undone) prefixes.
    *
    * @param title - Exact title of the note
-   * @param account - Account containing the note (defaults to iCloud)
+   * @param account - Account containing the note (defaults to Notes.app's default account)
    * @returns Markdown content, or empty string if not found
    *
    * @example


### PR DESCRIPTION
Carries forward @lakerfan0306's diagnosis from #128, which they withdrew before it was reviewed. The diagnosis was right and worth keeping; the proposed repair had a hazard, so this ships the hardened version.

## What was actually broken

Every method taking an optional `account` fell back to the literal string `"iCloud"`. That is wrong whenever the real account name differs for *any* reason:

- the user's default account simply is not iCloud,
- the account name is localized, or
- the name carries a trailing U+F8FF (Apple logo) character — what the reporter hit, and unfixable from the caller's side, because the name they could see was not the name AppleScript matched.

The default path now resolves through AppleScript's own `default account`:

```
$ osascript -e 'tell application "Notes" to get name of default account'
iCloud
```

The health check carried the same bug in a second form — it listed notes in `accounts[0]`, whichever account enumerated first, and called that the default. It now exercises the real one.

## Why not just prefix-match

#128 proposed `tell (first account whose name starts with "X")`. Prefix matching is the right instinct, but `first … whose` is a silent wrong-target hazard — if the prefix matches more than one account, AppleScript picks whichever it lists first and reports success:

```
$ osascript -e 'tell application "Notes" to get name of every account'
iCloud, rob@superiortech.io, robert.b.sweet@gmail.com

$ osascript -e 'tell application "Notes" to get name of (first account whose name starts with "rob")'
rob@superiortech.io
```

Two accounts start with `rob`; one is chosen, nothing surfaces the ambiguity. Across the ~10 account-scoped call sites that includes `delete-note`, `move-note` and `batch-move-notes` — so the failure mode is a delete or move landing in the wrong account and reporting success.

So explicit names resolve as **exact match wins outright → *unique* prefix match resolves → more than one match is refused, naming every candidate**. Same resolution shape as the sibling fix in apple-mail-mcp #137.

#128 also would not have fixed the reporter's case end-to-end: `moveNoteById` and `batchMoveNotes` interpolate `of account "${safeAccount}"` directly and were untouched by that diff. Resolution here happens in AppleScript and binds one `__acctRef`, so those paths inherit it.

## Unresolvable account no longer reports "note not found"

The methods that swallow AppleScript failures into `false`/`null` could not tell a precondition error from a real outcome, so naming a bad account sent you hunting for a missing note. Resolution failures are now tagged and re-raised with their real message. Genuine failures still return `false`/`null`.

## Verified against real Notes.app

Three accounts (`iCloud`, `rob@superiortech.io`, `robert.b.sweet@gmail.com`), driving the built bundle over a real MCP handshake:

| call | result |
|---|---|
| `list-folders` (no account) | resolves the real default; payload reports `iCloud` |
| `account: "iCloud"` | exact match, 5 folders |
| `account: "robert"` | unique prefix → `robert.b.sweet@gmail.com` |
| `account: "rob"` | **refused**: `is ambiguous - it matches 2 accounts: rob@superiortech.io, robert.b.sweet@gmail.com` |
| `account: "Nope"` | `Account "Nope" not found` |
| `create-note` → `move-note` → `delete-note` | full cycle; reports the resolved account |
| `delete-note` with `account: "rob"` | refused, note **not** deleted, real cause surfaced |

No extra `osascript` round trip on the resolution path — it is inlined into the script that was already running. The payload-only default lookup is cached for the life of the server process (the manager is a module-level singleton), so it costs one call total.

## Also in this PR

- All `account` parameter descriptions — tool schemas, README tool reference, manager JSDoc — said "defaults to iCloud". Updated to the real behavior.
- README **Working with Accounts** documents the ladder and why ambiguity is a refusal rather than a best guess.
- 531 tests pass, including 8 new ones covering exact/prefix/ambiguous/not-found, the destructive paths, and the precondition-vs-outcome error split.
- Version bumped to 2.7.1 with CHANGELOG.

Original: #128.