### PR TITLE
fix(security): stop a symlink from carrying an attachment save out of the allowed roots

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-notes",
-      "version": "2.7.4",
+      "version": "2.7.5",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-notes",
-      "version": "2.7.4",
+      "version": "2.7.5",
       "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.7.4",
+  "version": "2.7.5",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "apple-notes",
       "description": "Manage Apple Notes through natural language - create, search, read, update, delete, and organize notes and folders",
-      "version": "2.7.4",
+      "version": "2.7.5",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.7.4",
+  "version": "2.7.5",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, and organize notes and folders (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 ## [Unreleased]
 
+## [2.7.5] - 2026-08-14
+
+### Fixed
+
+- **A symlink inside an allowed root carried an attachment save straight out of it.** `assertSafeSavePath` resolved the destination with `resolve()` and compared that against the allowed roots. `resolve()` collapses `..` but knows nothing about symlinks, so a link living inside a root passed the prefix check and Notes' AppleScript `save` followed it out — `~/probe/escape -> /etc` made `~/probe/escape/hosts` an ALLOWED destination returning `/Users/<you>/probe/escape/hosts`. The module docstring has always claimed "no writing outside sensible roots, no path traversal"; it delivered only the lexical half of the second clause.
+
+  The destination file normally does not exist yet, so the whole path cannot simply be canonicalized. The deepest **existing** ancestor is canonicalized instead — that is the only place a symlink can be — checked against the canonicalized roots, and the fully reassembled destination is checked as well. A destination that **already exists as a symlink** is now refused outright rather than followed, which is how a file outside the roots would otherwise be clobbered.
+
+  Canonicalization uses `fs.realpathSync.native`, not `fs.realpathSync`: the JS emulation resolves symlinks but preserves whatever casing the caller supplied, and macOS APFS is case-insensitive, so an exact-case comparison is defeated by respelling one segment. The roots go through the same call. That is also what keeps the legitimate cases working — macOS's `/tmp` is a symlink to `/private/tmp` and `/var/folders` to `/private/var/folders`, so a caller passing the already-resolved real path must not be refused, and is not. The returned value is still the caller's own spelling, so `/tmp/x` continues to write to `/tmp/x`.
+
+  The root boundary is a path **segment**, not a string prefix, so a sibling that merely shares a prefix (`/Volumes-evil`, `/Users/robother`) cannot slip through.
+
+- **`ensureParentDir` created the parent directory before anything validated the path.** `mkdirSync(…, { recursive: true })` builds directories **through** a symlink, so a validate-after-mkdir arrangement plants exactly the escape the check exists to prevent. It now validates first and throws the same errors `assertSafeSavePath` does. The one call site (`saveAttachmentById`) already validated first; re-checking inside the function makes the ordering a property of the function rather than of its callers.
+
+  **Proved by breaking it.** Reverting the guard fails 4 of the 19 tests in `attachmentFs.test.ts` (581/581 → 577/581 suite-wide), and the `mkdir` test fails on the directory it actually created out at `/private/var/tmp`, not merely on a missing error — the side effect is asserted before the throw for that reason. Restoring it returns 19/19 and 581/581. Two tests hold the opposite direction, so the fix cannot pass by refusing everything: a symlink that stays **inside** the roots is still accepted, and so is the real `/private/var/folders` spelling of a temp directory.
+
 ## [2.7.4] - 2026-08-13
 
 ### Documentation

--- a/build/index.js
+++ b/build/index.js
@@ -3660,49 +3660,49 @@ var require_fast_uri = __commonJS({
       schemelessOptions.skipEscape = true;
       return serialize(resolved, schemelessOptions);
     }
-    function resolveComponent(base, relative, options, skipNormalization) {
+    function resolveComponent(base, relative2, options, skipNormalization) {
       const target = {};
       if (!skipNormalization) {
         base = parse3(serialize(base, options), options);
-        relative = parse3(serialize(relative, options), options);
+        relative2 = parse3(serialize(relative2, options), options);
       }
       options = options || {};
-      if (!options.tolerant && relative.scheme) {
-        target.scheme = relative.scheme;
-        target.userinfo = relative.userinfo;
-        target.host = relative.host;
-        target.port = relative.port;
-        target.path = removeDotSegments(relative.path || "");
-        target.query = relative.query;
+      if (!options.tolerant && relative2.scheme) {
+        target.scheme = relative2.scheme;
+        target.userinfo = relative2.userinfo;
+        target.host = relative2.host;
+        target.port = relative2.port;
+        target.path = removeDotSegments(relative2.path || "");
+        target.query = relative2.query;
       } else {
-        if (relative.userinfo !== void 0 || relative.host !== void 0 || relative.port !== void 0) {
-          target.userinfo = relative.userinfo;
-          target.host = relative.host;
-          target.port = relative.port;
-          target.path = removeDotSegments(relative.path || "");
-          target.query = relative.query;
+        if (relative2.userinfo !== void 0 || relative2.host !== void 0 || relative2.port !== void 0) {
+          target.userinfo = relative2.userinfo;
+          target.host = relative2.host;
+          target.port = relative2.port;
+          target.path = removeDotSegments(relative2.path || "");
+          target.query = relative2.query;
         } else {
-          if (!relative.path) {
+          if (!relative2.path) {
             target.path = base.path;
-            if (relative.query !== void 0) {
-              target.query = relative.query;
+            if (relative2.query !== void 0) {
+              target.query = relative2.query;
             } else {
               target.query = base.query;
             }
           } else {
-            if (relative.path[0] === "/") {
-              target.path = removeDotSegments(relative.path);
+            if (relative2.path[0] === "/") {
+              target.path = removeDotSegments(relative2.path);
             } else {
               if ((base.userinfo !== void 0 || base.host !== void 0 || base.port !== void 0) && !base.path) {
-                target.path = "/" + relative.path;
+                target.path = "/" + relative2.path;
               } else if (!base.path) {
-                target.path = relative.path;
+                target.path = relative2.path;
               } else {
-                target.path = base.path.slice(0, base.path.lastIndexOf("/") + 1) + relative.path;
+                target.path = base.path.slice(0, base.path.lastIndexOf("/") + 1) + relative2.path;
               }
               target.path = removeDotSegments(target.path);
             }
-            target.query = relative.query;
+            target.query = relative2.query;
           }
           target.userinfo = base.userinfo;
           target.host = base.host;
@@ -3710,7 +3710,7 @@ var require_fast_uri = __commonJS({
         }
         target.scheme = base.scheme;
       }
-      target.fragment = relative.fragment;
+      target.fragment = relative2.fragment;
       return target;
     }
     function equal(uriA, uriB, options) {
@@ -11912,9 +11912,9 @@ var require_URL = __commonJS({
       },
       // See: http://tools.ietf.org/html/rfc3986#section-5.2
       // and https://url.spec.whatwg.org/#constructors
-      resolve: function(relative) {
+      resolve: function(relative2) {
         var base = this;
-        var r = new URL2(relative);
+        var r = new URL2(relative2);
         var t = new URL2();
         if (r.scheme !== void 0) {
           t.scheme = r.scheme;
@@ -24193,14 +24193,14 @@ var require_turndown_cjs = __commonJS({
         } else if (node.nodeType === 1) {
           replacement = replacementForNode.call(self, node);
         }
-        return join6(output, replacement);
+        return join7(output, replacement);
       }, "");
     }
     function postProcess(output) {
       var self = this;
       this.rules.forEach(function(rule) {
         if (typeof rule.append === "function") {
-          output = join6(output, rule.append(self.options));
+          output = join7(output, rule.append(self.options));
         }
       });
       return output.replace(/^[\t\r\n]+/, "").replace(/[\t\r\n\s]+$/, "");
@@ -24212,7 +24212,7 @@ var require_turndown_cjs = __commonJS({
       if (whitespace.leading || whitespace.trailing) content = content.trim();
       return whitespace.leading + rule.replacement(content, node, this.options) + whitespace.trailing;
     }
-    function join6(output, replacement) {
+    function join7(output, replacement) {
       var s1 = trimTrailingNewlines(output);
       var s2 = trimLeadingNewlines(replacement);
       var nls = Math.max(output.length - s1.length, replacement.length - s2.length);
@@ -39204,8 +39204,17 @@ function getChecklistItems(noteId) {
 }
 
 // src/utils/attachmentFs.ts
-import { existsSync as existsSync2, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync } from "fs";
-import { dirname, isAbsolute, resolve, sep } from "path";
+import {
+  existsSync as existsSync2,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync
+} from "fs";
+import { dirname, isAbsolute, join as join2, relative, resolve, sep } from "path";
 import { homedir as homedir2, tmpdir } from "os";
 function allowedSaveRoots() {
   return [
@@ -39217,16 +39226,77 @@ function allowedSaveRoots() {
     "/private/tmp"
   ];
 }
-function ensureParentDir(abs) {
+function canonicalize(path4) {
+  return realpathSync.native(path4);
+}
+function isWithinRoots(candidate, roots) {
+  return roots.some((root) => {
+    const base = root.endsWith(sep) ? root.slice(0, -1) : root;
+    return candidate === base || candidate.startsWith(base + sep);
+  });
+}
+function canonicalRoots(roots) {
+  const canonical = [];
+  for (const root of roots) {
+    const abs = resolve(root);
+    let resolved;
+    try {
+      resolved = canonicalize(abs);
+    } catch {
+      resolved = abs;
+    }
+    if (!canonical.includes(resolved)) canonical.push(resolved);
+  }
+  return canonical;
+}
+function entryExists(path4) {
+  try {
+    lstatSync(path4);
+    return true;
+  } catch {
+    return false;
+  }
+}
+function deepestExistingAncestor(abs) {
+  let current = abs;
+  for (; ; ) {
+    if (entryExists(current)) return current;
+    const parent = dirname(current);
+    if (parent === current) return current;
+    current = parent;
+  }
+}
+function ensureParentDir(abs, roots = allowedSaveRoots()) {
+  assertSafeSavePath(abs, roots);
   mkdirSync(dirname(abs), { recursive: true });
 }
 function assertSafeSavePath(p, roots = allowedSaveRoots()) {
   if (!p || !p.trim()) throw new Error("A destination path is required.");
   if (!isAbsolute(p)) throw new Error(`Destination path must be absolute: "${p}"`);
   const abs = resolve(p);
-  const ok = roots.some((r) => abs === r || abs.startsWith(r.endsWith(sep) ? r : r + sep));
-  if (!ok) {
+  if (!isWithinRoots(abs, roots)) {
     throw new Error(`Refusing to write outside allowed locations (home, temp, /Volumes): "${abs}"`);
+  }
+  const ancestor = deepestExistingAncestor(abs);
+  if (ancestor === abs && lstatSync(abs).isSymbolicLink()) {
+    throw new Error(`Refusing to write to the symbolic link "${abs}".`);
+  }
+  let canonicalAncestor;
+  try {
+    canonicalAncestor = canonicalize(ancestor);
+  } catch {
+    throw new Error(`Destination path cannot be resolved: "${abs}"`);
+  }
+  const suffix = relative(ancestor, abs);
+  if (suffix.split(sep).includes("..")) {
+    throw new Error(`Refusing to write outside allowed locations (home, temp, /Volumes): "${abs}"`);
+  }
+  const canonicalDest = suffix ? join2(canonicalAncestor, suffix) : canonicalAncestor;
+  const allowed = canonicalRoots(roots);
+  if (!isWithinRoots(canonicalAncestor, allowed) || !isWithinRoots(canonicalDest, allowed)) {
+    throw new Error(
+      `Refusing to write outside allowed locations (home, temp, /Volumes): "${abs}" resolves to "${canonicalDest}" through a symbolic link.`
+    );
   }
   return abs;
 }
@@ -39272,7 +39342,7 @@ function cleanupTempDir(dir) {
 var import_turndown = __toESM(require_turndown_cjs(), 1);
 import { existsSync as existsSync3 } from "fs";
 import { homedir as homedir3 } from "os";
-import { join as join2 } from "path";
+import { join as join3 } from "path";
 var FIELD_SEP = "";
 var RECORD_SEP = "";
 var AS_FIELD_SEP = "(ASCII character 31)";
@@ -39464,7 +39534,7 @@ function getNoteLinkFromDB(coreDataId) {
   const match = coreDataId.match(/\/p(\d+)$/);
   if (!match) return null;
   const pk = parseInt(match[1], 10);
-  const dbPath = join2(homedir3(), "Library/Group Containers/group.com.apple.notes/NoteStore.sqlite");
+  const dbPath = join3(homedir3(), "Library/Group Containers/group.com.apple.notes/NoteStore.sqlite");
   if (!existsSync3(dbPath)) return null;
   try {
     const { DatabaseSync } = __require("node:sqlite");
@@ -42108,12 +42178,12 @@ function formatDoctorReport(r) {
 
 // src/services/fileConfig.ts
 import { existsSync as existsSync6, readFileSync as readFileSync2 } from "fs";
-import { join as join5 } from "path";
+import { join as join6 } from "path";
 import { homedir as homedir6 } from "os";
 function fileConfigPath(env = process.env) {
   const override = env.APPLE_NOTES_MCP_CONFIG_FILE;
   if (override && override.trim()) return override.trim();
-  return join5(homedir6(), "Library", "Application Support", "apple-notes-mcp", "config.json");
+  return join6(homedir6(), "Library", "Application Support", "apple-notes-mcp", "config.json");
 }
 function loadFileConfig(env = process.env, path4 = fileConfigPath(env)) {
   const applied = [];

--- a/build/index.js
+++ b/build/index.js
@@ -39253,8 +39253,9 @@ function entryExists(path4) {
   try {
     lstatSync(path4);
     return true;
-  } catch {
-    return false;
+  } catch (e) {
+    const code = e.code;
+    return !(code === "ENOENT" || code === "ENOTDIR");
   }
 }
 function deepestExistingAncestor(abs) {

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes",
-  "version": "2.7.4",
+  "version": "2.7.5",
   "description": "Manage Apple Notes through natural language - create, search, read, update, delete, organize folders, inspect metadata, run diagnostics, and work with attachments (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes-mcp",
-  "version": "2.7.4",
+  "version": "2.7.5",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Notes - create, search, update, and manage notes via Claude and other AI assistants",
   "type": "module",

--- a/src/utils/attachmentFs.test.ts
+++ b/src/utils/attachmentFs.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from "vitest";
-import { writeFileSync, existsSync, mkdtempSync } from "fs";
+import { writeFileSync, existsSync, mkdtempSync, realpathSync, symlinkSync } from "fs";
 import { homedir, tmpdir } from "os";
 import { join } from "path";
 import {
@@ -46,6 +46,97 @@ describe("assertSafeSavePath (#27)", () => {
 
   it("exposes the allowed roots", () => {
     expect(allowedSaveRoots()).toEqual(expect.arrayContaining(["/Volumes"]));
+  });
+});
+
+/**
+ * Symlink escape: `resolve()` collapses `..` but knows nothing about symlinks,
+ * so a link INSIDE an allowed root used to pass the prefix check and the write
+ * followed it straight out. Every fixture below is built inside `makeTempDir()`
+ * — an allowed root — so the assertions reach the symlink logic instead of
+ * dying on the lexical check that already existed.
+ *
+ * `/private/var/tmp` is the escape target: it is writable and is deliberately
+ * NOT under any allowed root (the roots cover `/private/var/folders`, not
+ * `/private/var/tmp`), which lets the mkdir test prove nothing was created.
+ */
+describe("assertSafeSavePath — symlink escape", () => {
+  const outsideRoots = () => {
+    const dir = mkdtempSync("/private/var/tmp/anatt-outside-");
+    dirs.push(dir);
+    return dir;
+  };
+
+  it("refuses a destination reached through a symlinked directory component", () => {
+    const dir = makeTempDir();
+    dirs.push(dir);
+    symlinkSync("/etc", join(dir, "escape"), "dir");
+    expect(() => assertSafeSavePath(join(dir, "escape", "hosts"))).toThrow(/outside allowed/);
+  });
+
+  it("refuses a not-yet-existing destination several levels below the symlink", () => {
+    const dir = makeTempDir();
+    dirs.push(dir);
+    symlinkSync(outsideRoots(), join(dir, "escape"), "dir");
+    expect(() => assertSafeSavePath(join(dir, "escape", "deep", "nested", "x.png"))).toThrow(
+      /outside allowed/
+    );
+  });
+
+  it("refuses a destination that already exists as a symlink", () => {
+    const dir = makeTempDir();
+    dirs.push(dir);
+    // Points outside the roots: following it is how a file elsewhere gets clobbered.
+    symlinkSync("/etc/hosts", join(dir, "clobber-outside"));
+    expect(() => assertSafeSavePath(join(dir, "clobber-outside"))).toThrow(/symbolic link/);
+
+    // Refused even when the link target is itself inside an allowed root: the
+    // caller asked for this path, not for whatever it currently points at.
+    const real = join(dir, "real.png");
+    writeFileSync(real, "x");
+    symlinkSync(real, join(dir, "clobber-inside"));
+    expect(() => assertSafeSavePath(join(dir, "clobber-inside"))).toThrow(/symbolic link/);
+  });
+
+  it("still accepts a symlink that stays inside the allowed roots", () => {
+    const dir = makeTempDir();
+    dirs.push(dir);
+    const target = makeTempDir();
+    dirs.push(target);
+    symlinkSync(target, join(dir, "inside"), "dir");
+    const dest = join(dir, "inside", "x.png");
+    expect(assertSafeSavePath(dest)).toBe(dest);
+  });
+
+  it("accepts the real path behind the /tmp and /var/folders symlinks", () => {
+    // macOS's /tmp and /var are symlinks into /private. A caller that passes the
+    // already-resolved real path must not be refused by the canonicalization.
+    const dir = makeTempDir();
+    dirs.push(dir);
+    const realDir = realpathSync.native(dir);
+    expect(realDir.startsWith("/private/")).toBe(true);
+    expect(() => assertSafeSavePath(join(realDir, "x.png"))).not.toThrow();
+    expect(() => assertSafeSavePath("/private/tmp/x.png")).not.toThrow();
+    expect(() => assertSafeSavePath("/tmp/x.png")).not.toThrow();
+  });
+
+  it("ensureParentDir validates BEFORE mkdir, so mkdir -p cannot build a path through the symlink", () => {
+    const dir = makeTempDir();
+    dirs.push(dir);
+    const outside = outsideRoots();
+    symlinkSync(outside, join(dir, "escape"), "dir");
+
+    // The side effect is asserted BEFORE the throw, so a validation-after-mkdir
+    // implementation fails on the directory it created rather than on the
+    // missing error — which is the behaviour actually being guarded.
+    let threw = false;
+    try {
+      ensureParentDir(join(dir, "escape", "deep", "nested", "x.png"));
+    } catch {
+      threw = true;
+    }
+    expect(existsSync(join(outside, "deep"))).toBe(false);
+    expect(threw).toBe(true);
   });
 });
 

--- a/src/utils/attachmentFs.test.ts
+++ b/src/utils/attachmentFs.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, afterEach } from "vitest";
-import { writeFileSync, existsSync, mkdtempSync, realpathSync, symlinkSync } from "fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir, tmpdir } from "os";
 import { join } from "path";
 import {
@@ -209,5 +217,35 @@ describe("ensureParentDir", () => {
     const dir = makeTempDir();
     dirs.push(dir);
     expect(() => ensureParentDir(join(dir, "photo.png"))).not.toThrow();
+  });
+});
+
+describe("the boundary compares path segments, not string prefixes", () => {
+  it("refuses a REAL sibling dir whose name merely shares an allowed root's prefix", () => {
+    // This has to use an existing sibling and an injected root set. A
+    // non-existent path like /Volumes-evil is already refused for an unrelated
+    // reason (its deepest existing ancestor is "/", which is in no root), so it
+    // would pass even with the boundary broken — proving nothing.
+    const box = mkdtempSync(join(homedir(), ".anatt-seg-"));
+    try {
+      const root = join(box, "allowed");
+      const sibling = join(box, "allowedevil"); // shares the "allowed" prefix
+      mkdirSync(root);
+      mkdirSync(sibling);
+
+      // Inside the root: fine.
+      expect(() => assertSafeSavePath(join(root, "ok.png"), [root])).not.toThrow();
+      // Prefix-sharing sibling: must be refused. A bare startsWith admits it.
+      expect(() => assertSafeSavePath(join(sibling, "pwned.png"), [root])).toThrow(
+        /Refusing to write outside/
+      );
+    } finally {
+      rmSync(box, { recursive: true, force: true });
+    }
+  });
+
+  it("still accepts ordinary paths inside the real allowed roots", () => {
+    expect(() => assertSafeSavePath(join(homedir(), "Downloads", "x.png"))).not.toThrow();
+    expect(() => assertSafeSavePath("/private/tmp/x.png")).not.toThrow();
   });
 });

--- a/src/utils/attachmentFs.ts
+++ b/src/utils/attachmentFs.ts
@@ -2,13 +2,23 @@
  * Filesystem helpers for saving / fetching note attachments (#27).
  *
  * Notes.app exports an attachment to a path via AppleScript `save`. These helpers
- * keep that safe (no writing outside sensible roots, no path traversal) and
- * provide a base64 read for the fetch-attachment tool.
+ * keep that safe (no writing outside sensible roots, no path traversal, no
+ * escaping through a symlinked path component) and provide a base64 read for the
+ * fetch-attachment tool.
  *
  * @module utils/attachmentFs
  */
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync } from "fs";
-import { dirname, isAbsolute, resolve, sep } from "path";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+} from "fs";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "path";
 import { homedir, tmpdir } from "os";
 
 /**
@@ -29,26 +39,152 @@ export function allowedSaveRoots(): string[] {
 }
 
 /**
+ * Canonicalize with the platform call, not the JS emulation.
+ *
+ * `fs.realpathSync` resolves symlinks but preserves whatever casing the caller
+ * supplied; only `fs.realpathSync.native` returns the true on-disk name. macOS
+ * APFS is case-insensitive by default, so without the native call an exact-case
+ * comparison is defeated by respelling one segment — the same directory reached
+ * as `/Users/rob/…` and `/users/rob/…` would canonicalize to two different
+ * strings and only one of them would match a root.
+ *
+ * Both the candidate and the roots go through this, which also keeps the
+ * comparison correct on case-sensitive volumes, where the respelling simply does
+ * not exist and canonicalization throws.
+ */
+function canonicalize(path: string): string {
+  return realpathSync.native(path);
+}
+
+/**
+ * True if `candidate` is one of `roots` or strictly inside one.
+ *
+ * The boundary is a path SEGMENT, not a string prefix: a bare `startsWith`
+ * would admit a sibling whose name merely shares the prefix (`/Volumes-evil`
+ * startsWith `/Volumes`; `/Users/robother` startsWith `/Users/rob`). Both
+ * arguments must already be absolute.
+ */
+function isWithinRoots(candidate: string, roots: string[]): boolean {
+  return roots.some((root) => {
+    const base = root.endsWith(sep) ? root.slice(0, -1) : root;
+    return candidate === base || candidate.startsWith(base + sep);
+  });
+}
+
+/**
+ * The allowed roots in their true on-disk spelling. A root that cannot be
+ * resolved (it does not exist on this machine) keeps its literal form: it can
+ * authorize nothing until it exists, and the candidate check fails on its own.
+ */
+function canonicalRoots(roots: string[]): string[] {
+  const canonical: string[] = [];
+  for (const root of roots) {
+    const abs = resolve(root);
+    let resolved: string;
+    try {
+      resolved = canonicalize(abs);
+    } catch {
+      resolved = abs;
+    }
+    if (!canonical.includes(resolved)) canonical.push(resolved);
+  }
+  return canonical;
+}
+
+/** True if the entry exists, symlinks NOT followed (a dangling link still counts). */
+function entryExists(path: string): boolean {
+  try {
+    lstatSync(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The deepest ancestor of `abs` (possibly `abs` itself) that exists on disk.
+ *
+ * The destination file normally does not exist yet, so the whole path cannot be
+ * canonicalized directly — but every component that DOES exist can be, and that
+ * is where a symlink escape has to live.
+ */
+function deepestExistingAncestor(abs: string): string {
+  let current = abs;
+  for (;;) {
+    if (entryExists(current)) return current;
+    const parent = dirname(current);
+    if (parent === current) return current;
+    current = parent;
+  }
+}
+
+/**
  * Ensure the parent directory of a save destination exists. Notes.app's
  * AppleScript `save` does not create intermediate directories; without this it
  * fails with an opaque "Failed saving an attachment to <path>" error.
+ *
+ * Validates first, and throws exactly as `assertSafeSavePath` does: `mkdir -p`
+ * happily creates directories THROUGH a symlink, so creating the parent before
+ * the boundary check would plant the escape it is meant to prevent. Re-checking
+ * here (callers already validate) keeps that ordering true no matter who calls.
  */
-export function ensureParentDir(abs: string): void {
+export function ensureParentDir(abs: string, roots: string[] = allowedSaveRoots()): void {
+  assertSafeSavePath(abs, roots);
   mkdirSync(dirname(abs), { recursive: true });
 }
 
 /**
  * Validate a user-supplied destination path. Returns the resolved absolute path,
- * or throws if it is relative or escapes the allowed roots.
+ * or throws if it is relative, escapes the allowed roots lexically, or would
+ * reach outside them through a symlinked path component.
+ *
+ * `resolve()` alone is not a boundary: it collapses `..` but knows nothing about
+ * symlinks, so a link INSIDE an allowed root (`~/escape -> /etc`) passed the old
+ * prefix check and the subsequent write followed it out. The destination file
+ * usually does not exist yet, so this canonicalizes the deepest EXISTING
+ * ancestor — where any symlink must be — checks that against the canonicalized
+ * roots, then re-checks the fully reassembled destination. A destination that
+ * already exists as a symlink is refused outright: following it is how a file
+ * outside the roots gets clobbered.
+ *
+ * The returned path is the caller's own spelling (`resolve(p)`), not the
+ * canonical one, so `/tmp/x` still writes to `/tmp/x` — validated to be the same
+ * file as the canonical `/private/tmp/x`.
  */
 export function assertSafeSavePath(p: string, roots: string[] = allowedSaveRoots()): string {
   if (!p || !p.trim()) throw new Error("A destination path is required.");
   if (!isAbsolute(p)) throw new Error(`Destination path must be absolute: "${p}"`);
   const abs = resolve(p);
-  const ok = roots.some((r) => abs === r || abs.startsWith(r.endsWith(sep) ? r : r + sep));
-  if (!ok) {
+  if (!isWithinRoots(abs, roots)) {
     throw new Error(`Refusing to write outside allowed locations (home, temp, /Volumes): "${abs}"`);
   }
+
+  const ancestor = deepestExistingAncestor(abs);
+  if (ancestor === abs && lstatSync(abs).isSymbolicLink()) {
+    throw new Error(`Refusing to write to the symbolic link "${abs}".`);
+  }
+
+  let canonicalAncestor: string;
+  try {
+    canonicalAncestor = canonicalize(ancestor);
+  } catch {
+    throw new Error(`Destination path cannot be resolved: "${abs}"`);
+  }
+
+  const suffix = relative(ancestor, abs);
+  if (suffix.split(sep).includes("..")) {
+    throw new Error(`Refusing to write outside allowed locations (home, temp, /Volumes): "${abs}"`);
+  }
+  const canonicalDest = suffix ? join(canonicalAncestor, suffix) : canonicalAncestor;
+
+  const allowed = canonicalRoots(roots);
+  if (!isWithinRoots(canonicalAncestor, allowed) || !isWithinRoots(canonicalDest, allowed)) {
+    throw new Error(
+      `Refusing to write outside allowed locations (home, temp, /Volumes): "${abs}" ` +
+        `resolves to "${canonicalDest}" through a symbolic link.`
+    );
+  }
+
   return abs;
 }
 

--- a/src/utils/attachmentFs.ts
+++ b/src/utils/attachmentFs.ts
@@ -96,8 +96,15 @@ function entryExists(path: string): boolean {
   try {
     lstatSync(path);
     return true;
-  } catch {
-    return false;
+  } catch (e) {
+    // Only "genuinely absent" may report false. Any other failure — EACCES on a
+    // non-traversable parent, ELOOP — means something IS there that we could not
+    // inspect, and reporting it absent makes the ancestor walk step straight past
+    // it and treat a real (possibly symlinked) component as an uncanonicalized
+    // tail. Fail closed: treat it as present so the boundary check runs against
+    // it rather than around it.
+    const code = (e as NodeJS.ErrnoException).code;
+    return !(code === "ENOENT" || code === "ENOTDIR");
   }
 }
 


### PR DESCRIPTION
`assertSafeSavePath` promised "no writing outside sensible roots, **no path traversal**" and delivered only the first half. It resolved with `resolve(p)` — which collapses `..` but knows nothing about symlinks — then compared prefixes. A link *inside* an allowed root passed, and Notes.app's AppleScript `save` followed it out.

**Reproduced before any code was written:**

```
~/.probe-XXXX/escape -> /etc
assertSafeSavePath("~/.probe-XXXX/escape/hosts")
  -> ALLOWED, returned /Users/rob/.probe-XXXX/escape/hosts
```

## The fix

The destination file normally does not exist yet, so the whole path cannot simply be realpath'd. Instead: canonicalize the deepest **existing** ancestor (walked with `lstat`, so a dangling or looping link still counts as existing), check it against the canonicalized roots, then reassemble and re-check the full destination. A destination that already exists as a symlink is refused rather than followed.

Canonicalization uses `fs.realpathSync.native`, not the JS `realpathSync` — the latter preserves the caller's casing and is defeated on case-insensitive APFS by respelling a segment. Same class of bug as apple-mail-mcp 2.10.29. The roots go through the same call, which is what keeps `/tmp` → `/private/tmp` and `/var/folders` → `/private/var/folders` working for callers that pass an already-resolved real path.

`ensureParentDir` now validates **before** `mkdirSync(recursive)`. `mkdir -p` builds directories *through* a symlink, so validate-after-mkdir plants the very escape the check exists to prevent. The sole call site already validated first; this makes it a property of the function rather than of its callers.

## Follow-ups from adversarial review (same PR, 2.7.5 hasn't shipped)

- **`entryExists` swallowed every `lstat` error**, so a component that exists but can't be inspected (EACCES, ELOOP) read as absent and the walk stepped past it. Only ENOENT/ENOTDIR may report absent now; everything else fails closed.
- **The segment boundary had no test.** Replacing it with a bare `startsWith` left all 19 tests green while admitting `/Volumes-evil`, `/private/tmp-evil` and a sibling of the home root.

  Worth recording so it isn't "simplified" back: the *obvious* test proves nothing. Asserting that `/Volumes-evil/x.png` is refused passes even with the boundary broken, because that path doesn't exist, so its deepest existing ancestor is `/` — which is in no allowed root, and it's rejected for an unrelated reason. The real test injects a root set and creates an actual prefix-sharing sibling directory.

## Verification

Every guard was proven by breaking it:

| Reverted | Result |
|---|---|
| the whole symlink fix | **4 tests fail** — including one that fails on the *side effect*: `mkdir -p` had genuinely created a directory outside every allowed root |
| segment boundary → bare `startsWith` | **1 test fails** (was 0 — completely unguarded) |

Two tests are anti-vacuity controls that pass in **both** states, proving the fix doesn't just refuse everything: a symlink that stays inside the roots is still accepted, and so are the real `/private/...` spellings behind `/tmp` and `/var/folders`.

Full suite 583 passing; typecheck, lint, format clean; bundle rebuilt and committed (`git status` empty after a re-run). 2.7.5 with a real CHANGELOG heading.

## One judgment call to confirm

A destination that already exists as a symlink is refused **even when its target is inside an allowed root** — so `~/latest.png -> ~/Pictures/x.png` is now refused. apple-mail-mcp refuses *all* pre-existing destinations, so this is strictly looser than mail; I kept notes' existing overwrite-a-regular-file behaviour and closed only the symlink case. Say if you'd rather match mail exactly.

https://claude.ai/code/session_01PnVGWuj73YQTvpPzFfdWs9