### PR TITLE
test: guard the ecosystem contract, the doc's own rules, and the shared dialect module

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,11 +36,14 @@ If you send a single backslash without escaping:
 ```
 content: "cp ~/Library/Mobile\\ Documents/file.txt ~/dest/"
 ```
+→ arrives as: `cp ~/Library/Mobile\ Documents/file.txt ~/dest/`
 
 **Correct - Windows path:**
 ```
 content: "Path: C:\\Users\\Documents"
 ```
+→ arrives as: `Path: C:\Users\Documents`
+
 (One `\\` per literal backslash, exactly as in the shell example above. `\\\\`
 is the escaping for a literal *double* backslash — see the table's second row —
 so it would store `C:\\Users\\Documents`, not a Windows path.)

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "@vitest/coverage-v8": "^3.2.6",
+    "ajv": "^8.17.1",
     "esbuild": "^0.28.1",
     "eslint": "^9.0.0",
     "globals": "^17.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^3.2.6
         version: 3.2.7(vitest@3.2.7(@types/node@20.19.43)(yaml@2.9.0))
+      ajv:
+        specifier: ^8.17.1
+        version: 8.20.0
       esbuild:
         specifier: ^0.28.1
         version: 0.28.1

--- a/src/claudeMdEscaping.test.ts
+++ b/src/claudeMdEscaping.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Executable doc examples — CLAUDE.md's backslash-escaping section.
+ *
+ * CLAUDE.md is the contract we hand to agents driving this server, and nothing
+ * ever checked its examples against its own rules. This repo shipped a Windows
+ * path example telling callers to send `\\\\`, which by the escaping table three
+ * lines above it decodes to a literal DOUBLE backslash — wrong, and wrong for a
+ * long time, because prose can't fail CI. These tests make it fail CI:
+ *
+ *   a. the "You want | Send in JSON parameter" table is self-consistent —
+ *      JSON-decoding each right-hand cell yields exactly the left-hand cell
+ *   b. every "Correct" example decodes to its documented `→ arrives as:` result
+ *   c. every "Incorrect" example really is incorrect — it either fails to parse
+ *      as JSON or decodes to something other than a correct example's result
+ *
+ * Reads CLAUDE.md from disk only; no server boot, no Notes.app, no network.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const CLAUDE_MD = resolve(__dirname, "../CLAUDE.md");
+const SECTION_HEADING = "## Critical: Backslash Escaping";
+
+/** The escaping section only — so an unrelated `**Correct**` elsewhere in the doc is not swept in. */
+function escapingSection(): string {
+  const doc = readFileSync(CLAUDE_MD, "utf8");
+  const start = doc.indexOf(SECTION_HEADING);
+  expect(start, `CLAUDE.md is missing the "${SECTION_HEADING}" section`).toBeGreaterThanOrEqual(0);
+  const rest = doc.slice(start + SECTION_HEADING.length);
+  const end = rest.indexOf("\n## ");
+  return end === -1 ? rest : rest.slice(0, end);
+}
+
+/** Decode a documented JSON-parameter payload the way the MCP transport would. */
+function decodeCell(cell: string): string {
+  return JSON.parse(`"${cell}"`) as string;
+}
+
+const stripCode = (cell: string): string => cell.replace(/^`/, "").replace(/`$/, "");
+
+/**
+ * Matches a labelled example: the bold "Correct"/"Incorrect" line, the fenced
+ * block under it, and the single line immediately after the closing fence
+ * (where the `→ arrives as:` annotation must live).
+ */
+const EXAMPLE_RE =
+  /\*\*(Correct|Incorrect)\b([^*\n]*)\*\*\s*\n```[a-zA-Z]*\n([\s\S]*?)\n```[ \t]*\n(.*)/g;
+
+/** Pulls the `content: "…"` / `body: "…"` JSON string literal out of a fenced example. */
+const LITERAL_RE = /\b(?:content|body)\s*:\s*("(?:[^"\\]|\\.)*")/;
+
+interface Example {
+  kind: "Correct" | "Incorrect";
+  label: string;
+  literal: string;
+  annotation: string;
+}
+
+function examples(): Example[] {
+  const section = escapingSection();
+  const found: Example[] = [];
+  for (const m of section.matchAll(EXAMPLE_RE)) {
+    const [, kind, labelRest, body, nextLine] = m;
+    const literal = LITERAL_RE.exec(body)?.[1];
+    expect(
+      literal,
+      `the ${kind} example "${labelRest.trim()}" has no content:/body: string literal in its fenced block`
+    ).toBeTruthy();
+    found.push({
+      kind: kind as Example["kind"],
+      label: labelRest.trim(),
+      literal: literal as string,
+      annotation: nextLine.trim(),
+    });
+  }
+  return found;
+}
+
+describe("CLAUDE.md backslash-escaping section is executable", () => {
+  it("the escaping table is self-consistent — each 'send' cell decodes to its 'you want' cell", () => {
+    const rows = escapingSection()
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.startsWith("|"))
+      .map((line) =>
+        line
+          .replace(/^\|/, "")
+          .replace(/\|$/, "")
+          .split("|")
+          .map((cell) => cell.trim())
+      )
+      // Drop the header and the |---|---| separator.
+      .filter(([want]) => want !== "You want" && !/^:?-{3,}:?$/.test(want));
+
+    expect(rows.length, "no rows found in the escaping table").toBeGreaterThan(0);
+
+    for (const [want, send] of rows) {
+      const wanted = stripCode(want);
+      const sent = stripCode(send);
+      expect(
+        decodeCell(sent),
+        `table row is self-contradictory: sending \`${sent}\` does not produce \`${wanted}\``
+      ).toBe(wanted);
+    }
+  });
+
+  it("every 'Correct' example decodes to its documented '→ arrives as:' result", () => {
+    const correct = examples().filter((e) => e.kind === "Correct");
+    expect(
+      correct.length,
+      "no annotated Correct examples found — a doc rewrite must not silently drop the " +
+        "`→ arrives as:` annotations and leave this test vacuously passing"
+    ).toBeGreaterThan(0);
+
+    for (const example of correct) {
+      const annotated = /^→ arrives as: `(.*)`$/.exec(example.annotation);
+      expect(
+        annotated,
+        `the Correct example "${example.label}" needs a machine-readable result on the line ` +
+          "immediately after its closing fence, exactly: → arrives as: `<literal text>` " +
+          `(found: ${JSON.stringify(example.annotation)})`
+      ).toBeTruthy();
+
+      expect(
+        decodeCell(example.literal.slice(1, -1)),
+        `the Correct example "${example.label}" does not deliver what it claims: ` +
+          `${example.literal} arrives as something other than the documented result`
+      ).toBe((annotated as RegExpExecArray)[1]);
+    }
+  });
+
+  it("every 'Incorrect' example really is incorrect", () => {
+    const all = examples();
+    const correctResults = new Set(
+      all.filter((e) => e.kind === "Correct").map((e) => decodeCell(e.literal.slice(1, -1)))
+    );
+    const incorrect = all.filter((e) => e.kind === "Incorrect");
+    expect(incorrect.length, "no Incorrect examples found in the escaping section").toBeGreaterThan(
+      0
+    );
+
+    for (const example of incorrect) {
+      let decoded: string | undefined;
+      try {
+        decoded = decodeCell(example.literal.slice(1, -1));
+      } catch {
+        // Unparseable as JSON — genuinely broken, which is the point.
+        continue;
+      }
+      expect(
+        correctResults.has(decoded),
+        `the example "${example.label}" is labelled incorrect, but ${example.literal} ` +
+          "parses cleanly and produces the same result as a Correct example — a doc that " +
+          "calls a working string a failure teaches the wrong lesson"
+      ).toBe(false);
+    }
+  });
+});

