### PR TITLE
docs: fix the Windows escaping example and the stale iCloud default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,8 +39,11 @@ content: "cp ~/Library/Mobile\\ Documents/file.txt ~/dest/"
 
 **Correct - Windows path:**
 ```
-content: "Path: C:\\\\Users\\\\Documents"
+content: "Path: C:\\Users\\Documents"
 ```
+(One `\\` per literal backslash, exactly as in the shell example above. `\\\\`
+is the escaping for a literal *double* backslash — see the table's second row —
+so it would store `C:\\Users\\Documents`, not a Windows path.)
 
 **Incorrect - Will fail:**
 ```
@@ -183,7 +186,7 @@ This works in: `create-note` (folder param), `create-folder`, `search-notes`, `l
 - No action needed — enrichment happens transparently
 
 ### Multi-account
-- Default account is iCloud
+- Omitting `account` targets whatever Notes.app reports as its **`default account`** — which is often, but not necessarily, iCloud. Since 2.7.1 the server resolves that name at runtime instead of assuming the literal `"iCloud"`, so it is also correct for a localized account name, a non-iCloud default, or a name carrying a trailing U+F8FF ()
 - Use `list-accounts` to see available accounts
 - Pass `account` parameter to target specific account
 - When using `id`, account is not needed (IDs are globally unique)

--- a/src/services/appleNotesManager.ts
+++ b/src/services/appleNotesManager.ts
@@ -733,7 +733,7 @@ function extractCoreDataId(output: string, prefix: string): string {
  * ```typescript
  * const notes = new AppleNotesManager();
  *
- * // Create a note in the default (iCloud) account
+ * // Create a note in Notes.app's default account (not necessarily iCloud)
  * const note = notes.createNote("Shopping List", "Eggs, Milk, Bread");
  *
  * // Search across all notes


### PR DESCRIPTION
Two inaccuracies in `CLAUDE.md`, both surfaced while reviewing #133. Docs only — no tool, parameter, or behavior change.

## 1. The Windows escaping example was wrong

```
**Correct - Windows path:**
content: "Path: C:\\\\Users\\\\Documents"
```

By the file's **own** escaping table, `\\\\` is the encoding for a literal *double* backslash:

| You want | Send in JSON parameter |
|----------|------------------------|
| `\` | `\\` |
| `\\` | `\\\\` |

So that example stores `C:\\Users\\Documents`, not a Windows path — and it contradicts the shell example immediately above it, which correctly uses one `\\` per literal backslash. Fixed to `C:\\Users\\Documents`, with a note explaining why the four-backslash form is the wrong tool here.

Worth recording how this surfaced: #133 removed the "Testing Your Understanding" self-quiz, and that quiz's third line (`C:\Users\` → `C:\\Users\\`) was the only place in the file that got this right. Removing it was still correct — the quiz was redundant with the table and the bug is pre-existing — but it left the incorrect example as the file's only Windows guidance, which is what prompted checking it.

## 2. "Default account is iCloud" has been wrong since 2.7.1

`### Multi-account` still claimed a hardcoded iCloud default. #129 removed exactly that assumption: account resolution now reads Notes.app's own `default account` at runtime rather than substituting the literal `"iCloud"`, specifically so it stays correct for a localized account name, a default that isn't iCloud, or a name carrying a trailing U+F8FF.

The source says so explicitly:

```
 * 1. **No account requested** → Notes.app's own `default account`, never the
 *    literal `"iCloud"`. A hardcoded name is wrong whenever the real one differs
```

Left as-is, the file told the model the opposite of what the code does. The same stale parenthetical in the `AppleNotesManager` JSDoc example is fixed too.

## Why no version bump or CHANGELOG entry

`CLAUDE.md` is not in `package.json` `files[]` (`["build","docs","README.md","LICENSE"]`), so it does not ship to npm. The one `src/` edit is inside a JSDoc comment, and esbuild strips it — the committed bundle is byte-identical across a rebuild (sha256 unchanged), so `version-guard`'s `src/**/*.ts` rule is not triggered.

Gate: lint, typecheck, `format:check`, and 565 unit tests all pass.
