### PR TITLE
docs: remove the Testing Your Understanding self-quiz from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,14 +211,6 @@ This works in: `create-note` (folder param), `create-folder`, `search-notes`, `l
 | "iCloud sync in progress" | Wait and retry - results may be incomplete |
 | "No checklist items found" | Note has no checklists, or Full Disk Access not granted |
 
-## Testing Your Understanding
-
-Before creating notes with shell commands or paths containing backslashes, verify you're escaping correctly:
-
-- `~/path/to/file` - No escaping needed (no backslashes)
-- `Mobile\ Documents` - Needs escaping: `Mobile\\ Documents`
-- `C:\Users\` - Needs escaping: `C:\\Users\\`
-
 ## Recurring macOS permission prompts → offer the official-Node fix
 
 If a user reports being **repeatedly** prompted for Full Disk Access or


### PR DESCRIPTION
CLAUDE.md ended with a "Testing Your Understanding" section that reran three examples from the Critical: Backslash Escaping table as a quiz. The model reading the file already has those rules a few sections up, so the quiz spends context without adding information, and current guidance on agent context files flags exactly this pattern as removable.

This PR deletes the quiz section and nothing else. The escaping table, the "Why This Matters" explanation, and the worked examples all stay where they were, since those are the real gotchas.

The change only touches CLAUDE.md, but lint, the full test suite (565 tests), and the build all pass locally.