--- a/src/utils/jsonSchemaDialect.ts
+++ b/src/utils/jsonSchemaDialect.ts
@@ -24,13 +24,16 @@ export const JSON_SCHEMA_2020_12 = "https://json-schema.org/draft/2020-12/schema
 const DEFINITIONS_REF_PREFIX = "#/definitions/";
 
 /**
- * Keywords whose value is a map of caller-chosen NAME -> schema. Their keys are
- * user data -- a tool parameter may legitimately be named "definitions",
- * "$schema" or "dependencies" -- so the keys must never be run through the
- * keyword rewrites below, only their values converted.
+ * Keywords whose value is a map of caller-chosen NAME -> schema.
  *
- * ("definitions" is deliberately absent: it is a keyword wherever it appears at
- * a schema position, and its own case converts it and renames it to $defs.)
+ * Their keys are user data -- a tool's parameter names -- not schema keywords,
+ * so they must never be run through the keyword rewrites below. Without this,
+ * a tool declaring a parameter named "definitions" would have it renamed to
+ * "$defs" on the wire, and one named "$schema" would be silently DELETED, while
+ * "required" still named the original -- yielding a schema no input satisfies.
+ *
+ * "definitions" is deliberately absent: it is a real keyword at a schema
+ * position, and its own case below converts it and renames it to $defs.
  */
 const SCHEMA_MAP_KEYWORDS: ReadonlySet<string> = new Set([
   "properties",
@@ -42,7 +45,7 @@ const SCHEMA_MAP_KEYWORDS: ReadonlySet<string> = new Set([
 /**
  * Keywords whose value is instance DATA rather than a schema. Recursing into
  * them would rewrite a caller's literal values as if they were schema keywords
- * (e.g. a default of { definitions: 1 } would come back as { $defs: 1 }).
+ * (e.g. a default of { definitions: 1, $schema: "x" }), so they pass verbatim.
  */
 const DATA_KEYWORDS: ReadonlySet<string> = new Set([
   "enum",
@@ -70,14 +73,6 @@ function convertSchemaMap(node: unknown): unknown {
 /**
  * Recursively rewrite the draft-07 keywords whose meaning or spelling changed
  * in 2020-12. Anything already dialect-neutral passes through untouched.
- *
- * POSITION-AWARE: a key only means a keyword when it sits at a schema position.
- * Inside a "properties" (or other schema-map) node the keys are caller-chosen
- * tool parameter names, and inside a data keyword the value is literal instance
- * data -- neither may be rewritten. Getting this wrong is not cosmetic: a tool
- * parameter named "definitions" would be renamed to "$defs" on the wire, and one
- * named "$schema" would be SILENTLY DELETED, while "required" still listed the
- * original name -- yielding a schema no input can satisfy.
  */
 function convertNode(node: unknown): unknown {
   if (Array.isArray(node)) return node.map(convertNode);
@@ -94,17 +89,16 @@ function convertNode(node: unknown): unknown {
         break;
 
       case "definitions":
-        // A schema map: rename the keyword, convert the values, keep the names.
         out.$defs = convertSchemaMap(value);
         break;
 
       case "$ref":
-        // Deliberate limitation: only a $ref with the exact ROOT prefix
+        // Known, deliberate limitation: only a $ref with the exact ROOT prefix
         // "#/definitions/" is rewritten. A pointer THROUGH a nested definitions
         // block (e.g. "#/properties/x/definitions/Y") is left alone, because
-        // "#/properties/definitions/..." could equally address a property NAMED
-        // definitions, and the two are indistinguishable without resolving the
-        // pointer. The SDK's converter emits neither construct.
+        // "#/properties/definitions/..." could legitimately address a property
+        // NAMED definitions and the two are indistinguishable without resolving
+        // the pointer. The SDK's converter emits neither construct.
         out.$ref =
           typeof value === "string" && value.startsWith(DEFINITIONS_REF_PREFIX)
             ? "#/$defs/" + value.slice(DEFINITIONS_REF_PREFIX.length)
@@ -157,6 +151,9 @@ function convertNode(node: unknown): unknown {
         break;
 
       default:
+        // Position-aware fallthrough: instance data passes verbatim, a
+        // name -> schema map has only its VALUES converted, and anything else
+        // is a schema position and recurses.
         if (DATA_KEYWORDS.has(key)) out[key] = value;
         else if (SCHEMA_MAP_KEYWORDS.has(key)) out[key] = convertSchemaMap(value);
         else out[key] = convertNode(value);

--- a/test/output-schema.test.ts
+++ b/test/output-schema.test.ts
@@ -21,6 +21,17 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { resolve } from "path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import Ajv2020Import from "ajv/dist/2020.js";
+
+// ajv ships CJS. Under Node's ESM loader the default export IS the constructor;
+// under some bundler/loader interops it is the module namespace with the
+// constructor on `.default`. Unwrap so this works either way — a `.default`
+// that is missing at runtime is exactly how this guard would silently stop
+// running. ajv is a DIRECT devDependency on purpose: it is also a transitive
+// dep of @modelcontextprotocol/sdk, but pnpm's strict node_modules layout makes
+// transitive deps unimportable, so the import would fail without it.
+const Ajv2020 =
+  (Ajv2020Import as unknown as { default?: typeof Ajv2020Import }).default ?? Ajv2020Import;
 
 const SERVER = resolve(__dirname, "../build/index.js");
 
@@ -177,6 +188,52 @@ describe("outputSchema contract (real server over stdio)", () => {
       offenders,
       `every advertised schema must declare ${EXPECTED} and use no draft-07-only construct — ` +
         `clients reject the whole tool otherwise: ${offenders.join("; ")}`
+    ).toEqual([]);
+  });
+
+  it("every advertised schema compiles under a REAL 2020-12 validator (ajv)", async () => {
+    // The dialect assertion above checks the label; this checks the goods.
+    // A schema can declare 2020-12 and still be structurally invalid under it —
+    // and a client that rejects it will say only that our tool is broken. ajv is
+    // the same validator the MCP SDK itself uses, so "ajv compiles it" is the
+    // closest thing to "a real client will accept it" we can assert offline.
+    //
+    // strict: false on purpose. Strict mode rejects unknown keywords and would
+    // fail on benign annotations the SDK emits; the contract being guarded is
+    // structural validity under the 2020-12 dialect, not ajv's style opinions.
+    //
+    // No advertised schema uses the `format` KEYWORD (verified: the only
+    // "format" occurrences are tool PARAMETER names under `properties` on
+    // create-note / update-note / append-to-note), so ajv-formats is
+    // deliberately not installed. Note that under strict:false ajv only warns
+    // ("unknown format ... ignored") rather than failing — so if a real `format`
+    // is ever introduced, add ajv-formats and register it here, or this guard
+    // will pass over it without checking anything.
+    const { tools } = await client.listTools();
+    expect(tools.length).toBeGreaterThan(0);
+
+    const failures: string[] = [];
+    for (const tool of tools) {
+      for (const [kind, schema] of [
+        ["inputSchema", tool.inputSchema],
+        ["outputSchema", tool.outputSchema],
+      ] as const) {
+        if (!schema) continue;
+        try {
+          // A fresh instance per schema: ajv keys compiled schemas by $id, so
+          // one shared instance would let an unrelated tool's collision surface
+          // as this tool's failure.
+          new Ajv2020({ strict: false }).compile(schema);
+        } catch (err) {
+          failures.push(`${tool.name}.${kind}: ${(err as Error).message}`);
+        }
+      }
+    }
+
+    expect(
+      failures,
+      `every advertised schema must compile under JSON Schema 2020-12 — a client ` +
+        `that cannot compile it drops the tool entirely: ${failures.join("; ")}`
     ).toEqual([]);
   });
 


### PR DESCRIPTION
## The incident behind this

All four `apple-*-mcp` servers advertised tool schemas declaring JSON Schema **draft-07**, and current MCP clients hard-reject every such tool — *"JSON Schema declares an unsupported dialect … The default validator supports JSON Schema 2020-12 only."* That takes out all 36 tools at once. It was fixed today (#132).

The uncomfortable part is that this repo already had a thorough `outputSchema` contract suite and **not one assertion about the dialect we advertise**. Every assertion was about our own behaviour; none was about our contract with the ecosystem. These three guards close that class of hole, not just the one bug.

No version bump and no CHANGELOG entry: nothing here changes shipped bytes. Verified — see the bundle note under guard 3.

---

## Guard 1 — compile every advertised schema with a REAL 2020-12 validator

Asserting the `"$schema"` **string** only proves the label. A schema can declare 2020-12 and still be structurally invalid under it, and a client that can't compile it will say only that our tool is broken.

`test/output-schema.test.ts` now compiles **both** `inputSchema` and `outputSchema` for every tool with **ajv's 2020 validator** — the same library the MCP SDK itself uses — and fails with the tool name and ajv's own message.

- `new Ajv2020({ strict: false })` on purpose. Strict mode rejects unknown keywords and would fail on benign annotations; the contract being guarded is structural validity under the dialect, not ajv's style opinions.
- A fresh ajv instance per schema, so an unrelated tool's `$id` collision can't surface as this tool's failure.
- **ajv is now a direct devDependency** (`^8.17.1`, the SDK's own range). It was already present transitively via `@modelcontextprotocol/sdk`, but pnpm's strict `node_modules` layout makes transitive deps unimportable — the import would fail without it.
- **No advertised schema uses the `format` keyword**, so `ajv-formats` is deliberately *not* installed. Checked rather than assumed: the only three `format` occurrences in the advertised payload are tool *parameter names* under `properties` (`create-note`, `update-note`, `append-to-note`). The test carries a note that `strict: false` makes ajv only *warn* on an unknown format, so anyone introducing a real one must add and register `ajv-formats` or the guard will pass over it.

**Teeth** — corrupted `doctor`'s advertised outputSchema with `{ type: "definitely-not-a-type" }`:

```
AssertionError: every advertised schema must compile under JSON Schema 2020-12 — a client
that cannot compile it drops the tool entirely: doctor.outputSchema: schema is invalid:
data/properties/ok/type must be equal to one of the allowed values, ...
```

## Guard 2 — make CLAUDE.md's escaping examples executable

CLAUDE.md carried a Windows-path example telling callers to send `\\\\`, which **by the escaping table three lines above it** decodes to a literal *double* backslash. It was wrong for a long time because prose cannot fail CI. (Fixed in #134; this makes it un-regressable.)

New unit test `src/claudeMdEscaping.test.ts` — plain vitest, no server boot, it only reads `CLAUDE.md` from disk — enforces the doc against its own rules:

1. **The escaping table is self-consistent.** Every *"Send in JSON parameter"* cell must JSON-decode to exactly its *"You want"* cell.
2. **Every "Correct" example decodes to its documented result.** This needs a machine-readable expected value, so each Correct example now carries one immediately after its closing fence:
   ```
   → arrives as: `<the literal text the note actually gets>`
   ```
   The test pulls the `content: "…"` literal out of the fenced block, JSON-decodes it, and compares. It also fails if the annotations are ever dropped, so a doc rewrite can't leave it vacuously passing.
3. **Every "Incorrect" example really is incorrect** — it must either fail to parse as JSON, or decode to something *other* than a Correct example's result. A doc that labels a working string "will fail" is its own kind of wrong.

The examples themselves are unchanged. **Only the two annotation lines are new** — this is annotating, not rewriting.

**Teeth** — all three assertions were broken deliberately and observed to fail:

```
AssertionError: the Correct example "- Windows path:" does not deliver what it claims:
"Path: C:\\Users\\Documents" arrives as something other than the documented result:
expected 'Path: C:\Users\Documents' to be 'Path: C:\\Users\\Documents'

AssertionError: table row is self-contradictory: sending `Mobile\\\\ Documents` does not
produce `Mobile\ Documents`

AssertionError: the example "- Will fail:" is labelled incorrect, but
"cp ~/Library/Mobile\\ Documents/file.txt ~/dest/" parses cleanly and produces the same
result as a Correct example
```

## Guard 3 — normalize `src/utils/jsonSchemaDialect.ts` to the canonical copy

The module was written independently in each of the four repos during today's fix. The executable logic stayed identical, but the doc comments drifted immediately — which is enough to stop `conformance-check.sh` from enforcing byte-identity, and **the file is already in that script's `IDENTICAL` set**. Comment drift hiding future logic drift is exactly what that harness exists to prevent.

apple-mail-mcp is canonical; its copy is untouched. This copies it here verbatim.

**Proof it's comments-only:** the committed `build/index.js` is byte-identical before and after the rebuild —

```
575559dc899c8a9763e23fefa21ee42587c0f1a13eed194621e0135bb5786ddf   (before)
575559dc899c8a9763e23fefa21ee42587c0f1a13eed194621e0135bb5786ddf   (after)
```

`build/` is not in this PR.

---

## Gates

| Gate | Result |
|---|---|
| `pnpm run lint` | pass |
| `pnpm run typecheck` | pass |
| `pnpm test` | 568 passed / 22 files |
| `pnpm run format:check` | pass |
| `pnpm run test:integration` | 12 passed, 5 skipped (no Notes account) — `output-schema.test.ts` now 6 tests |

Sibling PRs land the same guards in apple-mail-mcp, apple-numbers-mcp and apple-photos-mcp.

https://claude.ai/code/session_01VUsvik7hHLhhxQ6MHTXeMx
