### PR TITLE
harden: raise the pnpm supply-chain soak to 7 days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## [Unreleased]
 
+### Changed
+
+- **Supply-chain soak raised from 1 day to 7 days** (`minimumReleaseAge: 10080` in
+  `pnpm-workspace.yaml`). This is a development/CI-time policy — no shipped bytes change.
+  It is not redundant with Dependabot's existing 7-day cooldown: the cooldown governs only
+  what Dependabot *proposes* (direct dependencies), while `minimumReleaseAge` governs
+  everything a resolution *installs*, including transitive packages Dependabot never sees.
+  Verified against this repo's committed lockfile, which needs no churn to satisfy it.
+  Prompted by [sweetrb/apple-mail-mcp#174](https://github.com/sweetrb/apple-mail-mcp/pull/174)
+  (@anupamme), applied across all four Apple MCP repos so the value cannot drift.
+
 ## [2.7.5] - 2026-08-14
 
 ### Fixed

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,9 +7,19 @@
 allowBuilds:
   esbuild: true
 
-# Pin pnpm 11's supply-chain minimum-release-age default explicitly (1440 min = 1 day)
-# so it is documented and stable across pnpm upgrades. See https://pnpm.io/supply-chain-security.
-minimumReleaseAge: 1440
+# Supply-chain soak: refuse any package version younger than 7 days (10080 min).
+# Deliberately stricter than pnpm 11's 1440-minute default, and deliberately NOT
+# redundant with dependabot.yml's 7-day cooldown: the cooldown governs only what
+# Dependabot *proposes* (direct deps), while this governs everything a resolution
+# *installs*. Transitive packages reach the lockfile without Dependabot ever seeing
+# them -- apple-mail-mcp carried a 5-day-old transitive ip-address@10.5.0 under the
+# 1440 default, which this value rejects. See https://pnpm.io/supply-chain-security.
+#
+# Cost of the stricter value, stated here so it is not rediscovered painfully: an
+# urgent upstream fix cannot be installed until it is 7 days old. There is no
+# minimumReleaseAgeExclude carve-out; if one is ever needed, add it narrowly and
+# remove it once the version ages past the cutoff.
+minimumReleaseAge: 10080
 
 # The MCP SDK currently caps these transitive dependencies below their first
 # fully patched releases. Keep the overrides until the SDK's ranges move past


### PR DESCRIPTION
Raises `minimumReleaseAge` in `pnpm-workspace.yaml` from 1440 (1 day) to 10080 (7 days), matching the value proposed for apple-mail-mcp in sweetrb/apple-mail-mcp#174 by @anupamme. Applied to all four repos in one pass so the value cannot drift.

## Why this isn't redundant with the Dependabot cooldown

`dependabot.yml` already has a 7-day cooldown, so it's fair to ask what this adds. They cover different things:

- **cooldown** governs what Dependabot *proposes* — direct dependencies only.
- **`minimumReleaseAge`** governs what a resolution *installs* — including transitive packages Dependabot never proposes and therefore never delays.

That gap is not hypothetical. apple-mail-mcp's lockfile was carrying `ip-address@10.5.0`, published 2026-08-10 — 5 days old, a transitive dependency, admitted by the 1440 default with the 7-day cooldown fully in force. The stricter value rejects it.

## Verification

`pnpm install --frozen-lockfile` (the exact CI gate, which re-verifies every lockfile entry against the active policy) passes against this repo's committed lockfile under 10080 with **no lockfile churn** — the resolution here is already old enough.

Development/CI-time policy only: `pnpm-workspace.yaml` is not shipped bytes, no `build/**` or `src/` change, so no version bump is owed. CHANGELOG entry filed under `[Unreleased]`.

## Cost, recorded in the file itself

An urgent upstream fix can't be installed until it's 7 days old. No `minimumReleaseAgeExclude` carve-out exists; if one is ever needed it should be added narrowly and removed once the version ages past the cutoff. The comment block says so, so it doesn't have to be rediscovered.