### PR TITLE
docs: a fixed Node path, so the "grants carry over" promise is true

### DIFF
--- a/docs/NODE-RUNTIME-AND-TCC-PERMISSIONS.md
+++ b/docs/NODE-RUNTIME-AND-TCC-PERMISSIONS.md
@@ -60,8 +60,8 @@ the MCP runtime from your Homebrew/dev Node, which can keep updating freely.
    curl -O https://nodejs.org/dist/$VER/node-$VER-$ARCH.tar.gz
    curl -O https://nodejs.org/dist/$VER/SHASUMS256.txt
    grep "  node-$VER-$ARCH.tar.gz$" SHASUMS256.txt | shasum -a 256 -c -   # must print OK
-   tar -xzf node-$VER-$ARCH.tar.gz
-   ln -sfn node-$VER-$ARCH node-current
+   mkdir -p node-current
+   tar -xzf node-$VER-$ARCH.tar.gz --strip-components=1 -C node-current
    ```
 
 2. Confirm it's Developer-ID signed:
@@ -98,12 +98,36 @@ the MCP runtime from your Homebrew/dev Node, which can keep updating freely.
    - *Automation*: the first time the server drives an app you'll get a one-time
      `"node" wants to control "<App>"` prompt — click **Allow**.
 
-   Both grants are keyed to the official Node's stable signature, so you should
-   not be asked again — including after future Node updates. You can delete the
-   stale "node" rows from the Full Disk Access list.
+   ⚠️ **A TCC grant is keyed to the binary's resolved *path*, not only to its
+   signature.** Because the steps above unpack Node into a fixed directory
+   (`~/mcp-runtime/node-current`) rather than a versioned one, that path never
+   moves and the grants survive Node updates — see "Updating" below. If you
+   instead point `node-current` at a `node-vX.Y.Z-…` directory, every update
+   changes the resolved path, presents a brand-new ungranted identity, and you
+   will be re-prompted for all of it.
+
+   You can delete any stale "node" rows from the Full Disk Access list.
 
 ### Updating the dedicated Node later
 
-Drop a newer official LTS tarball into `~/mcp-runtime/`, repoint the
-`node-current` symlink, and restart your client. The signing identity is
-unchanged, so existing grants carry over — no re-approval.
+Replace the **contents** of the same directory — do not create a new one and do
+not repoint anything:
+
+```bash
+VER=v24.19.0 ARCH=darwin-arm64
+cd ~/mcp-runtime
+curl -O https://nodejs.org/dist/$VER/node-$VER-$ARCH.tar.gz
+curl -O https://nodejs.org/dist/$VER/SHASUMS256.txt
+grep "  node-$VER-$ARCH.tar.gz$" SHASUMS256.txt | shasum -a 256 -c -   # must print OK
+rm -rf node-current && mkdir -p node-current
+tar -xzf node-$VER-$ARCH.tar.gz --strip-components=1 -C node-current
+```
+
+The path is unchanged and the official builds are Developer-ID signed with a
+requirement that pins identifier + Team ID (no cdhash), so **both** halves of
+the grant still match: existing grants carry over with no re-approval.
+
+⚠️ **Restart your MCP client afterwards.** Replacing the binary unlinks the one
+any already-running server is executing; macOS then cannot validate that path,
+so those processes fail with *"Permission denied"* until they are restarted.
+Nothing is wrong with your grants — a freshly launched server works fine.


### PR DESCRIPTION
## The problem

These docs tell the reader to install Node as a **versioned** directory and point `node-current` at it:

```bash
ln -sfn node-$VER-$ARCH node-current
```

…and then promise:

> Both grants are keyed to the official Node's stable signature, so you should not be asked again — including after future Node updates.

> The signing identity is unchanged, so existing grants carry over — no re-approval.

**That promise is false, and these instructions are what make it false.** A TCC grant has two independent legs: the lookup key (for a bare Mach-O, the *resolved realpath*) and the stored `csreq`. Signature stability only ever satisfied the second. Repointing `node-current` at a new `node-vX.Y.Z-…` directory moves the **path**, which presents a brand-new ungranted identity — so the user is re-prompted for Full Disk Access and every Automation target on every Node update, having been told they would not be.

## The fix

Unpack Node into a **fixed** directory and replace its *contents* on update, so the resolved path never moves:

```bash
mkdir -p node-current
tar -xzf node-$VER-$ARCH.tar.gz --strip-components=1 -C node-current
```

Now both legs are stable — the path is held still, and the official builds are Developer-ID signed with a requirement pinning identifier + Team ID and **no cdhash**, so a newer build still satisfies the requirement recorded at grant time. The promise becomes earned rather than asserted.

Also adds a warning the old text omitted: replacing the binary **unlinks the one any already-running server is executing**, so those processes fail with *"Permission denied"* until the client is restarted. Nothing is wrong with the grants — a freshly launched server works fine — but the symptom reads exactly like revoked permissions and sends people back to System Settings for a grant they already have.

## Notes

- **Docs only.** No `build/**`, `requirements.txt`, or non-`.ts` file under `src/` is touched, so `version-guard` owes no version bump.
- `docs` is in `files`, so this reaches npm users on the next release.
- Verified against the same change applied across all four repos.
