### PR TITLE
docs: fix the shipped four-backslash escaping instruction, drop Windows examples, extend the guard to README.md

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-notes",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-notes",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "apple-notes",
       "description": "Manage Apple Notes through natural language - create, search, read, update, delete, and organize notes and folders",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, and organize notes and folders (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## [Unreleased]
 
+## [2.7.3] - 2026-08-13
+
+### Documentation
+
+- **README.md told callers to send FOUR backslashes for one literal backslash, and README.md is the file that ships.** The "common patterns requiring escaping" list said to send `Mobile\\\\ Documents`, `C:\\\\Users\\\\` and `\\\\d+` to store the literal texts `Mobile\ Documents`, `C:\Users\` and `\d+`, and the worked example's `content` field carried the same four-backslash form. Four backslashes in a JSON string literal decode to **two** literal backslashes, so an agent following those instructions stored `Mobile\\ Documents`, `C:\\Users\\` and `\\d+` — every escaped path and every regex silently doubled. The prose under the example was self-contradictory in the same way: it claimed `\\\\` in JSON becomes `\\` in the actual string "which represents a single `\`", but `\\` in the resulting string is two characters, not one. CLAUDE.md has said `\\` since it was written, so the two docs contradicted each other inside one repo — and the **shipped** one was the wrong one, because README.md is in package.json `files[]` and goes out in the npm tarball while CLAUDE.md does not. Every corrected example was verified by decoding it through `JSON.parse`, not by counting backslashes; eyeballing is how the original survived review.
+
+- **Dropped the Windows examples from README.md and CLAUDE.md.** This server drives Apple Notes through AppleScript and cannot run anywhere but macOS, so `C:\Users\` was generic MCP boilerplate that was never localized — and it is not a coincidence that the wrong escaping hid on the one platform nobody here could test against. The generic rule (one literal backslash is sent as `\\`) already covers every platform, so no coverage is lost. CLAUDE.md's Windows worked example is replaced by two macOS-native ones — a regex, and a **literal double backslash**, which is the table's second row and precisely the form the README was misusing; README.md gains the same pair, one as a fenced JSON payload and one as a patterns bullet.
+
+### Added
+
+- **The doc guard now covers README.md, not just CLAUDE.md.** `src/readmeEscaping.test.ts` joins the existing `src/claudeMdEscaping.test.ts`; both live under `src/` deliberately, since `vitest.config.ts` includes `src/**/*.test.ts` only and the required `test (22)` / `test (24)` CI contexts run `pnpm test`. It parses every "common patterns" bullet and asserts the documented JSON payload decodes to exactly the documented plain text — the assertion that catches the bug above — parses each worked fenced JSON block as JSON and asserts its `content` field equals the `→ arrives as:` annotation on the line after the closing fence, and fails if either doc reintroduces a Windows example. Each check also asserts it found something to check, so a doc rewrite that changes the format fails loudly instead of passing vacuously. Proved against the real defect before shipping: restoring the four-backslash Windows bullet fails with `README.md escaping bullet "- Windows paths: ..." is self-contradictory: "Windows paths" says to send C:\\\\Users\\\\, but that JSON string literal decodes to "C:\\Users\\", not C:\Users\`.
+
 ## [2.7.2] - 2026-08-12
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,15 +38,21 @@ content: "cp ~/Library/Mobile\\ Documents/file.txt ~/dest/"
 ```
 → arrives as: `cp ~/Library/Mobile\ Documents/file.txt ~/dest/`
 
-**Correct - Windows path:**
+**Correct - Regex pattern:**
 ```
-content: "Path: C:\\Users\\Documents"
+content: "Version pattern: \\d+\\.\\d+"
 ```
-→ arrives as: `Path: C:\Users\Documents`
+→ arrives as: `Version pattern: \d+\.\d+`
+
+**Correct - Literal double backslash:**
+```
+content: "In a JSON string, one backslash is written \\\\"
+```
+→ arrives as: `In a JSON string, one backslash is written \\`
 
 (One `\\` per literal backslash, exactly as in the shell example above. `\\\\`
 is the escaping for a literal *double* backslash — see the table's second row —
-so it would store `C:\\Users\\Documents`, not a Windows path.)
+so sending `\\\\` where you mean a single backslash stores two of them.)
 
 **Incorrect - Will fail:**
 ```

--- a/README.md
+++ b/README.md
@@ -1187,16 +1187,26 @@ When sending content containing backslashes (`\`) to this MCP server, **you must
 ```json
 {
   "title": "Install Script",
-  "content": "cp ~/Library/Mobile\\\\ Documents/file.txt ~/.config/"
+  "content": "cp ~/Library/Mobile\\ Documents/file.txt ~/.config/"
 }
 ```
+→ arrives as: `cp ~/Library/Mobile\ Documents/file.txt ~/.config/`
 
-The `\\\\` in JSON becomes `\\` in the actual string, which represents a single `\` in the note.
+In a JSON string literal the two characters `\\` denote **one** literal backslash. Doubling them to `\\\\` denotes *two* backslashes in the note, which is almost never what you want.
+
+**Example - Literal double backslash:**
+```json
+{
+  "title": "Escaping Notes",
+  "content": "Send \\\\ only when you want two backslashes"
+}
+```
+→ arrives as: `Send \\ only when you want two backslashes`
 
 **Common patterns requiring escaping:**
-- Shell escaped spaces: `Mobile\ Documents` → `Mobile\\\\ Documents` in JSON
-- Windows paths: `C:\Users\` → `C:\\\\Users\\\\` in JSON
-- Regex patterns: `\d+` → `\\\\d+` in JSON
+- Shell escaped spaces: `Mobile\ Documents` → `Mobile\\ Documents` in JSON
+- Regex patterns: `\d+` → `\\d+` in JSON
+- Literal double backslash: `\\` → `\\\\` in JSON
 
 **If you see errors** when creating/updating notes with backslashes, double-check that backslashes are properly escaped in the JSON payload.
 

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes-mcp",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Notes - create, search, update, and manage notes via Claude and other AI assistants",
   "type": "module",

--- a/src/readmeEscaping.test.ts
+++ b/src/readmeEscaping.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Executable doc examples — README.md's backslash-escaping section.
+ *
+ * README.md is listed in package.json `files[]`, so it ships in the npm tarball;
+ * CLAUDE.md does not. The escaping guard that landed alongside this file's sibling
+ * (`claudeMdEscaping.test.ts`) checked CLAUDE.md only — the file that does NOT ship —
+ * while the file that DOES ship carried a wrong instruction of exactly the class the
+ * guard was written to catch:
+ *
+ *     - Windows paths: `C:\Users\` → `C:\\\\Users\\\\` in JSON
+ *
+ * Four backslashes in a JSON string literal decode to TWO literal backslashes, so that
+ * line produced `C:\\Users\\`, not `C:\Users\`. README.md and CLAUDE.md contradicted
+ * each other inside one repo, and the shipped one was the wrong one.
+ *
+ * These tests hold README.md to the same standard as CLAUDE.md:
+ *
+ *   a. every "common patterns" bullet is self-consistent — JSON-decoding the documented
+ *      payload yields exactly the documented plain text (this is the assertion that
+ *      catches the bug above)
+ *   b. every worked ```json example decodes to its documented `→ arrives as:` result —
+ *      the block is parsed as JSON, not regexed, so the decoding is the transport's own
+ *   c. neither doc reintroduces a Windows example — these servers are macOS-only
+ *
+ * Reads the docs from disk only; no server boot, no Notes.app, no network.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const README = resolve(__dirname, "../README.md");
+const CLAUDE_MD = resolve(__dirname, "../CLAUDE.md");
+const README_HEADING = "### Backslash Escaping (Important for AI Agents)";
+const CLAUDE_HEADING = "## Critical: Backslash Escaping";
+const PATTERNS_MARKER = "**Common patterns requiring escaping:**";
+
+/**
+ * The escaping section only, so an unrelated fenced block elsewhere in the doc is not
+ * swept in. Ends at the next heading of the same or higher level, or at a `---` rule.
+ */
+function section(file: string, heading: string): string {
+  const doc = readFileSync(file, "utf8");
+  const start = doc.indexOf(heading);
+  expect(start, `${file} is missing the "${heading}" section`).toBeGreaterThanOrEqual(0);
+  const level = /^#+/.exec(heading)![0].length;
+  const rest = doc.slice(start + heading.length);
+  const end = rest.search(new RegExp(`\\n#{1,${level}} |\\n---\\n`));
+  return end === -1 ? rest : rest.slice(0, end);
+}
+
+const readmeSection = (): string => section(README, README_HEADING);
+
+/** Decode a documented JSON-parameter payload the way the MCP transport would. */
+function decodeLiteral(literal: string): string {
+  return JSON.parse(`"${literal}"`) as string;
+}
+
+/** ``- <label>: `<plain>` → `<json>` in JSON`` */
+const PATTERN_RE = /^- ([^:\n]+): `(.+?)` → `(.+?)` in JSON$/;
+
+/** A fenced JSON payload plus the single line immediately after its closing fence. */
+const JSON_EXAMPLE_RE = /```json\n([\s\S]*?)\n```[ \t]*\n(.*)/g;
+
+const ANNOTATION_RE = /^→ arrives as: `(.*)`$/;
+
+describe("README.md backslash-escaping section is executable", () => {
+  it("every 'common patterns' bullet is self-consistent — the JSON form decodes to the plain form", () => {
+    const body = readmeSection();
+    const at = body.indexOf(PATTERNS_MARKER);
+    expect(
+      at,
+      `README.md's escaping section is missing "${PATTERNS_MARKER}"`
+    ).toBeGreaterThanOrEqual(0);
+
+    const bullets: string[] = [];
+    for (const raw of body.slice(at + PATTERNS_MARKER.length).split("\n")) {
+      const line = raw.trim();
+      if (line === "") {
+        if (bullets.length > 0) break;
+        continue;
+      }
+      if (!line.startsWith("- ")) break;
+      bullets.push(line);
+    }
+
+    expect(
+      bullets.length,
+      `no bullets found under "${PATTERNS_MARKER}" — a doc rewrite must not silently drop ` +
+        "them and leave this test vacuously passing"
+    ).toBeGreaterThan(0);
+
+    for (const bullet of bullets) {
+      const m = PATTERN_RE.exec(bullet);
+      expect(
+        m,
+        "escaping bullet is not in the machine-checkable form " +
+          "``- <label>: `<plain>` → `<json>` in JSON``, so nothing verifies it: " +
+          JSON.stringify(bullet)
+      ).toBeTruthy();
+
+      const [, label, want, send] = m as RegExpExecArray;
+      let decoded: string;
+      try {
+        decoded = decodeLiteral(send);
+      } catch (err) {
+        throw new Error(
+          `README.md escaping bullet ${JSON.stringify(bullet)} tells callers to send ` +
+            `\`${send}\`, which is not a valid JSON string body: ${(err as Error).message}`
+        );
+      }
+      expect(
+        decoded,
+        `README.md escaping bullet ${JSON.stringify(bullet)} is self-contradictory: ` +
+          `"${label.trim()}" says to send \`${send}\`, but that JSON string literal decodes ` +
+          `to ${JSON.stringify(decoded)}, not \`${want}\``
+      ).toBe(want);
+    }
+  });
+
+  it("every worked JSON example decodes to its documented '→ arrives as:' result", () => {
+    const found = [...readmeSection().matchAll(JSON_EXAMPLE_RE)];
+    expect(
+      found.length,
+      "no fenced json worked examples found in README.md's escaping section — a doc rewrite " +
+        "must not silently drop them and leave this test vacuously passing"
+    ).toBeGreaterThan(0);
+
+    for (const [, block, nextLine] of found) {
+      const payload = JSON.parse(block) as Record<string, unknown>;
+      const field = "content" in payload ? "content" : "body";
+      const value = payload[field];
+      expect(
+        typeof value,
+        `the worked example ${JSON.stringify(block)} has no string content:/body: field to check`
+      ).toBe("string");
+
+      const annotated = ANNOTATION_RE.exec(nextLine.trim());
+      expect(
+        annotated,
+        "a worked example needs a machine-readable result on the line immediately after its " +
+          "closing fence, exactly: → arrives as: `<literal text>` " +
+          `(found: ${JSON.stringify(nextLine.trim())})`
+      ).toBeTruthy();
+
+      expect(
+        value,
+        `the worked example ${JSON.stringify(payload.title)} does not deliver what it claims: ` +
+          `its ${field} field decodes to ${JSON.stringify(value)}, not the documented result`
+      ).toBe((annotated as RegExpExecArray)[1]);
+    }
+  });
+
+  it("neither doc reintroduces a Windows example — these servers are macOS-only", () => {
+    const sections: Array<[string, string]> = [
+      ["README.md", readmeSection()],
+      ["CLAUDE.md", section(CLAUDE_MD, CLAUDE_HEADING)],
+    ];
+
+    for (const [name, text] of sections) {
+      expect(
+        /windows|[A-Za-z]:\\/i.test(text),
+        `${name}'s backslash-escaping section carries a Windows example. Apple Notes runs ` +
+          "only on macOS, so a Windows path teaches nothing here and is how the wrong " +
+          "four-backslash instruction survived review — use the shell escaped-space, regex " +
+          "or literal-double-backslash examples instead."
+      ).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## The shipped docs told callers to send the wrong number of backslashes

`README.md` is listed in `package.json` `files[]`, so it goes out in every npm tarball.
`CLAUDE.md` is not. The escaping guard that landed with `src/claudeMdEscaping.test.ts`
checked **only** `CLAUDE.md` — the file that does not ship — while the file that **does**
ship carried a wrong instruction of exactly the class the guard was written to catch:

```
- Windows paths: `C:\Users\` → `C:\\\\Users\\\\` in JSON
```

Four backslashes in a JSON string literal decode to **two** literal backslashes. That
line produced `C:\\Users\\`, not `C:\Users\`. The same four-backslash form appeared in
the shell-escaped-space bullet, the regex bullet, and the worked example's `content`
field — so an agent following the README silently doubled every escaped path and every
regex it wrote into a note.

The explanatory sentence was self-contradictory in the same way:

> The `\\\\` in JSON becomes `\\` in the actual string, which represents a single `\` in the note.

`\\` in the resulting string is **two** characters, not one.

`CLAUDE.md` has said `\\` since it was written, so `README.md` and `CLAUDE.md`
contradicted each other inside one repo — and the shipped one was the wrong one.

### Corrected

| README.md | before | after |
|---|---|---|
| worked example `content` | `cp ~/Library/Mobile\\\\ Documents/…` | `cp ~/Library/Mobile\\ Documents/…` |
| explanatory sentence | "`\\\\` … becomes `\\` … represents a single `\`" | "the two characters `\\` denote **one** literal backslash" |
| shell bullet | `` `Mobile\ Documents` → `Mobile\\\\ Documents` `` | `` `Mobile\ Documents` → `Mobile\\ Documents` `` |
| regex bullet | `` `\d+` → `\\\\d+` `` | `` `\d+` → `\\d+` `` |
| Windows bullet | `` `C:\Users\` → `C:\\\\Users\\\\` `` | replaced by `` `\\` → `\\\\` `` (literal double backslash) |

Every corrected example was verified by **decoding** it (`JSON.parse('"' + literal + '"')`),
not by counting backslashes — eyeballing is how the original survived review.

## Windows examples removed (both docs)

This server drives Apple Notes through AppleScript and cannot run anywhere but macOS, so
`C:\Users\` was generic MCP boilerplate that was never localized. It is not a coincidence
that the wrong escaping hid on the one platform nobody here could test against.

Nothing is lost: the generic rule — one literal backslash is sent as `\\` — already covers
every platform, and the escaping table's platform-neutral rows (`\` → `\\`, `\\` → `\\\\`)
are untouched. The sections are not left thin:

- **CLAUDE.md** replaces the Windows worked example with **two** macOS-native ones — a
  regex (`"Version pattern: \\d+\\.\\d+"`) and a **literal double backslash**
  (`"… one backslash is written \\\\"`), which is the table's second row and precisely the
  form the README was misusing.
- **README.md** gains the same pair: the double-backslash case as a second fenced `json`
  worked example, and as the bullet that replaces the Windows row.

## The guard now covers README.md

`src/readmeEscaping.test.ts` (sibling to the existing `claudeMdEscaping.test.ts`):

1. **Every "common patterns" bullet is self-consistent** — parses each
   `` - <label>: `A` → `B` in JSON `` bullet and asserts JSON-decoding `B` yields exactly
   `A`. This is the assertion that catches the shipped bug.
2. **Every worked example decodes to its documented result** — the ```` ```json ```` block
   is parsed **as JSON** (not regexed) and its `content` field must equal the
   `→ arrives as: ` annotation on the line after the closing fence, using the same
   convention CLAUDE.md already uses.
3. **Neither doc reintroduces a Windows example.**

Each check also asserts it *found something to check*, so a doc rewrite that changes the
format fails loudly instead of passing vacuously.

It lives under `src/` deliberately: `vitest.config.ts` includes `src/**/*.test.ts` only, and
the required `test (22)` / `test (24)` contexts run `pnpm test` — a test under `test/` would
not run in CI. All existing CLAUDE.md assertions are untouched and still pass.

### Proof the guard has teeth against the real bug

Restoring the actual shipped line temporarily:

```
- Windows paths: `C:\Users\` → `C:\\\\Users\\\\` in JSON
```

```
AssertionError: README.md escaping bullet "- Windows paths: `C:\\Users\\` → `C:\\\\\\\\Users\\\\\\\\` in JSON"
is self-contradictory: "Windows paths" says to send `C:\\\\Users\\\\`, but that JSON string literal
decodes to "C:\\\\Users\\\\", not `C:\Users\`: expected 'C:\\Users\\' to be 'C:\Users\'
```

(the doubling in the message is `JSON.stringify`'s own escaping of the offending line)

And restoring the four-backslash form inside the worked example:

```
AssertionError: the worked example "Install Script" does not deliver what it claims: its content
field decodes to "cp ~/Library/Mobile\\\\ Documents/file.txt ~/.config/", not the documented result
```

Both restored to correct afterwards.

## Version bump

Bumped to **2.7.3** with a `## [2.7.3] - 2026-08-13` CHANGELOG heading (`## [Unreleased]`
kept present and empty). `README.md` ships, so this is a change to shipped bytes:
`publish.yml` skips a version already on npm, so an un-bumped change never reaches the
users who are currently following the wrong instruction.

Note `version-guard.yml` would **not** have forced this — it keys on `build/**`,
`requirements.txt` and non-`.ts` files under `src/`, none of which changed. The house rule
is broader than the check.

## Verification

- `pnpm run lint` / `pnpm run typecheck` / `pnpm test` (571 passed, 23 files) /
  `pnpm run format:check` — all green
- `pnpm run test:integration` against real Notes.app — 12 passed, 5 self-skipped
- **Committed bundle unchanged**, as expected for a docs + test change:
  `sha256 575559dc899c8a9763e23fefa21ee42587c0f1a13eed194621e0135bb5786ddf` before and after
  a clean `pnpm run build`; `git diff origin/main -- build/` is empty
