### PR TITLE
test: guard that the docs describe the software that actually exists

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-notes",
-      "version": "2.7.3",
+      "version": "2.7.4",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-notes",
-      "version": "2.7.3",
+      "version": "2.7.4",
       "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "apple-notes",
       "description": "Manage Apple Notes through natural language - create, search, read, update, delete, and organize notes and folders",
-      "version": "2.7.3",
+      "version": "2.7.4",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, and organize notes and folders (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 ## [Unreleased]
 
+## [2.7.4] - 2026-08-13
+
+### Documentation
+
+- **The `.mcp.json` entrypoint excerpt was fenced ` ```json ` but is not JSON.** The block under "The entrypoint is written as:" is a bare object member — `"args": ["${CLAUDE_PROJECT_DIR:-.}/build/index.js"]` — so anything that treats a ` ```json ` fence as a copyable document (a reader, a tool, an agent extracting config from the docs) gets `Unexpected non-whitespace character after JSON at position 6`. Retagged ` ```text ` and labelled in prose as an excerpt of that file rather than a whole config. It was retagged, **not** added to an allowlist: an allowlist is how the guard below would have become decorative on its first day. README.md ships in the npm tarball (it is in package.json `files[]`), which is why a docs-only fix is released rather than parked.
+
+### Added
+
+- **Two guards that hold the docs to the software that actually exists** (`src/docsTruth.test.ts`). `claudeMdEscaping.test.ts` and `readmeEscaping.test.ts` made the escaping *examples* executable after the four-backslash defect shipped; nothing covered the rest of the documented surface, and the other defect that week — "the default account is iCloud" outliving the code that assumed it — was the same failure in a different sentence: a doc that nothing compares to reality.
+
+  **Guard A — every documented example is real.** (a) Every fenced ` ```json ` block in README.md, CLAUDE.md and `docs/*.md` must parse as JSON, because a malformed example in setup docs actively breaks whoever copies it; the scanner handles indented and longer-run fences so a block cannot dodge it by nesting in a list. (b) Every `APPLE_*_MCP_*` variable named in those docs must appear under `src/`, so a renamed or deleted knob cannot keep being advertised. A family prefix written in prose (`APPLE_NOTES_MCP_*`) is accepted only when it is a **strict prefix** of a real variable — judged structurally, with no repo-specific names hardcoded — so `APPLE_NOTES_MCP_TIMEOUT` (a prefix of the real `APPLE_NOTES_MCP_TIMEOUT_MS`, but not written as a family) still fails.
+
+  **Guard B — the README Tool Reference matches the advertised tool surface, in both directions:** no advertised tool undocumented (a tool shipped without docs is undiscoverable), and no documented tool absent from the server (a documented tool that does not exist sends every caller into a `-32602`). The truth is read from the **built server over stdio** (`initialize` → `tools/list`), not by regexing `src/index.ts`, because the wire is the contract users actually see; the documented set is parsed from the `## Tool Reference` section **only**, since the rest of the README names tools in prose and workflows and scanning the whole file would mask exactly the drift this catches. Both directions agree today — 36 advertised, 36 documented.
+
+  **Placement was the point.** Twice a guard was written that never ran in CI. `vitest.config.ts` includes `src/**/*.test.ts` and is what `pnpm test` / `pnpm run test:coverage` execute, which is what the **required** `test (22)` / `test (24)` contexts run — so this file lives in `src/`, not `test/`, whose config backs no required context. `build/index.js` is git-tracked and package.json's `prepare` script rebuilds it during CI's `pnpm install --frozen-lockfile`, before the test step, so it is present when Guard B spawns it; there is deliberately **no** skip-if-missing branch, which is how a guard passes vacuously forever.
+
+  **Every assertion was proved by breaking what it protects.** A trailing comma in the `search-notes` example fails with ``README.md:233 — a ```json example does not parse as JSON … Expected double-quoted property name``; documenting `APPLE_NOTES_MCP_ATTACHMENT_CACHE_TTL` fails with "does not appear anywhere under src/"; deleting the `get-note-link` entry fails with "the server advertises 1 tool(s) that README.md's Tool Reference never documents: get-note-link"; adding a phantom `pin-note` entry fails with "documents 1 tool(s) the server does not advertise: pin-note". Each check also has a vacuity floor, proved the same way: retagging every `json` fence away, emptying the Tool Reference section, deleting it outright, stripping every environment-variable mention, and hiding `build/index.js` each **fail** rather than pass on an empty set.
+
 ## [2.7.3] - 2026-08-13
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -1052,9 +1052,9 @@ If installed from source, use this configuration:
 
 This repo ships a `.mcp.json` at its root so that, when you run `claude` from inside a clone, the server is registered automatically as a **project-scope** server — no manual config needed. Just launch Claude Code from the repo directory and approve the server when prompted (the bundled `build/index.js` is committed, so no build step is required).
 
-The entrypoint is written as:
+The entrypoint is written as (an excerpt of that file, not a whole config):
 
-```json
+```text
 "args": ["${CLAUDE_PROJECT_DIR:-.}/build/index.js"]
 ```
 

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes-mcp",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Notes - create, search, update, and manage notes via Claude and other AI assistants",
   "type": "module",

--- a/src/docsTruth.test.ts
+++ b/src/docsTruth.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Doc-truth guards — the docs must describe the software that actually exists.
+ *
+ * Two defects shipped in one week that nothing mechanical could have caught, because
+ * nothing ever compared a doc to reality:
+ *
+ *   1. Every backslash-escaping instruction in the **published** README was wrong (four
+ *      backslashes where two were correct) while CLAUDE.md said the opposite — two files
+ *      inside one repo contradicting each other, and the shipped one was the wrong one.
+ *   2. "Default account is iCloud" survived in CLAUDE.md after the code stopped assuming
+ *      that name. The behaviour moved; the sentence describing it did not.
+ *
+ * `claudeMdEscaping.test.ts` / `readmeEscaping.test.ts` made the escaping *examples*
+ * executable. These two guards go after the other half of the surface:
+ *
+ *   A. every documented example is real — every ```json fence in README.md, CLAUDE.md and
+ *      docs/*.md parses as JSON, and every APPLE_*_MCP_* environment variable named in
+ *      those docs exists under src/.
+ *   B. the README's `## Tool Reference` documents *exactly* the tool surface the built
+ *      server advertises over the wire — no undocumented tool, no phantom tool.
+ *
+ * PLACEMENT (this is where the previous two guards went wrong — twice a guard was written
+ * that never ran in CI). `vitest.config.ts` includes `src/**\/*.test.ts` and is what
+ * `pnpm test` / `pnpm run test:coverage` execute, which is what the REQUIRED branch
+ * protection contexts `test (22)` / `test (24)` run. This file therefore lives in `src/`.
+ * The `integration` context runs a different config and is not required — nothing here
+ * may depend on it.
+ *
+ * Guard B reads the truth from the **built server** (`build/index.js`, initialize →
+ * tools/list) rather than by regexing `src/index.ts`, because the wire is the contract a
+ * user actually sees. There is deliberately NO skip-if-`build/`-is-missing branch — that
+ * is how a guard passes vacuously forever. `build/index.js` is git-tracked (it is what npm
+ * and marketplace users run), so it exists at checkout, and package.json's `prepare`
+ * script rebuilds it during CI's `pnpm install --frozen-lockfile`, before the test step.
+ * If it is ever absent, this file fails, which is the correct outcome.
+ *
+ * No Notes.app, no network, no TCC: reading files and a `tools/list` round-trip only.
+ */
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "child_process";
+import { existsSync, readdirSync, readFileSync } from "fs";
+import { resolve } from "path";
+
+const REPO = resolve(__dirname, "..");
+const SERVER = resolve(REPO, "build/index.js");
+
+/** README.md, CLAUDE.md and every docs/*.md, as repo-relative paths. */
+function docFiles(): string[] {
+  const docs = readdirSync(resolve(REPO, "docs"))
+    .filter((f) => f.endsWith(".md"))
+    .sort()
+    .map((f) => `docs/${f}`);
+  return ["README.md", "CLAUDE.md", ...docs];
+}
+
+const read = (rel: string): string => readFileSync(resolve(REPO, rel), "utf8");
+
+interface Fence {
+  file: string;
+  line: number;
+  lang: string;
+  body: string;
+}
+
+/**
+ * Every fenced block in a markdown file, with its info string and 1-based opening line.
+ * Handles indented fences (fences nested in list items) and longer-than-three run lengths,
+ * so a block cannot dodge the guard by being indented.
+ */
+function fences(rel: string): Fence[] {
+  const lines = read(rel).split("\n");
+  const found: Fence[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const open = /^(\s*)(`{3,})(.*)$/.exec(lines[i]);
+    if (!open) {
+      i++;
+      continue;
+    }
+    const [, indent, ticks, info] = open;
+    const closer = new RegExp(`^\\s{0,${indent.length}}\`{${ticks.length},}\\s*$`);
+    const body: string[] = [];
+    let j = i + 1;
+    while (j < lines.length && !closer.test(lines[j])) {
+      body.push(lines[j]);
+      j++;
+    }
+    found.push({
+      file: rel,
+      line: i + 1,
+      lang: info.trim().split(/\s+/)[0].toLowerCase(),
+      body: body.join("\n"),
+    });
+    i = j + 1;
+  }
+  return found;
+}
+
+describe("Guard A — every documented example is real", () => {
+  it("every fenced ```json block in README.md, CLAUDE.md and docs/*.md parses as JSON", () => {
+    const blocks = docFiles().flatMap((f) => fences(f).filter((b) => b.lang === "json"));
+
+    // Vacuity floor. A ```json fence that is a deliberate FRAGMENT must be retagged
+    // ```jsonc / ```text — honestly not-JSON — never allowlisted; but retagging
+    // *everything* is how this guard would become decorative, so an empty set fails.
+    expect(
+      blocks.length,
+      "no ```json fences found in README.md, CLAUDE.md or docs/*.md — either the docs lost " +
+        "all their JSON examples or every fence was retagged away from `json`, and this " +
+        "guard is now checking nothing"
+    ).toBeGreaterThan(0);
+
+    for (const block of blocks) {
+      try {
+        JSON.parse(block.body);
+      } catch (err) {
+        throw new Error(
+          `${block.file}:${block.line} — a \`\`\`json example does not parse as JSON, so a ` +
+            `user who copies it gets a syntax error: ${(err as Error).message}\n` +
+            "If the block is a deliberate fragment rather than a whole document, retag the " +
+            "fence ```jsonc or ```text instead of leaving it mislabelled.\n---\n" +
+            block.body +
+            "\n---"
+        );
+      }
+    }
+  });
+
+  it("every APPLE_*_MCP_* environment variable named in the docs exists under src/", () => {
+    // Trailing `[A-Z0-9_]*` is intentionally allowed to be empty so that a family prefix
+    // written in prose (`APPLE_NOTES_MCP_*`) is CAPTURED and judged, not silently skipped.
+    const ENV_RE = /APPLE_[A-Z0-9]+_MCP_[A-Z0-9_]*/g;
+
+    const tokensIn = (text: string): string[] => [...text.matchAll(ENV_RE)].map((m) => m[0]);
+
+    const walk = (dir: string): string[] =>
+      readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
+        const p = resolve(dir, e.name);
+        return e.isDirectory() ? walk(p) : [p];
+      });
+
+    const srcTokens = new Set(
+      walk(resolve(REPO, "src")).flatMap((f) => tokensIn(readFileSync(f, "utf8")))
+    );
+
+    const documented = new Map<string, string[]>();
+    for (const rel of docFiles()) {
+      for (const token of tokensIn(read(rel))) {
+        const where = documented.get(token) ?? [];
+        if (!where.includes(rel)) where.push(rel);
+        documented.set(token, where);
+      }
+    }
+
+    expect(
+      documented.size,
+      "no APPLE_*_MCP_* environment variables found anywhere in README.md, CLAUDE.md or " +
+        "docs/*.md — the Configuration section documents several, so finding none means " +
+        "this guard is scanning nothing"
+    ).toBeGreaterThan(0);
+
+    const srcList = [...srcTokens].sort();
+    for (const [token, where] of [...documented].sort()) {
+      if (srcTokens.has(token)) continue;
+
+      // A family prefix used as a name in prose (`APPLE_NOTES_MCP_*` → `APPLE_NOTES_MCP_`)
+      // is legitimate exactly when it is a STRICT prefix of a real variable. Judged
+      // structurally — nothing about this repo's current variable names is hardcoded.
+      if (token.endsWith("_") && srcList.some((real) => real !== token && real.startsWith(token))) {
+        continue;
+      }
+
+      throw new Error(
+        `${where.join(", ")} document(s) the environment variable \`${token}\`, which does not ` +
+          "appear anywhere under src/. Either the knob was renamed or deleted and the docs " +
+          "still advertise it, or it is a typo. Variables the code actually reads: " +
+          srcList.join(", ")
+      );
+    }
+  });
+});
+
+describe("Guard B — the README Tool Reference matches the advertised tool surface", () => {
+  /** Tool names the built server advertises over stdio: initialize → tools/list. */
+  function advertisedTools(): string[] {
+    expect(
+      existsSync(SERVER),
+      `${SERVER} is missing. It is git-tracked (it is the bundle npm users run) and ` +
+        "package.json's `prepare` script rebuilds it during `pnpm install`, so it must be " +
+        "present before tests run. This guard deliberately has no skip branch: a doc guard " +
+        "that quietly no-ops when its source of truth is absent passes forever and proves " +
+        "nothing. Run `pnpm run build`."
+    ).toBe(true);
+
+    const request =
+      [
+        {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2024-11-05",
+            capabilities: {},
+            clientInfo: { name: "docs-truth-guard", version: "0" },
+          },
+        },
+        { jsonrpc: "2.0", method: "notifications/initialized" },
+        { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} },
+      ]
+        .map((m) => JSON.stringify(m))
+        .join("\n") + "\n";
+
+    const proc = spawnSync(process.execPath, [SERVER], {
+      input: request,
+      encoding: "utf8",
+      timeout: 60_000,
+      maxBuffer: 64 * 1024 * 1024,
+    });
+
+    const detail = `exit=${proc.status} signal=${proc.signal} stderr=${(proc.stderr || "").slice(-2000)}`;
+
+    let tools: Array<{ name: string }> | undefined;
+    for (const line of (proc.stdout || "").split("\n")) {
+      if (!line.trim()) continue;
+      let msg: { id?: number; result?: { tools?: Array<{ name: string }> } };
+      try {
+        msg = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (msg.id === 2 && msg.result?.tools) tools = msg.result.tools;
+    }
+
+    expect(
+      tools,
+      `the built server did not answer tools/list — cannot check the docs against a tool ` +
+        `surface that was never obtained (${detail})`
+    ).toBeTruthy();
+    expect(
+      (tools as Array<{ name: string }>).length,
+      `the built server advertised zero tools (${detail})`
+    ).toBeGreaterThan(0);
+
+    return (tools as Array<{ name: string }>).map((t) => t.name).sort();
+  }
+
+  /**
+   * Tool names documented in `## Tool Reference` ONLY. The rest of the README names tools
+   * in prose, workflows and cross-links, so scanning the whole file would mask exactly the
+   * drift this guard exists to catch (a tool "documented" by a passing mention).
+   *
+   * Entries are `#### \`tool-name\`` headings; a trailing annotation such as `(BETA)` is
+   * part of the heading, not of the name.
+   */
+  function documentedTools(): string[] {
+    const readme = read("README.md");
+    const heading = "\n## Tool Reference\n";
+    const start = readme.indexOf(heading);
+    expect(
+      start,
+      "README.md has no `## Tool Reference` section — that section IS the tool documentation, " +
+        "so its absence is a failure, not an excuse to skip the check"
+    ).toBeGreaterThanOrEqual(0);
+
+    const rest = readme.slice(start + heading.length);
+    const end = rest.search(/\n## /);
+    const section = end === -1 ? rest : rest.slice(0, end);
+
+    const names = [...section.matchAll(/^#### `([^`\n]+)`/gm)].map((m) => m[1]);
+
+    expect(
+      names.length,
+      "README.md's `## Tool Reference` section documents no tools (expected `#### `tool-name`` " +
+        "headings) — an empty section must fail rather than trivially satisfy an equality check"
+    ).toBeGreaterThan(0);
+
+    const dupes = names.filter((n, i) => names.indexOf(n) !== i);
+    expect(dupes, `README.md's Tool Reference documents the same tool twice: ${dupes}`).toEqual([]);
+
+    return [...names].sort();
+  }
+
+  it("no advertised tool is missing from the README Tool Reference", () => {
+    const advertised = advertisedTools();
+    const documented = new Set(documentedTools());
+    const undocumented = advertised.filter((name) => !documented.has(name));
+
+    expect(
+      undocumented,
+      `the server advertises ${undocumented.length} tool(s) that README.md's Tool Reference ` +
+        `never documents: ${undocumented.join(", ")}. A tool shipped without docs is a tool ` +
+        "users cannot discover — add a `#### `<name>`` entry."
+    ).toEqual([]);
+  }, 60_000);
+
+  it("no tool documented in the README Tool Reference is absent from the server", () => {
+    const advertised = new Set(advertisedTools());
+    const phantom = documentedTools().filter((name) => !advertised.has(name));
+
+    expect(
+      phantom,
+      `README.md's Tool Reference documents ${phantom.length} tool(s) the server does not ` +
+        `advertise: ${phantom.join(", ")}. Either the tool was renamed or removed and the docs ` +
+        "were not updated, or the name is a typo — a documented tool that does not exist sends " +
+        "every caller into a -32602."
+    ).toEqual([]);
+  }, 60_000);
+});


### PR DESCRIPTION
Two doc defects shipped this week and nothing mechanical could have caught either, because nothing ever compared a doc to reality: every backslash-escaping instruction in the **published** README was wrong while CLAUDE.md said the opposite, and "the default account is iCloud" outlived the code that assumed it. The escaping guards made the escaping *examples* executable; these two go after the rest of the surface.

## Guard A — every documented example is real

**(a)** Every fenced ` ```json ` block in README.md, CLAUDE.md and `docs/*.md` parses as JSON. A malformed example in setup docs actively breaks whoever copies it. The fence scanner handles indented and longer-run fences, so a block can't dodge it by nesting in a list.

**(b)** Every `APPLE_*_MCP_*` variable named in those docs exists under `src/`, so a renamed or deleted knob can't keep being advertised. A family prefix written in prose (`APPLE_NOTES_MCP_*`) is accepted only when it is a **strict prefix** of a real variable — judged structurally, no repo-specific names hardcoded. Proved both ways: `APPLE_NOTES_MCP_MAX_*` passes, `APPLE_NOTES_MCP_TIMEOUT` (a prefix of the real `..._TIMEOUT_MS`, but not written as a family) fails.

## Guard B — the README Tool Reference matches the advertised tool surface

Both directions: no advertised tool undocumented, no documented tool absent from the server. Truth comes from the **built server over stdio** (`initialize` → `tools/list`), not from regexing `src/index.ts` — the wire is the contract users see. The documented set is parsed from the `## Tool Reference` section **only**, because the rest of the README names tools in prose and workflows and scanning the whole file would mask the very drift this catches.

**Both directions agree on current content: 36 advertised, 36 documented.** No Tool Reference drift to fix.

## Placement — the part that went wrong twice before

`vitest.config.ts` includes `src/**/*.test.ts` and is what `pnpm test` / `pnpm run test:coverage` run, which is what the **required** `test (22)` / `test (24)` contexts run. So the file is `src/docsTruth.test.ts`, not `test/` — that config backs no required context here.

`build/index.js` is git-tracked (it is the bundle npm users run) **and** package.json's `prepare` rebuilds it during CI's `pnpm install --frozen-lockfile`, which happens before the test step — so it is present when Guard B spawns it. There is deliberately **no** skip-if-missing branch; hiding `build/index.js` makes this suite fail, which is the correct outcome.

## Teeth — every assertion proved by breaking what it protects

| break | failure |
|---|---|
| A(a) trailing comma in the `search-notes` example | ``README.md:233 — a ```json example does not parse as JSON, so a user who copies it gets a syntax error: Expected double-quoted property name in JSON at position 24`` |
| A(b) document `APPLE_NOTES_MCP_ATTACHMENT_CACHE_TTL` | ``README.md document(s) the environment variable `APPLE_NOTES_MCP_ATTACHMENT_CACHE_TTL`, which does not appear anywhere under src/`` |
| B(i) delete the `get-note-link` entry | ``the server advertises 1 tool(s) that README.md's Tool Reference never documents: get-note-link`` |
| B(ii) add a phantom `pin-note` entry | ``README.md's Tool Reference documents 1 tool(s) the server does not advertise: pin-note`` |

## Vacuity — each guard fails on an empty input set

| deletion | failure |
|---|---|
| retag every ` ```json ` fence away | ``no ```json fences found … this guard is now checking nothing: expected 0 to be greater than 0`` |
| empty the Tool Reference section | ``documents no tools … an empty section must fail rather than trivially satisfy an equality check`` |
| delete the Tool Reference section | ``README.md has no `## Tool Reference` section — that section IS the tool documentation, so its absence is a failure, not an excuse to skip the check`` |
| strip every env-var mention | ``no APPLE_*_MCP_* environment variables found anywhere … this guard is scanning nothing`` |
| hide `build/index.js` | ``build/index.js is missing … This guard deliberately has no skip branch`` |

## Real defect found and fixed

README.md's `.mcp.json` entrypoint excerpt was fenced ` ```json ` but is a bare object member, not a document, so it cannot parse. **Retagged ` ```text `** (honestly not-JSON) and labelled in prose as an excerpt — not allowlisted, because an allowlist is how a guard becomes decorative on day one. That is the only fence of 37 that failed.

## Why the bump

README.md is in package.json `files[]`, so the retag changes bytes users receive in the npm tarball, and `publish.yml` only publishes a version absent from npm — an un-bumped docs fix would sit on main and never ship. Patch bump to **2.7.4** with notes under a real `## [2.7.4] - 2026-08-13` heading; `## [Unreleased]` left present and empty.

Worth flagging: `version-guard.yml` would **not** have demanded this. Its shipped-bytes set is `build/**`, `requirements.txt` and non-`.ts` files under `src/`, and its header exempts docs-only changes explicitly — so README/CLAUDE.md/docs changes ship in the tarball while sitting outside the guard's definition of shipped bytes. The bump here is deliberate, and matches 2.7.3 (the docs-only README correction released the same way). Whether that gap in version-guard should be closed is a separate call.

## Gates

`lint` ✅ `typecheck` ✅ `test` ✅ 575 passed / 24 files `format:check` ✅ `test:integration` ✅ 12 passed, 5 skipped (no signed-in Notes account paths) `sync-plugin-version --check` ✅ `sync-skills --check` ✅

**Bundle unchanged:** `build/index.js` is byte-identical across a rebuild — sha256 `575559dc899c8a9763e23fefa21ee42587c0f1a13eed194621e0135bb5786ddf` before and after `pnpm run build`, `git diff --quiet build/` clean. Nothing esbuild inlines changed; the new file is a test.